### PR TITLE
Read Support for NWB

### DIFF
--- a/GuPPy/preprocess.py
+++ b/GuPPy/preprocess.py
@@ -155,8 +155,9 @@ def add_control_channel(filepath, arr):
 	return arr
 
 # check if dealing with TDT files or csv files
+# NWB files are treated like TDT files
 def check_TDT(filepath):
-	path = glob.glob(os.path.join(filepath, '*.tsq'))
+	path = glob.glob(os.path.join(filepath, '*.tsq')) + glob.glob(os.path.join(filepath, '*.nwb'))
 	if len(path)>0:
 		return True
 	else:

--- a/GuPPy/readTevTsq.py
+++ b/GuPPy/readTevTsq.py
@@ -13,6 +13,7 @@ import pandas as pd
 from numpy import int32, uint32, uint8, uint16, float64, int64, int32, float32
 import multiprocessing as mp
 from tqdm import tqdm
+from pprint import pprint
 
 def insertLog(text, level):
     file = os.path.join('.','..','guppy.log')
@@ -336,6 +337,10 @@ def readtev(data, filepath, event, outputPath):
 
 
 	S['data'] = (S['data'].T).reshape(-1, order='F')
+
+	S_print = S.copy()
+	S_print.pop('data')
+	pprint(S_print)
 	
 	save_dict_to_hdf5(S, event, outputPath)
 	
@@ -546,6 +551,28 @@ def readRawData(inputParametersPath):
 	print("### Raw data fetched and saved.")
 	insertLog('Raw data fetched and saved.', logging.INFO)
 	insertLog("#" * 400, logging.INFO)
+
+# from pynwb import NWBHDF5IO
+# def read_nwb(filepath, event, outputPath, indices):
+# 	"""
+# 	Read photometry data from an NWB file and save the output to a hdf5 file.
+# 	"""
+# 	print(f"Reading NWB file {filepath} for event {event} to save to {outputPath} with indices {indices}")
+
+# 	with NWBHDF5IO(filepath, 'r') as io:
+# 		nwbfile = io.read()
+# 		fiber_photometry_response_series = nwbfile.acquisition[event].data[:, indices]
+# 		sampling_rate = fiber_photometry_response_series.rate
+
+# 	S = dict()
+# 	S['storename'] = str(event)
+# 	S['sampling_rate'] = sampling_rate
+# 	S['timestamps'] = np.arange(0, fiber_photometry_response_series.shape[0]) / sampling_rate
+# 	S['data'] = fiber_photometry_response_series
+    # save_dict_to_hdf5(S, event, outputPath)
+    # check_data(S, filepath, event, outputPath)
+    # print("Data for event {} fetched and stored.".format(event))
+    # insertLog("Data for event {} fetched and stored.".format(event), logging.INFO)
 
 # if __name__ == "__main__":
 # 	print('run')

--- a/GuPPy/readTevTsq.py
+++ b/GuPPy/readTevTsq.py
@@ -12,6 +12,7 @@ import numpy as np
 import pandas as pd
 from numpy import int32, uint32, uint8, uint16, float64, int64, int32, float32
 import multiprocessing as mp
+from tqdm import tqdm
 
 def insertLog(text, level):
     file = os.path.join('.','..','guppy.log')
@@ -322,7 +323,7 @@ def readtev(data, filepath, event, outputPath):
 	if formatNew != 5:
 		nsample = (data_size[first_row,]-10)*int(table[formatNew, 2])
 		S['data'] = np.zeros((len(fp_loc), nsample))
-		for i in range(0, len(fp_loc)):
+		for i in tqdm(range(0, len(fp_loc))):
 			with open(tevfilepath, 'rb') as fp:
 				fp.seek(fp_loc[i], os.SEEK_SET)
 				S['data'][i,:] = np.fromfile(fp, dtype=table[formatNew, 3], count=nsample).reshape(1, nsample, order='F')

--- a/GuPPy/runFiberPhotometryAnalysis.ipynb
+++ b/GuPPy/runFiberPhotometryAnalysis.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -17,8 +17,7 @@
      "output_type": "stream",
      "text": [
       "The autoreload extension is already loaded. To reload it, use:\n",
-      "  %reload_ext autoreload\n",
-      "Warning: Cannot change to a different GUI toolkit: tk. Using osx instead.\n"
+      "  %reload_ext autoreload\n"
      ]
     }
    ],
@@ -29,7 +28,6 @@
     "%matplotlib tk\n",
     "import os\n",
     "import json\n",
-    "from readTevTsq import readRawData\n",
     "from preprocess import extractTsAndSignal\n",
     "from computePsth import psthForEachStorename\n",
     "from findTransientsFreqAndAmp import executeFindFreqAndAmp"
@@ -54,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,41 +83,50 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "### Reading raw data... ###\n",
+      "/Volumes/T7/CatalystNeuro/NWB/Lerner/guppy_example_data/Photo_112_283-190620-093542\n",
+      "Trying to read tsq file.\n",
+      "Data from tsq file fetched.\n",
+      "Reading data for event Dv1A ...\n",
+      "In readtev(), type(S['sampling_rate']) = <class 'numpy.float32'>\n"
+     ]
+    },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[autoreload of readTevTsq failed: Traceback (most recent call last):\n",
-      "  File \"/opt/anaconda3/envs/guppy_env/lib/python3.6/site-packages/IPython/extensions/autoreload.py\", line 245, in check\n",
-      "    superreload(m, reload, self.old_objects)\n",
-      "  File \"/opt/anaconda3/envs/guppy_env/lib/python3.6/site-packages/IPython/extensions/autoreload.py\", line 394, in superreload\n",
-      "    module = reload(module)\n",
-      "  File \"/opt/anaconda3/envs/guppy_env/lib/python3.6/imp.py\", line 315, in reload\n",
-      "    return importlib.reload(module)\n",
-      "  File \"/opt/anaconda3/envs/guppy_env/lib/python3.6/importlib/__init__.py\", line 166, in reload\n",
-      "    _bootstrap._exec(spec, module)\n",
-      "  File \"<frozen importlib._bootstrap>\", line 618, in _exec\n",
-      "  File \"<frozen importlib._bootstrap_external>\", line 678, in exec_module\n",
-      "  File \"<frozen importlib._bootstrap>\", line 219, in _call_with_frames_removed\n",
-      "  File \"/Users/pauladkisson/Documents/CatalystNeuro/NWB/LernerConv/GuPPy/GuPPy/readTevTsq.py\", line 555, in <module>\n",
-      "    from pynwb import NWBHDF5IO\n",
-      "ModuleNotFoundError: No module named 'pynwb'\n",
-      "]\n"
+      "100%|██████████| 29389/29389 [05:47<00:00, 84.64it/s] \n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "### Reading raw data... ###\n",
-      "/Volumes/T7/CatalystNeuro/NWB/Lerner/guppy_example_data/sub-112.283_ses-FP_PS_2019-06-20T09-32-04.nwb\n",
-      "Trying to read tsq file.\n",
-      "\u001b[1mtsq file not found.\u001b[1m\n",
-      "Checking if doric file exists.\n",
-      "\u001b[1mDoric file not found.\u001b[1m\n",
+      "Data for event Dv1A fetched and stored.\n",
+      "Reading data for event Dv2A ...\n",
+      "In readtev(), type(S['sampling_rate']) = <class 'numpy.float32'>\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 29389/29389 [09:31<00:00, 51.38it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Data for event Dv2A fetched and stored.\n",
+      "Time taken = 920.97965\n",
       "### Raw data fetched and saved.\n"
      ]
     }
@@ -131,28 +138,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Reading NWB file /Volumes/T7/CatalystNeuro/NWB/Lerner/guppy_example_data/sub-112.283_ses-FP_PS_2019-06-20T09-32-04.nwb for event fiber_photometry_response_series to save to /Volumes/T7/CatalystNeuro/NWB/Lerner/guppy_example_data/sub-112.283_ses-FP_PS_2019-06-20T09-32-04_output\n"
+      "Reading all events [0, 1] from NWB file /Volumes/T7/CatalystNeuro/NWB/Lerner/guppy_example_data/sub-112.283_ses-FP_PS_2019-06-20T09-32-04/sub-112.283_ses-FP_PS_2019-06-20T09-32-04.nwb to save to /Volumes/T7/CatalystNeuro/NWB/Lerner/guppy_example_data/sub-112.283_ses-FP_PS_2019-06-20T09-32-04/sub-112.283_ses-FP_PS_2019-06-20T09-32-04_output_0\n",
+      "Data for event event_0 fetched and stored.\n",
+      "Data for event event_1 fetched and stored.\n"
      ]
     }
    ],
    "source": [
-    "#readRawData(inputParametersPath)\n",
-    "\n",
     "from readTevTsq import read_nwb\n",
     "import json\n",
+    "from pathlib import Path\n",
+    "inputParametersPath = \"/Users/pauladkisson/GuPPyParamtersUsed.json\"\n",
+    "\n",
     "with open(inputParametersPath) as f:\n",
     "    inputParameters = json.load(f)\n",
-    "filepath = inputParameters['folderNames'][0]\n",
-    "event = \"fiber_photometry_response_series\"\n",
-    "outputPath = \"/Volumes/T7/CatalystNeuro/NWB/Lerner/guppy_example_data/sub-112.283_ses-FP_PS_2019-06-20T09-32-04_output\"\n",
-    "read_nwb(filepath=filepath, event=event, outputPath=outputPath)\n"
+    "folder_path = Path(inputParameters['folderNames'][0])\n",
+    "nwbfile_name = folder_path.name + \".nwb\"\n",
+    "filepath = folder_path / nwbfile_name\n",
+    "outputPath = \"/Volumes/T7/CatalystNeuro/NWB/Lerner/guppy_example_data/sub-112.283_ses-FP_PS_2019-06-20T09-32-04/sub-112.283_ses-FP_PS_2019-06-20T09-32-04_output_0\"\n",
+    "indices = [0, 1]\n",
+    "read_nwb(filepath, outputPath, indices)"
    ]
   },
   {
@@ -165,7 +177,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -215,7 +227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {

--- a/GuPPy/runFiberPhotometryAnalysis.ipynb
+++ b/GuPPy/runFiberPhotometryAnalysis.ipynb
@@ -4,40 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Step 1: Import Python Packages"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The autoreload extension is already loaded. To reload it, use:\n",
-      "  %reload_ext autoreload\n"
-     ]
-    }
-   ],
-   "source": [
-    "%load_ext autoreload\n",
-    "%autoreload 2\n",
-    "\n",
-    "%matplotlib tk\n",
-    "import os\n",
-    "import json\n",
-    "from preprocess import extractTsAndSignal\n",
-    "from computePsth import psthForEachStorename\n",
-    "from findTransientsFreqAndAmp import executeFindFreqAndAmp"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Step 2: Input Parameters GUI\n",
+    "### Step 1: Input Parameters GUI\n",
     "\n",
     "a) Open a <strong>new </strong>terminal/anaconda window and navigate to location of code by entering 'cd path_to_code'\n",
     "<br> <b>Example: 'cd Desktop/GuPPy-main/'</b> <br> \n",
@@ -51,8 +18,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For steps 1-3, please use the conda environment defined by guppy_read_env.yaml, especially if using nwb files."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -63,7 +37,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Step 3:  Storenames GUI \n",
+    "### Step 2:  Storenames GUI \n",
     "\n",
     "a) Click Storenames GUI icon <br>\n",
     "b) Select desired storenames to be analyzed <br>\n",
@@ -78,12 +52,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Step 4:  Read Raw Data"
+    "### Step 3:  Read Raw Data"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -91,42 +65,14 @@
      "output_type": "stream",
      "text": [
       "### Reading raw data... ###\n",
-      "/Volumes/T7/CatalystNeuro/NWB/Lerner/guppy_example_data/Photo_112_283-190620-093542\n",
+      "/Volumes/T7/CatalystNeuro/NWB/Lerner/guppy_example_data/sub-112.283_ses-FP_PS_2019-06-20T09-32-04\n",
       "Trying to read tsq file.\n",
-      "Data from tsq file fetched.\n",
-      "Reading data for event Dv1A ...\n",
-      "In readtev(), type(S['sampling_rate']) = <class 'numpy.float32'>\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 29389/29389 [05:47<00:00, 84.64it/s] \n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Data for event Dv1A fetched and stored.\n",
-      "Reading data for event Dv2A ...\n",
-      "In readtev(), type(S['sampling_rate']) = <class 'numpy.float32'>\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 29389/29389 [09:31<00:00, 51.38it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Data for event Dv2A fetched and stored.\n",
-      "Time taken = 920.97965\n",
+      "\u001b[1mtsq file not found.\u001b[1m\n",
+      "Checking if doric file exists.\n",
+      "\u001b[1mDoric file not found.\u001b[1m\n",
+      "Reading all events [0, 1] from NWB file /Volumes/T7/CatalystNeuro/NWB/Lerner/guppy_example_data/sub-112.283_ses-FP_PS_2019-06-20T09-32-04/sub-112.283_ses-FP_PS_2019-06-20T09-32-04.nwb to save to /Volumes/T7/CatalystNeuro/NWB/Lerner/guppy_example_data/sub-112.283_ses-FP_PS_2019-06-20T09-32-04/sub-112.283_ses-FP_PS_2019-06-20T09-32-04_output_0\n",
+      "Data for event event_0 fetched and stored.\n",
+      "Data for event event_1 fetched and stored.\n",
       "### Raw data fetched and saved.\n"
      ]
     }
@@ -137,34 +83,36 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 3,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Reading all events [0, 1] from NWB file /Volumes/T7/CatalystNeuro/NWB/Lerner/guppy_example_data/sub-112.283_ses-FP_PS_2019-06-20T09-32-04/sub-112.283_ses-FP_PS_2019-06-20T09-32-04.nwb to save to /Volumes/T7/CatalystNeuro/NWB/Lerner/guppy_example_data/sub-112.283_ses-FP_PS_2019-06-20T09-32-04/sub-112.283_ses-FP_PS_2019-06-20T09-32-04_output_0\n",
-      "Data for event event_0 fetched and stored.\n",
-      "Data for event event_1 fetched and stored.\n"
-     ]
-    }
-   ],
    "source": [
-    "from readTevTsq import read_nwb\n",
-    "import json\n",
-    "from pathlib import Path\n",
-    "inputParametersPath = \"/Users/pauladkisson/GuPPyParamtersUsed.json\"\n",
+    "### Step 4: Import Python Packages"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For steps 4-8, please use the main guppy environment installed from the spec_file appropriate for your OS."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
     "\n",
-    "with open(inputParametersPath) as f:\n",
-    "    inputParameters = json.load(f)\n",
-    "folder_path = Path(inputParameters['folderNames'][0])\n",
-    "nwbfile_name = folder_path.name + \".nwb\"\n",
-    "filepath = folder_path / nwbfile_name\n",
-    "outputPath = \"/Volumes/T7/CatalystNeuro/NWB/Lerner/guppy_example_data/sub-112.283_ses-FP_PS_2019-06-20T09-32-04/sub-112.283_ses-FP_PS_2019-06-20T09-32-04_output_0\"\n",
-    "indices = [0, 1]\n",
-    "read_nwb(filepath, outputPath, indices)"
+    "%matplotlib tk\n",
+    "import os\n",
+    "import json\n",
+    "from preprocess import extractTsAndSignal\n",
+    "from computePsth import psthForEachStorename\n",
+    "from findTransientsFreqAndAmp import executeFindFreqAndAmp\n",
+    "\n",
+    "inputParametersPath = \"/Users/pauladkisson/GuPPyParamtersUsed.json\""
    ]
   },
   {
@@ -177,7 +125,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -227,7 +175,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {

--- a/GuPPy/runFiberPhotometryAnalysis.ipynb
+++ b/GuPPy/runFiberPhotometryAnalysis.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -85,54 +85,74 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[autoreload of readTevTsq failed: Traceback (most recent call last):\n",
+      "  File \"/opt/anaconda3/envs/guppy_env/lib/python3.6/site-packages/IPython/extensions/autoreload.py\", line 245, in check\n",
+      "    superreload(m, reload, self.old_objects)\n",
+      "  File \"/opt/anaconda3/envs/guppy_env/lib/python3.6/site-packages/IPython/extensions/autoreload.py\", line 394, in superreload\n",
+      "    module = reload(module)\n",
+      "  File \"/opt/anaconda3/envs/guppy_env/lib/python3.6/imp.py\", line 315, in reload\n",
+      "    return importlib.reload(module)\n",
+      "  File \"/opt/anaconda3/envs/guppy_env/lib/python3.6/importlib/__init__.py\", line 166, in reload\n",
+      "    _bootstrap._exec(spec, module)\n",
+      "  File \"<frozen importlib._bootstrap>\", line 618, in _exec\n",
+      "  File \"<frozen importlib._bootstrap_external>\", line 678, in exec_module\n",
+      "  File \"<frozen importlib._bootstrap>\", line 219, in _call_with_frames_removed\n",
+      "  File \"/Users/pauladkisson/Documents/CatalystNeuro/NWB/LernerConv/GuPPy/GuPPy/readTevTsq.py\", line 555, in <module>\n",
+      "    from pynwb import NWBHDF5IO\n",
+      "ModuleNotFoundError: No module named 'pynwb'\n",
+      "]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "### Reading raw data... ###\n",
+      "/Volumes/T7/CatalystNeuro/NWB/Lerner/guppy_example_data/sub-112.283_ses-FP_PS_2019-06-20T09-32-04.nwb\n",
+      "Trying to read tsq file.\n",
+      "\u001b[1mtsq file not found.\u001b[1m\n",
+      "Checking if doric file exists.\n",
+      "\u001b[1mDoric file not found.\u001b[1m\n",
+      "### Raw data fetched and saved.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from readTevTsq import readRawData\n",
+    "readRawData(inputParametersPath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "### Reading raw data... ###\n",
-      "/Volumes/T7/CatalystNeuro/NWB/Lerner/guppy_example_data/Photo_112_283-190620-093542\n",
-      "Trying to read tsq file.\n",
-      "Data from tsq file fetched.\n",
-      "Reading data for event Dv1A ...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 29389/29389 [06:38<00:00, 73.70it/s] \n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Data for event Dv1A fetched and stored.\n",
-      "Reading data for event Dv2A ...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 29389/29389 [09:43<00:00, 50.39it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Data for event Dv2A fetched and stored.\n",
-      "Time taken = 983.78427\n",
-      "### Raw data fetched and saved.\n"
+      "Reading NWB file /Volumes/T7/CatalystNeuro/NWB/Lerner/guppy_example_data/sub-112.283_ses-FP_PS_2019-06-20T09-32-04.nwb for event fiber_photometry_response_series to save to /Volumes/T7/CatalystNeuro/NWB/Lerner/guppy_example_data/sub-112.283_ses-FP_PS_2019-06-20T09-32-04_output\n"
      ]
     }
    ],
    "source": [
-    "readRawData(inputParametersPath)"
+    "#readRawData(inputParametersPath)\n",
+    "\n",
+    "from readTevTsq import read_nwb\n",
+    "import json\n",
+    "with open(inputParametersPath) as f:\n",
+    "    inputParameters = json.load(f)\n",
+    "filepath = inputParameters['folderNames'][0]\n",
+    "event = \"fiber_photometry_response_series\"\n",
+    "outputPath = \"/Volumes/T7/CatalystNeuro/NWB/Lerner/guppy_example_data/sub-112.283_ses-FP_PS_2019-06-20T09-32-04_output\"\n",
+    "read_nwb(filepath=filepath, event=event, outputPath=outputPath)\n"
    ]
   },
   {
@@ -577,9 +597,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "guppy-test",
+   "display_name": "guppy_env",
    "language": "python",
-   "name": "guppy-test"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -591,7 +611,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/GuPPy/runFiberPhotometryAnalysis.ipynb
+++ b/GuPPy/runFiberPhotometryAnalysis.ipynb
@@ -9,9 +9,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The autoreload extension is already loaded. To reload it, use:\n",
+      "  %reload_ext autoreload\n",
+      "Warning: Cannot change to a different GUI toolkit: tk. Using osx instead.\n"
+     ]
+    }
+   ],
    "source": [
     "%load_ext autoreload\n",
     "%autoreload 2\n",
@@ -44,11 +54,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
-    "inputParametersPath = \"/Users/vns0170/GuPPyParamtersUsed.json\""
+    "inputParametersPath = \"/Users/pauladkisson/GuPPyParamtersUsed.json\""
    ]
   },
   {
@@ -75,7 +85,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -83,46 +93,40 @@
      "output_type": "stream",
      "text": [
       "### Reading raw data... ###\n",
-      "/Users/vns0170/Downloads/FP_Data/habitEarly/Photo_048_392-200728-121222\n",
+      "/Volumes/T7/CatalystNeuro/NWB/Lerner/guppy_example_data/Photo_112_283-190620-093542\n",
       "Trying to read tsq file.\n",
       "Data from tsq file fetched.\n",
-      "Reading data for event Dv1A ...\n",
-      "Reading data for event Dv2A ...\n",
+      "Reading data for event Dv1A ...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 29389/29389 [06:38<00:00, 73.70it/s] \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Data for event Dv1A fetched and stored.\n",
+      "Reading data for event Dv2A ...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 29389/29389 [09:43<00:00, 50.39it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Data for event Dv2A fetched and stored.\n",
-      "Reading data for event Dv3B ...\n",
-      "Reading data for event Dv4B ...\n",
-      "Data for event Dv3B fetched and stored.\n",
-      "Reading data for event LNRW ...\n",
-      "Data for event Dv4B fetched and stored.\n",
-      "Reading data for event LNnR ...\n",
-      "Data for event LNRW fetched and stored.\n",
-      "Reading data for event PrtN ...\n",
-      "Data for event LNnR fetched and stored.\n",
-      "Reading data for event PrtR ...\n",
-      "Data for event PrtN fetched and stored.\n",
-      "Data for event PrtR fetched and stored.\n",
-      "Time taken = 5.42340\n",
-      "/Users/vns0170/Downloads/FP_Data/habitEarly/Photo_63_207-181030-103332\n",
-      "Trying to read tsq file.\n",
-      "Data from tsq file fetched.\n",
-      "Reading data for event Dv1A ...\n",
-      "Reading data for event Dv2A ...\n",
-      "Data for event Dv1A fetched and stored.\n",
-      "Data for event Dv2A fetched and stored.\n",
-      "Reading data for event Dv3B ...\n",
-      "Reading data for event Dv4B ...\n",
-      "Data for event Dv3B fetched and stored.\n",
-      "Reading data for event LNRW ...\n",
-      "Data for event Dv4B fetched and stored.\n",
-      "Reading data for event LNnR ...\n",
-      "Data for event LNRW fetched and stored.\n",
-      "Reading data for event PrtN ...\n",
-      "Data for event LNnR fetched and stored.\n",
-      "Reading data for event PrtR ...\n",
-      "Data for event PrtN fetched and stored.\n",
-      "Data for event PrtR fetched and stored.\n",
-      "Time taken = 6.39616\n",
+      "Time taken = 983.78427\n",
       "### Raw data fetched and saved.\n"
      ]
     }
@@ -141,7 +145,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -149,7 +153,7 @@
      "output_type": "stream",
      "text": [
       "Extracting signal data and event timestamps...\n",
-      "Remove Artifacts :  True\n",
+      "Remove Artifacts :  False\n",
       "Combine Data :  False\n",
       "Isosbestic Control Channel :  True\n",
       "Correcting timestamps by getting rid of the first 1 seconds and convert timestamps to seconds...\n",
@@ -158,52 +162,9 @@
       "Timestamps corrections applied to the data and event timestamps.\n",
       "Applying correction of timestamps to the data and event timestamps...\n",
       "Timestamps corrections applied to the data and event timestamps.\n",
-      "Applying correction of timestamps to the data and event timestamps...\n",
-      "Timestamps corrections applied to the data and event timestamps.\n",
-      "Applying correction of timestamps to the data and event timestamps...\n",
-      "Timestamps corrections applied to the data and event timestamps.\n",
-      "Applying correction of timestamps to the data and event timestamps...\n",
-      "Timestamps corrections applied to the data and event timestamps.\n",
-      "Applying correction of timestamps to the data and event timestamps...\n",
-      "Timestamps corrections applied to the data and event timestamps.\n",
-      "Applying correction of timestamps to the data and event timestamps...\n",
-      "Timestamps corrections applied to the data and event timestamps.\n",
-      "Applying correction of timestamps to the data and event timestamps...\n",
-      "Timestamps corrections applied to the data and event timestamps.\n",
-      "Correcting timestamps by getting rid of the first 1 seconds and convert timestamps to seconds...\n",
-      "Timestamps corrected and converted to seconds.\n",
-      "Applying correction of timestamps to the data and event timestamps...\n",
-      "Timestamps corrections applied to the data and event timestamps.\n",
-      "Applying correction of timestamps to the data and event timestamps...\n",
-      "Timestamps corrections applied to the data and event timestamps.\n",
-      "Applying correction of timestamps to the data and event timestamps...\n",
-      "Timestamps corrections applied to the data and event timestamps.\n",
-      "Applying correction of timestamps to the data and event timestamps...\n",
-      "Timestamps corrections applied to the data and event timestamps.\n",
-      "Applying correction of timestamps to the data and event timestamps...\n",
-      "Timestamps corrections applied to the data and event timestamps.\n",
-      "Applying correction of timestamps to the data and event timestamps...\n",
-      "Timestamps corrections applied to the data and event timestamps.\n",
-      "Applying correction of timestamps to the data and event timestamps...\n",
-      "Timestamps corrections applied to the data and event timestamps.\n",
-      "Applying correction of timestamps to the data and event timestamps...\n",
-      "Timestamps corrections applied to the data and event timestamps.\n",
-      "Removing Artifacts from the data and correcting timestamps...\n",
       "Computing z-score for each of the data...\n",
-      "Remove Artifacts :  True\n",
-      "Remove Artifacts :  True\n",
+      "Remove Artifacts :  False\n",
       "z-score for the data computed.\n",
-      "Processing timestamps to get rid of artifacts using concatenate method...\n",
-      "Timestamps processed, artifacts are removed and good chunks are concatenated.\n",
-      "Artifacts from the data are removed and timestamps are corrected.\n",
-      "Removing Artifacts from the data and correcting timestamps...\n",
-      "Computing z-score for each of the data...\n",
-      "Remove Artifacts :  True\n",
-      "Remove Artifacts :  True\n",
-      "z-score for the data computed.\n",
-      "Processing timestamps to get rid of artifacts using concatenate method...\n",
-      "Timestamps processed, artifacts are removed and good chunks are concatenated.\n",
-      "Artifacts from the data are removed and timestamps are corrected.\n",
       "Signal data and event timestamps are extracted.\n"
      ]
     }
@@ -234,7 +195,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -243,81 +204,9 @@
      "text": [
       "Computing PSTH, Peak and Area for each event...\n",
       "Average for group :  False\n",
-      "Computing PSTH for event rwdNP...Computing PSTH for event urwdNP...\n",
-      "\n",
-      "PSTH for event rwdNP computed.\n",
-      "Computing PSTH for event rwdNP...\n",
-      "PSTH for event rwdNP computed.\n",
-      "Computing PSTH for event urwdPE...\n",
-      "PSTH for event urwdNP computed.\n",
-      "Computing PSTH for event urwdNP...\n",
-      "PSTH for event urwdPE computed.\n",
-      "Computing PSTH for event urwdPE...\n",
-      "PSTH for event urwdNP computed.\n",
-      "Computing PSTH for event rwdPE...\n",
-      "PSTH for event urwdPE computed.\n",
-      "PSTH for event rwdPE computed.\n",
-      "Computing PSTH for event rwdPE...\n",
-      "PSTH for event rwdPE computed.\n",
-      "Computing peak and area for PSTH mean signal for event rwdNP...Computing peak and area for PSTH mean signal for event urwdNP...\n",
-      "\n",
-      "Peak and Area for PSTH mean signal for event rwdNP computed.\n",
-      "Computing peak and area for PSTH mean signal for event rwdNP...\n",
-      "Peak and Area for PSTH mean signal for event rwdNP computed.\n",
-      "Computing peak and area for PSTH mean signal for event urwdPE...\n",
-      "Peak and Area for PSTH mean signal for event urwdNP computed.\n",
-      "Computing peak and area for PSTH mean signal for event urwdNP...\n",
-      "Peak and Area for PSTH mean signal for event urwdPE computed.\n",
-      "Computing peak and area for PSTH mean signal for event urwdPE...\n",
-      "Peak and Area for PSTH mean signal for event urwdNP computed.\n",
-      "Computing peak and area for PSTH mean signal for event rwdPE...\n",
-      "Peak and Area for PSTH mean signal for event rwdPE computed.\n",
-      "Computing peak and area for PSTH mean signal for event rwdPE...\n",
-      "Peak and Area for PSTH mean signal for event urwdPE computed.\n",
-      "Peak and Area for PSTH mean signal for event rwdPE computed.\n",
-      "Computing PSTH for event rwdNP...Computing PSTH for event urwdNP...\n",
-      "\n",
-      "PSTH for event rwdNP computed.\n",
-      "Computing PSTH for event rwdNP...\n",
-      "PSTH for event rwdNP computed.\n",
-      "Computing PSTH for event urwdPE...\n",
-      "PSTH for event urwdNP computed.\n",
-      "Computing PSTH for event urwdNP...\n",
-      "PSTH for event urwdPE computed.\n",
-      "Computing PSTH for event urwdPE...\n",
-      "PSTH for event urwdNP computed.\n",
-      "Computing PSTH for event rwdPE...\n",
-      "PSTH for event urwdPE computed.\n",
-      "PSTH for event rwdPE computed.\n",
-      "Computing PSTH for event rwdPE...\n",
-      "PSTH for event rwdPE computed.\n",
-      "Computing peak and area for PSTH mean signal for event urwdNP...Computing peak and area for PSTH mean signal for event rwdNP...\n",
-      "\n",
-      "Peak and Area for PSTH mean signal for event rwdNP computed.\n",
-      "Computing peak and area for PSTH mean signal for event rwdNP...\n",
-      "Peak and Area for PSTH mean signal for event rwdNP computed.\n",
-      "Computing peak and area for PSTH mean signal for event urwdPE...\n",
-      "Peak and Area for PSTH mean signal for event urwdNP computed.\n",
-      "Computing peak and area for PSTH mean signal for event urwdNP...\n",
-      "Peak and Area for PSTH mean signal for event urwdPE computed.\n",
-      "Computing peak and area for PSTH mean signal for event urwdPE...\n",
-      "Peak and Area for PSTH mean signal for event urwdNP computed.\n",
-      "Computing peak and area for PSTH mean signal for event rwdPE...\n",
-      "Peak and Area for PSTH mean signal for event urwdPE computed.\n",
-      "Peak and Area for PSTH mean signal for event rwdPE computed.\n",
-      "Computing peak and area for PSTH mean signal for event rwdPE...\n",
-      "Peak and Area for PSTH mean signal for event rwdPE computed.\n",
       "PSTH, Area and Peak are computed for all events.\n",
       "Finding transients in z-score data and calculating frequency and amplitude....\n",
       "Calculating frequency and amplitude of transients in z-score data....\n",
-      "Creating chunks for multiprocessing...\n",
-      "Chunks are created for multiprocessing.\n",
-      "Creating chunks for multiprocessing...\n",
-      "Chunks are created for multiprocessing.\n",
-      "Frequency and amplitude of transients in z_score data are calculated.\n",
-      "Calculating frequency and amplitude of transients in z-score data....\n",
-      "Creating chunks for multiprocessing...\n",
-      "Chunks are created for multiprocessing.\n",
       "Creating chunks for multiprocessing...\n",
       "Chunks are created for multiprocessing.\n",
       "Frequency and amplitude of transients in z_score data are calculated.\n",

--- a/guppy_read_env.yaml
+++ b/guppy_read_env.yaml
@@ -1,0 +1,14 @@
+name: guppy_read_env
+channels:
+  - defaults
+  - conda-forge
+dependencies:
+  - python>=3.8
+  - h5py
+  - numpy
+  - pandas
+  - tqdm
+  - ipykernel
+  - pip
+  - pip:
+    - pynwb


### PR DESCRIPTION
This PR adds read support for .nwb files.

The `readRawData()` function now automatically checks if nwb files are present in each data folder, and if so reads them and writes to hdf5 in a format identical to the other read functions.

Note: the primary conda environment defined by `spec_file_mac.txt` does not work for .nwb read since pynwb requires python>=3.8, but the existing guppy environment is in python 3.6.  To solve this problem, I defined a new `guppy_read_env`, which uses python>=3.8. 