### PR TITLE
Fix automatic format detection when npm_split_events = True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added group-analysis validation in steps 5 and 6 with actionable error messages for mismatched/non-overlapping storenames and missing average outputs, replacing the prior `IndexError` and silent fall-through behaviors. [PR #293](https://github.com/LernerLab/GuPPy/pull/293)
 - Sidebar button click handlers now surface input-parameter validation errors (e.g. "No folder is selected for analysis") as a persistent Panel notification instead of dying silently in a worker thread traceback. [PR #296](https://github.com/LernerLab/GuPPy/pull/296)
 - Fixed TDT split-event extraction collapsing float-valued event codes (e.g. `0.1, 0.2, 0.4, 0.8, 10.0`) to integers, which caused duplicate `storesList.csv` rows, silent overwrites of per-code HDF5 files, and a downstream `KeyError` in step-6 visualization; sub-event suffixes now preserve unique floats as filesystem-safe `0p1`, `0p2`, … strings. [PR #294](https://github.com/LernerLab/GuPPy/pull/294)
+- Fixed `detect_acquisition_formats` skipping the intermediate `event*.csv` files that `NpmRecordingExtractor` materializes when `npm_split_events=True`, which left `CsvRecordingExtractor` undispatched and broke step-3 reads of NPM split-event TTLs. Single-column timestamp CSVs are now uniformly reported as `csv` regardless of whether NPM data is present. [PR #298](https://github.com/LernerLab/GuPPy/pull/298)
 
 ## Deprecations and Removals
 

--- a/src/guppy/extractors/detect_acquisition_formats.py
+++ b/src/guppy/extractors/detect_acquisition_formats.py
@@ -140,16 +140,11 @@ def detect_acquisition_formats(folder_path):
         if not has_npm_data and "csv" in labels:
             formats.add("csv")
 
-    # Single-column timestamp CSVs provide external event timestamps. When NPM data is
-    # present, suppress only the NPM-generated split-event files (named event*.csv), since
-    # those are owned by NpmRecordingExtractor. External event CSVs with other names are
-    # still detected as "csv" and handled by CsvRecordingExtractor.
-    event_csv_paths = [p for p in csv_paths if _is_event_csv(p)]
-    if has_npm_data:
-        external_event_csv_paths = [p for p in event_csv_paths if not os.path.basename(p).startswith("event")]
-    else:
-        external_event_csv_paths = event_csv_paths
-    if external_event_csv_paths:
+    # Single-column timestamp CSVs are always read by CsvRecordingExtractor — both
+    # user-supplied external TTL files and the event*.csv intermediates that
+    # NpmRecordingExtractor materializes when npm_split_events is True (NPM extends
+    # CSV but excludes single-column CSVs from its own discover, delegating them to CSV).
+    if any(_is_event_csv(p) for p in csv_paths):
         formats.add("csv")
 
     return formats

--- a/tests/unit/extractors/test_detect_acquisition_formats.py
+++ b/tests/unit/extractors/test_detect_acquisition_formats.py
@@ -6,6 +6,7 @@ import shutil
 import pytest
 from conftest import STUBBED_TESTING_DATA
 
+from guppy.extractors import NpmRecordingExtractor
 from guppy.extractors.detect_acquisition_formats import (
     _classify_csv_file,
     _is_event_csv,
@@ -130,3 +131,26 @@ def test_detect_acquisition_formats_with_external_csv_events(tmp_path, session_s
     shutil.copytree(src, session_copy)
     (session_copy / "port_entries.csv").write_text("timestamps\n0.1\n0.2\n0.3\n")
     assert detect_acquisition_formats(str(session_copy)) == expected_formats
+
+
+def test_detect_acquisition_formats_after_npm_split_events(tmp_path):
+    # When an NPM session has split-event TTLs, NpmRecordingExtractor.discover_events_and_flags
+    # writes intermediate single-column "event*.csv" files that must subsequently be read by
+    # CsvRecordingExtractor. detect_acquisition_formats must therefore report both "npm" and
+    # "csv" so the read path dispatches CsvRecordingExtractor for those events.
+    src = os.path.join(STUBBED_TESTING_DATA, "npm/sampleData_NPM_4")
+    session_copy = tmp_path / "sampleData_NPM_4"
+    shutil.copytree(src, session_copy)
+
+    inputParameters = {
+        "npm_timestamp_column_names": None,
+        "npm_time_units": None,
+        "npm_split_events": [True, True],
+    }
+    NpmRecordingExtractor.discover_events_and_flags(
+        folder_path=str(session_copy),
+        num_ch=2,
+        inputParameters=inputParameters,
+    )
+
+    assert detect_acquisition_formats(str(session_copy)) == {"npm", "csv"}


### PR DESCRIPTION
Previously, for neurophotometrics data with split events, the automatic format detection would incorrectly state that only NPM data was present when in fact the split events need to be handled by the CSV recording extractor. 

This PR fixes that issue.