### PR TITLE
Add Codecov badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![DOI](https://zenodo.org/badge/382176345.svg)](https://zenodo.org/badge/latestdoi/382176345) [![Join the chat at https://gitter.im/LernerLab/GuPPy](https://badges.gitter.im/LernerLab/GuPPy.svg)](https://gitter.im/LernerLab/GuPPy?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![DOI](https://zenodo.org/badge/382176345.svg)](https://zenodo.org/badge/latestdoi/382176345) [![Join the chat at https://gitter.im/LernerLab/GuPPy](https://badges.gitter.im/LernerLab/GuPPy.svg)](https://gitter.im/LernerLab/GuPPy?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![codecov](https://codecov.io/gh/LernerLab/GuPPy/graph/badge.svg)](https://codecov.io/gh/LernerLab/GuPPy)
 
 <img src="assets/GuppyLogo.png" alt="GuPPy Logo" width="300">
 


### PR DESCRIPTION
## Summary
- Adds a Codecov coverage badge to the README alongside existing DOI and Gitter badges

## Test plan
- [x] Verify badge renders correctly on the PR/repo page
- [x] Verify badge links to the correct Codecov dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)