### PR TITLE
Added auto-publish workflow

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -1,0 +1,36 @@
+
+# Automatically builds and publishes Python package to PyPI when a GitHub release is published.
+# Uses build library to create distribution files from pyproject.toml configuration,
+# then uploads to PyPI using official PyPA GitHub Action with stored API token.
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Upload Package to TestPyPI
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install Building Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade build
+      - name: Build package
+        run: |
+          python -m build
+      - name: pypi-publish
+        uses: pypa/gh-action-pypi-publish@v1.12.4
+        with:
+          repository_url: https://test.pypi.org/legacy/
+          verbose: true
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}


### PR DESCRIPTION
Workflows need to be merged into main so that they are available to run from Github.