### PR TITLE
Added --start-path option for convenience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 - Added read support for NWB files with dedicated recording extractor. [PR #261](https://github.com/LernerLab/GuPPy/pull/261)
+- Added --start-path option to guppy launch command [PR #265](https://github.com/LernerLab/GuPPy/pull/265)
 
 ## Fixes
 - Fixed pickling issue for long storenames in `read_and_save_all_events`. [PR #261](https://github.com/LernerLab/GuPPy/pull/261)

--- a/src/guppy/frontend/input_parameters.py
+++ b/src/guppy/frontend/input_parameters.py
@@ -49,9 +49,9 @@ def getAbsPath(files_1, files_2):
 
 
 class ParameterForm:
-    def __init__(self, *, template):
+    def __init__(self, *, template, start_path=None):
         self.template = template
-        self.folder_path = _default_root_path()
+        self.folder_path = start_path if start_path and os.path.isdir(start_path) else _default_root_path()
         self.styles = dict(background="WhiteSmoke")
         self.setup_individual_parameters()
         self.setup_group_parameters()

--- a/src/guppy/main.py
+++ b/src/guppy/main.py
@@ -14,9 +14,9 @@ import panel as pn
 from .orchestration.home import build_homepage
 
 
-def serve_app():
+def serve_app(*, start_path=None):
     """Serve the GuPPy application using Panel."""
-    template = build_homepage()
+    template = build_homepage(start_path=start_path)
     pn.serve(template, show=True)
 
 
@@ -25,6 +25,7 @@ def main():
 
     Supports command-line flags:
     - --export-logs: Export the log file to Desktop for sharing with support
+    - --start-path: Set the initial directory for the folder selector
     - (no flags): Launch the GUI application
     """
     parser = argparse.ArgumentParser(description="GuPPy - Guided Photometry Analysis in Python")
@@ -33,6 +34,12 @@ def main():
         action="store_true",
         help="Export log file to Desktop with timestamped name for support purposes",
     )
+    parser.add_argument(
+        "--start-path",
+        type=str,
+        default=None,
+        help="Initial directory for the folder selector (defaults to home directory)",
+    )
 
     args = parser.parse_args()
 
@@ -40,7 +47,7 @@ def main():
         logging_config.export_log_file()
         return
 
-    serve_app()
+    serve_app(start_path=args.start_path)
 
 
 if __name__ == "__main__":

--- a/src/guppy/orchestration/home.py
+++ b/src/guppy/orchestration/home.py
@@ -33,12 +33,12 @@ def psthComputation(parameter_form, current_dir):
     subprocess.call([sys.executable, "-m", "guppy.orchestration.psth", json.dumps(inputParameters)])
 
 
-def build_homepage():
+def build_homepage(*, start_path=None):
     pn.extension()
     current_dir = os.getcwd()
 
     template = pn.template.BootstrapTemplate(title="Input Parameters GUI")
-    parameter_form = ParameterForm(template=template)
+    parameter_form = ParameterForm(template=template, start_path=start_path)
     sidebar = Sidebar(template=template)
 
     # ------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds a `--start-path` option to the GuPPy launch command to more easily specify a starting directory without having to click through the file selector every time. 