### PR TITLE
Add documentation site with Sphinx and a first tutorial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ GuPPy/runFiberPhotometryAnalysis.ipynb
 testing_data/
 
 CLAUDE.md
+
+docs/_build/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,14 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+  jobs:
+    install:
+      - pip install -U pip
+      - pip install .
+      - pip install --group docs
+
+sphinx:
+  configuration: docs/conf.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ## Deprecations and Removals
 
 ## Improvements
-- Added documentation site with Sphinx, pydata-sphinx-theme, and MyST-Parser. Includes Diataxis structure and a first tutorial covering the end-to-end GUI workflow with stubbed CSV test data. [PR #262](https://github.com/LernerLab/GuPPy/pull/262)
+- Added documentation site with Sphinx, pydata-sphinx-theme, and MyST-Parser. Includes Diataxis structure and a first tutorial covering the end-to-end GUI workflow with stubbed CSV test data. [PR #264](https://github.com/LernerLab/GuPPy/pull/264)
 - Improved test suite coverage to greater than or equal to 85% on CodeCov. [PR #260](https://github.com/LernerLab/GuPPy/pull/260)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Deprecations and Removals
 
 ## Improvements
+- Added documentation site with Sphinx, pydata-sphinx-theme, and MyST-Parser. Includes Diataxis structure and a first tutorial covering the end-to-end GUI workflow with stubbed CSV test data. [PR #262](https://github.com/LernerLab/GuPPy/pull/262)
 - Improved test suite coverage to greater than or equal to 85% on CodeCov. [PR #260](https://github.com/LernerLab/GuPPy/pull/260)
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,10 +16,13 @@ source_suffix = [".rst", ".md"]
 
 myst_enable_extensions = ["colon_fence"]
 
+html_logo = "../assets/GuppyLogo.png"
+
 html_theme_options = {
     "github_url": "https://github.com/LernerLab/GuPPy",
     "logo": {
-        "text": "GuPPy",
+        "image_light": "../assets/GuppyLogo.png",
+        "image_dark": "../assets/GuppyLogo.png",
     },
 }
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,29 @@
+project = "GuPPy"
+copyright = "2024, LernerLab"
+author = "LernerLab"
+
+extensions = [
+    "myst_parser",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.intersphinx",
+    "sphinx_autodoc_typehints",
+]
+
+html_theme = "pydata_sphinx_theme"
+
+source_suffix = [".rst", ".md"]
+
+myst_enable_extensions = ["colon_fence"]
+
+html_theme_options = {
+    "github_url": "https://github.com/LernerLab/GuPPy",
+    "logo": {
+        "text": "GuPPy",
+    },
+}
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "numpy": ("https://numpy.org/doc/stable", None),
+}

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -1,0 +1,3 @@
+# Explanation
+
+Explanation pages give background and context: the science behind fiber photometry, the design decisions in the GuPPy pipeline, and the reasoning behind key parameter choices. This section is coming in a follow-up release.

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -1,0 +1,3 @@
+# How-to Guides
+
+How-to guides are task-oriented references for readers who know what they want to accomplish. Updated guides for GuPPy v2 are in progress. In the meantime, the [GitHub Wiki](https://github.com/LernerLab/GuPPy/wiki) covers the v1 workflow and remains a useful reference for most steps.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,32 @@
+# GuPPy
+
+**Guided Photometry Analysis in Python** is an open-source tool for processing and analyzing fiber photometry recordings. It provides a GUI-based pipeline covering raw data ingestion, signal preprocessing, PSTH computation, transient detection, and visualization. Data formats supported include TDT, Doric, Neurophotometrics (NPM), and generic CSV.
+
+## Installation
+
+```bash
+pip install guppy-neuro
+```
+
+Then launch the GUI:
+
+```bash
+guppy
+```
+
+```{toctree}
+:maxdepth: 1
+:caption: Contents
+
+tutorials/index
+how-to/index
+explanation/index
+reference/index
+```
+
+## Links
+
+- [Source code](https://github.com/LernerLab/GuPPy)
+- [PyPI package](https://pypi.org/project/guppy-neuro/)
+- [Issue tracker](https://github.com/LernerLab/GuPPy/issues)
+- [GitHub Wiki](https://github.com/LernerLab/GuPPy/wiki) (covers v1.3.0 and earlier; updated guides for v2 are being added here)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,11 @@
 # GuPPy
 
+```{image} ../assets/GuppyLogo.png
+:alt: GuPPy logo
+:width: 300px
+:align: center
+```
+
 **Guided Photometry Analysis in Python** is an open-source tool for processing and analyzing fiber photometry recordings. It provides a GUI-based pipeline covering raw data ingestion, signal preprocessing, PSTH computation, transient detection, and visualization. Data formats supported include TDT, Doric, Neurophotometrics (NPM), and generic CSV.
 
 ## Installation

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,3 @@
+# Reference
+
+Auto-generated API documentation from source docstrings is coming in a follow-up release.

--- a/docs/tutorials/first_analysis.md
+++ b/docs/tutorials/first_analysis.md
@@ -1,0 +1,110 @@
+# Your First Analysis
+
+This tutorial walks through a complete GuPPy pipeline run from raw CSV data to a PSTH plot. You will use the small sample dataset that ships with the repository, so no data download is required.
+
+By the end you will have:
+
+- Launched the GuPPy GUI
+- Assigned names to your recording channels (storenames)
+- Ingested raw data into HDF5
+- Preprocessed the signal
+- Computed a PSTH
+- Opened the visualization panel
+
+## Prerequisites
+
+- GuPPy installed (`pip install guppy-neuro`).
+
+- The sample data lives at `stubbed_testing_data/csv/sample_data_csv_1/` inside the repository root. It contains three CSV files:
+
+  | File | Description |
+  |------|-------------|
+  | `Sample_Control_Channel.csv` | Isosbestic (405 nm) control channel |
+  | `Sample_Signal_Channel.csv` | Calcium-dependent (470 nm) signal channel |
+  | `Sample_TTL.csv` | Event timestamps |
+
+  Each signal CSV has three columns: `timestamps` (seconds), `data` (fluorescence), and `sampling_rate`. The TTL CSV has a single `timestamps` column.
+
+## Step 1: Launch the GUI
+
+```bash
+guppy
+```
+
+A browser tab opens showing the GuPPy dashboard. The main panel has three collapsible cards: **Individual Analysis**, **Group Analysis**, and **Visualization Parameters**.
+
+## Step 2: Set the analysis parameters
+
+Expand **Individual Analysis** if it is not already open.
+
+Use the file selector to navigate to `stubbed_testing_data/csv/sample_data_csv_1/` and select that folder.
+
+Set the following parameters (leave everything else at its default):
+
+| Parameter | Value | Why |
+|-----------|-------|-----|
+| Isosbestic Control Channel? | True | The sample data includes a 405 nm control channel. |
+| Eliminate first few seconds | 1 | Drops the first second of data, which can contain transient noise from the LED turning on. |
+| Window for Moving Average filter | 100 | Smoothing window in data points. The default works well for ~1 kHz recordings. |
+
+The z-score and PSTH parameters can remain at their defaults for this tutorial.
+
+## Step 3: Assign storenames
+
+Click **Save to File** at the top of the GUI. This opens the Storenames panel.
+
+GuPPy reads the CSV filenames and lists them as available channels. You need to tell it which channel is control (isosbestic), which is signal, and what the TTL represents.
+
+Map the channels using the naming convention `control_<region>` and `signal_<region>`:
+
+| Channel filename | Name to assign |
+|-----------------|----------------|
+| `Sample_Control_Channel` | `control_A` |
+| `Sample_Signal_Channel` | `signal_A` |
+| `Sample_TTL` | `RewardPort` |
+
+Select each storename from the list, type its name in the text field, then click **Select Storenames**. When all three are assigned, choose **create new** and click **Save**.
+
+GuPPy writes a `storeslist.json` file inside the session folder that records these assignments. The pipeline reads that file during preprocessing.
+
+## Step 4: Read raw data
+
+Click **Read Raw Data**.
+
+GuPPy loads each CSV file and writes the data into an HDF5 file (`{session_folder}/data.hdf5`). HDF5 is a binary format that stores large numerical arrays efficiently and supports partial reads, which speeds up the later pipeline steps.
+
+When the step completes the console will log a confirmation message.
+
+## Step 5: Preprocess
+
+Click **Preprocess**.
+
+GuPPy runs the following on the raw signal:
+
+1. Trims the first `timeForLightsTurnOn` seconds from both channels.
+2. Applies a moving-average filter to reduce high-frequency noise.
+3. Fits the control channel to the signal channel using a linear regression, then subtracts it. This removes motion artifacts and photobleaching that affect both channels equally.
+4. Computes the z-score of the corrected signal using the selected method (standard z-score by default).
+
+The z-scored trace is saved back into the HDF5 file.
+
+## Step 6: Compute PSTH
+
+Click **Compute PSTH**.
+
+GuPPy aligns the z-scored trace to each event timestamp in `Sample_TTL.csv`, extracts a window of `nSecPrev` seconds before and `nSecPost` seconds after each event, and averages across all trials. The result is a peri-stimulus time histogram (PSTH).
+
+The default window is -10 to +20 seconds. With the sample data you will get a small number of trials (the TTL file has just a handful of timestamps), so the average will be noisy. This is expected for a minimal example dataset.
+
+Output files are written to the session folder.
+
+## Step 7: Visualize
+
+Expand **Visualization Parameters**. Set **Visualize Average Results?** to `True` and click **Visualize**.
+
+The visualization panel opens and shows the average PSTH trace with a shaded confidence interval. The x-axis is time relative to the event, and the y-axis is z-score.
+
+## Next steps
+
+- See [How-to Guides](../how-to/index.md) for task-specific instructions (TDT data ingestion, artifact removal, group analysis, etc.).
+- See [Explanation](../explanation/index.md) for background on the isosbestic correction and z-score methods.

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,0 +1,9 @@
+# Tutorials
+
+Tutorials are learning-oriented guides that walk you through a complete workflow from start to finish. Follow them in order when you are new to GuPPy.
+
+```{toctree}
+:maxdepth: 1
+
+first_analysis
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,13 @@ dependencies = [
 ]
 
 [dependency-groups]
+docs = [
+    "sphinx",
+    "pydata-sphinx-theme",
+    "myst-parser",
+    "sphinx-autodoc-typehints",
+]
+
 test = [
     "pytest",
     "pytest-cov",


### PR DESCRIPTION
GuPPy has had no hosted documentation site since the v2 rewrite began. The GitHub Wiki covers v1.3.0 and is increasingly out of date as the codebase changes. This PR lays the foundation for a proper docs site on Read the Docs, structured around the [Diataxis framework](https://diataxis.fr) so content can grow incrementally without needing a future reorganization.

The infrastructure uses [Sphinx](https://www.sphinx-doc.org) with the [pydata-sphinx-theme](https://pydata-sphinx-theme.readthedocs.io) (the standard for scientific Python projects) and [MyST-Parser](https://myst-parser.readthedocs.io) so all content can be written in Markdown. Read the Docs is configured via `.readthedocs.yaml` using `pip install --group docs`, the same pattern used by [NeuroConv](https://github.com/catalystneuro/neuroconv). The Diataxis skeleton (Tutorials, How-to, Explanation, Reference) is in place, with three of the four sections stubbed and pointing to follow-up PRs.

The one piece of real content is a tutorial that walks a new user through the full GUI pipeline using the stubbed CSV data already in the repository, so no external download is required. Screenshots will be added to the tutorial in a follow-up PR. I have left wiki migration, explanation pages, and the API reference out of this PR to keep it reviewable; those are tracked in the documentation planning issue.
