### PR TITLE
Add type hints to extractors layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added numpydoc-style docstrings to all public functions in the testing layer (`src/guppy/testing/`). [PR #318](https://github.com/LernerLab/GuPPy/pull/318)
 - Added parameterized output directories: step 2 accepts a user-supplied run name, steps 1 and 3–6 honour a per-session run-name filter, and `GuPPyParamtersUsed.json` is written into the selected output directories so multiple parameter sets can coexist in one session. [PR #325](https://github.com/LernerLab/GuPPy/pull/325)
 - Added type hint checks to pre-commit. [PR #346](https://github.com/LernerLab/GuPPy/pull/346)
+- Added type hints to all functions in the extractors layer (`src/guppy/extractors/`). [PR #348](https://github.com/LernerLab/GuPPy/pull/348)
 
 ## Fixes
 - Fixed bug with step five, which was causing the baseline uncorrected HDF5 file to not exist. [PR #241](https://github.com/LernerLab/GuPPy/pull/241)

--- a/src/guppy/extractors/base_recording_extractor.py
+++ b/src/guppy/extractors/base_recording_extractor.py
@@ -3,6 +3,8 @@
 import logging
 import multiprocessing as mp
 from abc import ABC, abstractmethod
+from multiprocessing.sharedctypes import Synchronized
+from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -15,7 +17,7 @@ logger = logging.getLogger(__name__)
 _SAMPLES_DONE: "mp.sharedctypes.Synchronized | None" = None
 
 
-def _pool_initializer(samples_done):
+def _pool_initializer(samples_done: "Synchronized[int]") -> None:
     global _SAMPLES_DONE
     _SAMPLES_DONE = samples_done
 
@@ -96,7 +98,7 @@ class BaseRecordingExtractor(ABC):
         pass
 
     @abstractmethod
-    def stub(self, *, folder_path, duration_in_seconds=1.0):
+    def stub(self, *, folder_path: str | Path, duration_in_seconds: float = 1.0) -> None:
         """
         Create a stubbed copy of the data folder truncated to a short duration.
 
@@ -115,7 +117,12 @@ class BaseRecordingExtractor(ABC):
         pass
 
 
-def read_and_save_events_for_extractor(extractor, events, outputPath, event_total_samples):
+def read_and_save_events_for_extractor(
+    extractor: "BaseRecordingExtractor",
+    events: list[str],
+    outputPath: str,
+    event_total_samples: dict[str, int],
+) -> None:
     """
     Read all events owned by one extractor in a single batched call, save, and
     account progress per event.

--- a/src/guppy/extractors/csv_recording_extractor.py
+++ b/src/guppy/extractors/csv_recording_extractor.py
@@ -31,7 +31,7 @@ class CsvRecordingExtractor(BaseRecordingExtractor):
     """
 
     @classmethod
-    def discover_events_and_flags(cls, folder_path) -> tuple[list[str], list[str]]:
+    def discover_events_and_flags(cls, folder_path: str) -> tuple[list[str], list[str]]:
         """
         Discover available events and format flags from CSV files.
 
@@ -125,11 +125,11 @@ class CsvRecordingExtractor(BaseRecordingExtractor):
         logger.info("Importing of csv file is done.")
         return event_from_filename, flag_arr
 
-    def __init__(self, folder_path):
+    def __init__(self, folder_path: str) -> None:
         self.folder_path = folder_path
 
     @staticmethod
-    def _check_header(df):
+    def _check_header(df: pd.DataFrame) -> tuple[list[str], list[float]]:
         arr = list(df.columns)
         check_float = []
         for i in arr:
@@ -149,7 +149,7 @@ class CsvRecordingExtractor(BaseRecordingExtractor):
             total_lines = sum(1 for _ in file)
         return max(0, total_lines - 1)
 
-    def _read_csv(self, event):
+    def _read_csv(self, event: str) -> pd.DataFrame:
         logger.debug(f"Trying to read data for {event} from csv file.")
         csv_path = os.path.join(self.folder_path, event + ".csv")
         if not os.path.exists(csv_path):
@@ -202,7 +202,7 @@ class CsvRecordingExtractor(BaseRecordingExtractor):
                 )
         return output_dicts
 
-    def stub(self, *, folder_path, duration_in_seconds=1.0):
+    def stub(self, *, folder_path: str | Path, duration_in_seconds: float = 1.0) -> None:
         """
         Create a stubbed copy of the CSV folder with truncated data files.
 

--- a/src/guppy/extractors/dandi_nwb_recording_extractor.py
+++ b/src/guppy/extractors/dandi_nwb_recording_extractor.py
@@ -1,13 +1,14 @@
 """DANDI streaming NWB recording extractor for GuPPy fiber photometry pipeline."""
 
 import logging
+from pathlib import Path
 from typing import Any
 
 import h5py
 import numpy as np
 import remfile
 from dandi.dandiapi import DandiAPIClient
-from pynwb import NWBHDF5IO
+from pynwb import NWBHDF5IO, NWBFile
 
 from guppy.extractors.base_recording_extractor import add_samples_done
 from guppy.extractors.nwb_recording_extractor import (
@@ -21,14 +22,14 @@ logger = logging.getLogger(__name__)
 DANDI_URI_PREFIX = "dandi://"
 
 
-def is_dandi_uri(path):
+def is_dandi_uri(path: object) -> bool:
     """
     Check whether a path is a DANDI URI.
 
     Parameters
     ----------
-    path : str
-        Path to check.
+    path : object
+        Value to check.
 
     Returns
     -------
@@ -38,7 +39,7 @@ def is_dandi_uri(path):
     return isinstance(path, str) and path.startswith(DANDI_URI_PREFIX)
 
 
-def parse_dandi_uri(uri):
+def parse_dandi_uri(uri: str) -> tuple[str, str]:
     """
     Parse a DANDI URI into its dandiset ID and asset path.
 
@@ -76,7 +77,7 @@ class _CountingRemfile:
     unchanged from talking to the underlying ``remfile.File`` directly.
     """
 
-    def __init__(self, wrapped):
+    def __init__(self, wrapped: remfile.File) -> None:
         self._wrapped = wrapped
         self._current_event = None
         self._event_total_bytes = 0
@@ -114,7 +115,7 @@ class _CountingRemfile:
     def committed_samples_for_event(self, event: str) -> int:
         return self._committed_samples_by_event.get(event, 0)
 
-    def read(self, *args, **kwargs):
+    def read(self, *args: object, **kwargs: object) -> bytes:
         data = self._wrapped.read(*args, **kwargs)
         if self._current_event is not None and data and self._event_total_bytes > 0:
             self._bytes_seen_for_event += len(data)
@@ -128,7 +129,7 @@ class _CountingRemfile:
                 self._samples_committed_for_event = target_samples
         return data
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> object:
         return getattr(self._wrapped, name)
 
 
@@ -136,7 +137,9 @@ class _CountingRemfile:
 # the local-only live suite tests/unit/extractors/test_dandi_nwb_live.py (marker
 # ``dandi_live``, deselected in CI). Offline tests monkeypatch this function to open
 # a local mock NWB file instead.
-def _stream_nwb(*, dandiset_id, asset_path):  # pragma: no cover
+def _stream_nwb(
+    *, dandiset_id: str, asset_path: str
+) -> tuple[NWBFile, NWBHDF5IO, _CountingRemfile]:  # pragma: no cover
     """
     Open a streaming connection to an NWB file on the DANDI Archive.
 
@@ -181,7 +184,7 @@ class DandiNwbRecordingExtractor(NwbRecordingExtractor):
     """
 
     @classmethod
-    def discover_events_and_flags(cls, folder_path) -> tuple[list[str], list[str]]:
+    def discover_events_and_flags(cls, folder_path: str) -> tuple[list[str], list[str]]:
         """
         Discover available events from a DANDI-hosted NWB file.
 
@@ -203,7 +206,7 @@ class DandiNwbRecordingExtractor(NwbRecordingExtractor):
         io.close()
         return events, []
 
-    def __init__(self, *, folder_path):
+    def __init__(self, *, folder_path: str) -> None:
         self.folder_path = folder_path
         self._sample_count_cache: dict[str, int] | None = None
         self._byte_count_cache: dict[str, int] | None = None
@@ -284,6 +287,6 @@ class DandiNwbRecordingExtractor(NwbRecordingExtractor):
             io.close()
         return output_dicts
 
-    def stub(self, *, folder_path, duration_in_seconds=1.0):
+    def stub(self, *, folder_path: str | Path, duration_in_seconds: float = 1.0) -> None:
         """Stub method is not supported for DANDI-streamed NWB files."""
         raise NotImplementedError("Stub method is not supported for DANDI-streamed NWB files.")

--- a/src/guppy/extractors/detect_acquisition_formats.py
+++ b/src/guppy/extractors/detect_acquisition_formats.py
@@ -8,7 +8,7 @@ import pandas as pd
 logger = logging.getLogger(__name__)
 
 
-def _classify_csv_file(path):
+def _classify_csv_file(path: str) -> str:
     """
     Classify a single CSV file as belonging to one of three modalities.
 
@@ -75,7 +75,7 @@ def _classify_csv_file(path):
         raise ValueError(message)
 
 
-def _is_float(value):
+def _is_float(value: object) -> bool:
     """Return True if *value* can be interpreted as a float."""
     try:
         float(value)
@@ -84,7 +84,7 @@ def _is_float(value):
         return False
 
 
-def _is_event_csv(path):
+def _is_event_csv(path: str) -> bool:
     """
     Return True if the CSV file is an event_csv: a single column named 'timestamps'.
 
@@ -102,7 +102,7 @@ def _is_event_csv(path):
     return len(cols) == 1 and cols[0].lower() == "timestamps"
 
 
-def detect_acquisition_formats(folder_path):
+def detect_acquisition_formats(folder_path: str) -> set[str]:
     """
     Detect all acquisition formats present in a session folder.
 

--- a/src/guppy/extractors/doric_recording_extractor.py
+++ b/src/guppy/extractors/doric_recording_extractor.py
@@ -39,7 +39,7 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
     # TODO: consolidate duplicate flag logic between the `discover_events_and_flags` and the `check_doric` method.
 
     @classmethod
-    def discover_events_and_flags(cls, folder_path):
+    def discover_events_and_flags(cls, folder_path: str) -> tuple[list[str], list[str]]:
         """
         Discover available events and file format flags from Doric files.
 
@@ -100,12 +100,12 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
         logger.info("Doric event discovery complete.")
         return event_from_filename, flag_arr
 
-    def __init__(self, folder_path, event_name_to_event_type):
+    def __init__(self, folder_path: str, event_name_to_event_type: dict[str, str]) -> None:
         self.folder_path = folder_path
         self._event_name_to_event_type = event_name_to_event_type
 
     @staticmethod
-    def _read_doric_file(filepath):
+    def _read_doric_file(filepath: str) -> list[str]:
         """Static helper to read Doric file headers for event discovery."""
         with h5py.File(filepath, "r") as f:
             if "Traces" in list(f.keys()):
@@ -116,7 +116,7 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
         return keys
 
     @staticmethod
-    def _access_keys_doricV6(doric_file):
+    def _access_keys_doricV6(doric_file: h5py.File) -> list[str]:
         data = [doric_file["DataAcquisition"]]
         res = []
         while len(data) != 0:
@@ -140,19 +140,19 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
         return keys
 
     @staticmethod
-    def _access_keys_doricV1(doric_file):
+    def _access_keys_doricV1(doric_file: h5py.File) -> list[str]:
         keys = list(doric_file["Traces"]["Console"].keys())
         keys.remove("Time(s)")
 
         return keys
 
     @staticmethod
-    def _separate_last_element(arr):
+    def _separate_last_element(arr: list) -> tuple[list, object]:
         l = arr[-1]
         return arr[:-1], l
 
     @staticmethod
-    def _validate_signal_control_data(event, data, event_type):
+    def _validate_signal_control_data(event: str, data: np.ndarray, event_type: str) -> None:
         """Raise ValueError if ``data`` is unusable as a photometry signal/control trace.
 
         Rejects channels that are all-NaN, mostly-NaN (>=50%), or zero-variance —
@@ -226,7 +226,7 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
                     return 0
         return 0
 
-    def _check_doric(self):
+    def _check_doric(self) -> str | int:
         logger.debug("Checking if doric file exists")
         path = glob.glob(os.path.join(self.folder_path, "*.csv")) + glob.glob(os.path.join(self.folder_path, "*.doric"))
 
@@ -265,7 +265,7 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
         logger.info("Doric file found.")
         return flag_arr[0]
 
-    def _read_doric_csv(self, events):
+    def _read_doric_csv(self, events: list[str]) -> list[dict[str, object]]:
         path = glob.glob(os.path.join(self.folder_path, "*.csv"))
         if len(path) > 1:
             message = (
@@ -314,7 +314,7 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
 
         return output_dicts
 
-    def _read_doric_doric(self, events):
+    def _read_doric_doric(self, events: list[str]) -> list[dict[str, object]]:
         path = glob.glob(os.path.join(self.folder_path, "*.doric"))
         if len(path) > 1:
             message = (
@@ -330,7 +330,7 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
                 output_dicts = self._access_data_doricV6(f, events)
         return output_dicts
 
-    def _access_data_doricV6(self, doric_file, events):
+    def _access_data_doricV6(self, doric_file: h5py.File, events: list[str]) -> list[dict[str, object]]:
         data = [doric_file["DataAcquisition"]]
         res = []
         while len(data) != 0:
@@ -423,7 +423,7 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
 
         return output_dicts
 
-    def _access_data_doricV1(self, doric_file, events):
+    def _access_data_doricV1(self, doric_file: h5py.File, events: list[str]) -> list[dict[str, object]]:
         console = doric_file["Traces"]["Console"]
         output_dicts = []
         for event in events:
@@ -496,7 +496,7 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
 
         return output_dicts
 
-    def stub(self, *, folder_path, duration_in_seconds=1.0):
+    def stub(self, *, folder_path: Path | str, duration_in_seconds: float = 1.0) -> None:
         """
         Create a stubbed copy of the Doric folder truncated to a short duration.
 
@@ -524,7 +524,7 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
         elif flag == "doric_csv":
             self._stub_doric_csv(folder_path=folder_path, duration_in_seconds=duration_in_seconds)
 
-    def _stub_doric_hdf5(self, *, folder_path, duration_in_seconds):
+    def _stub_doric_hdf5(self, *, folder_path: Path | str, duration_in_seconds: float) -> None:
         doric_paths = glob.glob(os.path.join(folder_path, "*.doric"))
         doric_path = doric_paths[0]
 
@@ -541,7 +541,7 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
         # Replace after closing source_file so Windows does not raise PermissionError on open files.
         os.replace(temporary_path, doric_path)
 
-    def _stub_doric_hdf5_v1(self, *, source_file, doric_path, duration_in_seconds):
+    def _stub_doric_hdf5_v1(self, *, source_file: h5py.File, doric_path: str, duration_in_seconds: float) -> str:
         timestamps = np.array(source_file["Traces"]["Console"]["Time(s)"]["Console_time(s)"])
         cutoff_timestamp = timestamps[0] + duration_in_seconds
         cutoff_index = int(np.searchsorted(timestamps, cutoff_timestamp, side="right"))
@@ -565,7 +565,7 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
 
         return temporary_path
 
-    def _stub_doric_hdf5_v6(self, *, source_file, doric_path, duration_in_seconds):
+    def _stub_doric_hdf5_v6(self, *, source_file: h5py.File, doric_path: str, duration_in_seconds: float) -> str:
         temporary_path = doric_path + ".tmp"
         with h5py.File(temporary_path, "w") as destination_file:
             if "Configurations" in source_file:
@@ -577,7 +577,9 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
             )
         return temporary_path
 
-    def _copy_group_truncated(self, *, source_group, destination_group, duration_in_seconds):
+    def _copy_group_truncated(
+        self, *, source_group: h5py.Group, destination_group: h5py.Group, duration_in_seconds: float
+    ) -> None:
         if "Time" in source_group:
             time_data = source_group["Time"][:]
             cutoff_index = int(np.searchsorted(time_data, time_data[0] + duration_in_seconds, side="right"))
@@ -595,7 +597,7 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
                 else:
                     destination_group.create_dataset(key, data=item[:])
 
-    def _stub_doric_csv(self, *, folder_path, duration_in_seconds):
+    def _stub_doric_csv(self, *, folder_path: Path | str, duration_in_seconds: float) -> None:
         csv_paths = glob.glob(os.path.join(folder_path, "*.csv"))
         csv_path = csv_paths[0]
 

--- a/src/guppy/extractors/npm_recording_extractor.py
+++ b/src/guppy/extractors/npm_recording_extractor.py
@@ -37,7 +37,9 @@ class NpmRecordingExtractor(CsvRecordingExtractor):
     # Only overrides discover_events_and_flags() and adds NPM-specific helper methods.
 
     @classmethod
-    def discover_events_and_flags(cls, folder_path, num_ch, inputParameters) -> tuple[list[str], list[str]]:
+    def discover_events_and_flags(
+        cls, folder_path: str, num_ch: int, inputParameters: dict[str, object] | None
+    ) -> tuple[list[str], list[str]]:
         """
         Discover available events and format flags from NPM files.
 
@@ -293,7 +295,7 @@ class NpmRecordingExtractor(CsvRecordingExtractor):
         logger.info("Importing of NPM file is done.")
         return event_from_filename, flag_arr
 
-    def stub(self, *, folder_path, duration_in_seconds=1.0):
+    def stub(self, *, folder_path: str | Path, duration_in_seconds: float = 1.0) -> None:
         """
         Create a stubbed copy of the NPM folder with truncated signal files.
 
@@ -340,7 +342,7 @@ class NpmRecordingExtractor(CsvRecordingExtractor):
             dataframe.to_csv(csv_path, index=False, header=has_text_header)
 
     @classmethod
-    def has_multiple_event_ttls(cls, folder_path):
+    def has_multiple_event_ttls(cls, folder_path: str) -> list[bool]:
         """
         Check whether any NPM event files in the folder contain multiple TTL types.
 
@@ -415,7 +417,9 @@ class NpmRecordingExtractor(CsvRecordingExtractor):
     # function to decide indices of interleaved channels
     # in neurophotometrics data
     @classmethod
-    def decide_indices(cls, file, df, flag, num_ch=2):
+    def decide_indices(
+        cls, file: str, df: pd.DataFrame, flag: str, num_ch: int = 2
+    ) -> tuple[pd.DataFrame, dict[str, np.ndarray], int]:
         """
         Determine the row indices belonging to each interleaved channel in NPM data.
 
@@ -487,7 +491,7 @@ class NpmRecordingExtractor(CsvRecordingExtractor):
 
     # check flag consistency in neurophotometrics data
     @classmethod
-    def check_channels(cls, state):
+    def check_channels(cls, state: np.ndarray) -> tuple[int, np.ndarray]:
         """
         Validate and count unique channel states in NPM ``Flags``/``LedState`` data.
 
@@ -518,7 +522,7 @@ class NpmRecordingExtractor(CsvRecordingExtractor):
         return unique_state.shape[0], unique_state
 
     @classmethod
-    def needs_ts_unit(cls, folder_path, num_ch):
+    def needs_ts_unit(cls, folder_path: str, num_ch: int) -> tuple[list[bool], list[str]]:
         """
         Determine which NPM files require explicit timestamp-unit configuration.
 
@@ -618,7 +622,7 @@ class NpmRecordingExtractor(CsvRecordingExtractor):
         return ts_unit_needs, col_names_ts
 
     @staticmethod
-    def _update_df_with_timestamp_columns(df, timestamp_column_name):
+    def _update_df_with_timestamp_columns(df: pd.DataFrame, timestamp_column_name: str | None) -> pd.DataFrame:
         col_names = np.array(list(df.columns))
         col_names_ts = [""]
         for name in col_names:

--- a/src/guppy/extractors/nwb_recording_extractor.py
+++ b/src/guppy/extractors/nwb_recording_extractor.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
-from pynwb import NWBHDF5IO
+from pynwb import NWBHDF5IO, NWBFile
 
 from guppy.extractors.base_recording_extractor import BaseRecordingExtractor
 from guppy.utils._hdf5_io import write_hdf5
@@ -24,7 +24,7 @@ class NwbRecordingExtractor(BaseRecordingExtractor):
     """
 
     @classmethod
-    def discover_events_and_flags(cls, folder_path) -> tuple[list[str], list[str]]:
+    def discover_events_and_flags(cls, folder_path: str | Path) -> tuple[list[str], list[str]]:
         """
         Discover available events from an NWB file.
 
@@ -50,7 +50,7 @@ class NwbRecordingExtractor(BaseRecordingExtractor):
 
         return events, []
 
-    def __init__(self, *, folder_path):
+    def __init__(self, *, folder_path: str | Path) -> None:
         self.folder_path = folder_path
 
     def count_samples(self, *, event: str) -> int:
@@ -107,14 +107,14 @@ class NwbRecordingExtractor(BaseRecordingExtractor):
             if "npoints" in output_dict:
                 write_hdf5(output_dict["npoints"], event, outputPath, "npoints")
 
-    def stub(self, *, folder_path, duration_in_seconds=1.0):
+    def stub(self, *, folder_path: str | Path, duration_in_seconds: float = 1.0) -> None:
         """
         Stub method is unnecessary for NWB files.
         """
         raise NotImplementedError("Stub method is unnecessary for NWB files.")
 
 
-def _count_event_samples(*, nwbfile, io, event):
+def _count_event_samples(*, nwbfile: NWBFile, io: NWBHDF5IO, event: str) -> int:
     """Return total samples for ``event`` without materialising bulk data.
 
     For ``FiberPhotometryResponseSeries`` events the result is the dataset's
@@ -135,7 +135,7 @@ def _count_event_samples(*, nwbfile, io, event):
     return 0
 
 
-def _discover_events_from_nwbfile(*, nwbfile, io):
+def _discover_events_from_nwbfile(*, nwbfile: NWBFile, io: NWBHDF5IO) -> list[str]:
     """
     Extract event names from an already-open NWB file.
 
@@ -176,7 +176,7 @@ def _discover_events_from_nwbfile(*, nwbfile, io):
     return events
 
 
-def _read_events_from_nwbfile(*, nwbfile, io, events):
+def _read_events_from_nwbfile(*, nwbfile: NWBFile, io: NWBHDF5IO, events: list[str]) -> list[dict[str, Any]]:
     """
     Read data for specified events from an already-open NWB file.
 
@@ -232,7 +232,7 @@ def _read_events_from_nwbfile(*, nwbfile, io, events):
     return output_dicts
 
 
-def _register_unique_name(seen_names, name, type_label):
+def _register_unique_name(seen_names: set[str], name: str, type_label: str) -> None:
     """Add *name* to *seen_names*, raising ``ValueError`` if already present."""
     if name in seen_names:
         raise ValueError(
@@ -242,7 +242,7 @@ def _register_unique_name(seen_names, name, type_label):
     seen_names.add(name)
 
 
-def _discover_ndx_events_v02(nwbfile, seen_names):
+def _discover_ndx_events_v02(nwbfile: NWBFile, seen_names: set[str]) -> list[str]:
     """Discover event names from ndx-events v0.2 objects (AnnotatedEventsTable, LabeledEvents, Events)."""
     events = []
     for neurodata_object in nwbfile.objects.values():
@@ -260,7 +260,7 @@ def _discover_ndx_events_v02(nwbfile, seen_names):
     return events
 
 
-def _discover_ndx_events_v04(nwbfile, seen_names):
+def _discover_ndx_events_v04(nwbfile: NWBFile, seen_names: set[str]) -> list[str]:
     """Discover event names from ndx-events v0.4 EventsTable objects."""
     events = []
     for table_name, table in nwbfile.events__events_tables.items():
@@ -275,7 +275,7 @@ def _discover_ndx_events_v04(nwbfile, seen_names):
     return events
 
 
-def _build_event_index_v02(nwbfile):
+def _build_event_index_v02(nwbfile: NWBFile) -> dict[str, tuple]:
     """Build a unified event index for ndx-events v0.2 objects.
 
     Returns
@@ -299,7 +299,7 @@ def _build_event_index_v02(nwbfile):
     return index
 
 
-def _build_event_index_v04(nwbfile):
+def _build_event_index_v04(nwbfile: NWBFile) -> dict[str, tuple]:
     """Build a unified event index for ndx-events v0.4 EventsTable objects.
 
     Returns
@@ -319,7 +319,7 @@ def _build_event_index_v04(nwbfile):
     return index
 
 
-def _read_ndx_event(*, event_name, source_info):
+def _read_ndx_event(*, event_name: str, source_info: tuple) -> dict[str, object]:
     """Read timestamps for a single ndx-events event from its indexed source.
 
     Parameters
@@ -365,7 +365,7 @@ def _read_ndx_event(*, event_name, source_info):
     )
 
 
-def _find_nwb_file(folder_path):
+def _find_nwb_file(folder_path: str | Path) -> str:
     """Return the single NWB file path in *folder_path*, raising if not exactly one."""
     nwb_paths = list(Path(folder_path).glob("*.nwb"))
     if len(nwb_paths) > 1:
@@ -378,7 +378,7 @@ def _find_nwb_file(folder_path):
     return str(nwb_paths[0])
 
 
-def _get_ndx_events_version(io):
+def _get_ndx_events_version(io: NWBHDF5IO) -> str | None:
     """Return the ndx-events namespace version string from an open NWBHDF5IO, or None.
 
     Parameters
@@ -398,7 +398,7 @@ def _get_ndx_events_version(io):
     return namespace_catalog.get_namespace("ndx-events").version
 
 
-def _parse_event_name(event, series_name_to_object):
+def _parse_event_name(event: str, series_name_to_object: dict[str, object]) -> tuple[str, int | None]:
     """
     Resolve an event name to a series name and optional column index.
 
@@ -433,7 +433,7 @@ def _parse_event_name(event, series_name_to_object):
     )
 
 
-def _resolve_timing(series, num_samples):
+def _resolve_timing(series: object, num_samples: int) -> tuple[float, np.ndarray]:
     """
     Derive sampling rate and a full timestamps array from an NWB TimeSeries.
 

--- a/src/guppy/extractors/tdt_recording_extractor.py
+++ b/src/guppy/extractors/tdt_recording_extractor.py
@@ -30,7 +30,7 @@ class TdtRecordingExtractor(BaseRecordingExtractor):
     """
 
     @classmethod
-    def discover_events_and_flags(cls, folder_path) -> tuple[list[str], list[str]]:
+    def discover_events_and_flags(cls, folder_path: str) -> tuple[list[str], list[str]]:
         """
         Discover available events and format flags from TDT files.
 
@@ -65,12 +65,12 @@ class TdtRecordingExtractor(BaseRecordingExtractor):
         flags = []
         return events, flags
 
-    def __init__(self, folder_path):
+    def __init__(self, folder_path: str) -> None:
         self.folder_path = folder_path
         self._header_df, _ = self._readtsq(folder_path)
 
     @staticmethod
-    def _readtsq(folder_path):
+    def _readtsq(folder_path: str) -> tuple[pd.DataFrame | int, str | int]:
         logger.debug("Trying to read tsq file.")
         names = ("size", "type", "name", "chan", "sort_code", "timestamp", "fp_loc", "strobe", "format", "frequency")
         formats = (int32, int32, "S4", uint16, uint16, float64, int64, float64, int32, float32)
@@ -100,7 +100,7 @@ class TdtRecordingExtractor(BaseRecordingExtractor):
         logger.info("Data from tsq file fetched.")
         return df, flag
 
-    def _readtev(self, event):
+    def _readtev(self, event: str) -> dict[str, object]:
         data = self._header_df.copy()
         filepath = self.folder_path
 
@@ -238,12 +238,12 @@ class TdtRecordingExtractor(BaseRecordingExtractor):
         return output_dicts
 
     @staticmethod
-    def _ismember(arr, element):
+    def _ismember(arr: np.ndarray, element: str) -> np.ndarray:
         res = [1 if i == element else 0 for i in arr]
         return np.asarray(res)
 
     @staticmethod
-    def _format_split_suffix(value):
+    def _format_split_suffix(value: float) -> str:
         # "{:g}" renders integer-valued codes (int or 5.0) as "5", and collapses
         # float32 precision artifacts (0.10000000149... → "0.1") at 6 significant
         # digits. "." → "p" keeps the suffix free of the "_" / "." delimiters used
@@ -251,7 +251,7 @@ class TdtRecordingExtractor(BaseRecordingExtractor):
         return f"{float(value):g}".replace(".", "p")
 
     @staticmethod
-    def _event_needs_splitting(data, sampling_rate):
+    def _event_needs_splitting(data: np.ndarray, sampling_rate: float) -> bool:
         logger.info("Checking event storename data for creating multiple event names from single event storename...")
         diff = np.diff(data)
         if diff.shape[0] == 0:
@@ -260,7 +260,7 @@ class TdtRecordingExtractor(BaseRecordingExtractor):
             return True
         return False
 
-    def _split_event_data(self, event_dict, event):
+    def _split_event_data(self, event_dict: dict[str, object], event: str) -> list[dict[str, object]]:
         # Note that new_event is only used for the new storesList and event is still used for the old storesList
         new_event = event.replace("\\", "")
         new_event = event.replace("/", "")
@@ -282,7 +282,7 @@ class TdtRecordingExtractor(BaseRecordingExtractor):
 
         return event_dicts
 
-    def _split_event_storesList(self, event_dict, event, outputPath):
+    def _split_event_storesList(self, event_dict: dict[str, object], event: str, outputPath: str) -> None:
         # Note that new_event is only used for the new storesList and event is still used for the old storesList
         new_event = event.replace("\\", "")
         new_event = event.replace("/", "")
@@ -306,7 +306,7 @@ class TdtRecordingExtractor(BaseRecordingExtractor):
             np.savetxt(os.path.join(outputPath, "storesList.csv"), storesList, delimiter=",", fmt="%s")
         logger.info("The stores list file is changed.")
 
-    def _save_dict_to_hdf5(self, event_dict, outputPath):
+    def _save_dict_to_hdf5(self, event_dict: dict[str, object], outputPath: str) -> None:
         event = event_dict["storename"]
         write_hdf5(event_dict["storename"], event, outputPath, "storename")
         write_hdf5(event_dict["sampling_rate"], event, outputPath, "sampling_rate")
@@ -330,7 +330,12 @@ class TdtRecordingExtractor(BaseRecordingExtractor):
             self._save_dict_to_hdf5(event_dict=event_dict, outputPath=outputPath)
 
     @staticmethod
-    def _stub_tev_file(tev_file_path, header_df, stubbed_tev_file_path, stream_name_to_num_segments):
+    def _stub_tev_file(
+        tev_file_path: Path | str,
+        header_df: pd.DataFrame,
+        stubbed_tev_file_path: Path | str,
+        stream_name_to_num_segments: dict[str, int],
+    ) -> dict[int, int]:
         """
         Write a truncated TEV file containing only the first N data segments per stream.
 
@@ -397,8 +402,12 @@ class TdtRecordingExtractor(BaseRecordingExtractor):
 
     @staticmethod
     def _stub_tsq_file(
-        header_df, stubbed_tsq_file_path, stream_name_to_num_segments, original_to_new_fp_loc, stub_duration_in_seconds
-    ):
+        header_df: pd.DataFrame,
+        stubbed_tsq_file_path: Path | str,
+        stream_name_to_num_segments: dict[str, int],
+        original_to_new_fp_loc: dict[int, int],
+        stub_duration_in_seconds: float,
+    ) -> None:
         """
         Write a truncated TSQ header file matching the stubbed TEV file.
 
@@ -469,7 +478,9 @@ class TdtRecordingExtractor(BaseRecordingExtractor):
         stubbed_tsq_data.tofile(stubbed_tsq_file_path)
 
     @staticmethod
-    def _compute_stream_name_to_num_segments(header_df, stub_duration_in_seconds):
+    def _compute_stream_name_to_num_segments(
+        header_df: pd.DataFrame, stub_duration_in_seconds: float
+    ) -> dict[str, int]:
         """
         Compute the number of TEV segments to retain per stream for a given stub duration.
 
@@ -500,7 +511,7 @@ class TdtRecordingExtractor(BaseRecordingExtractor):
             stream_name_to_num_segments[stream_name_bytes.decode()] = number_of_segments
         return stream_name_to_num_segments
 
-    def stub(self, *, folder_path, duration_in_seconds=1.0):
+    def stub(self, *, folder_path: str | Path, duration_in_seconds: float = 1.0) -> None:
         """
         Create a stubbed copy of the TDT tank folder with truncated TEV and TSQ files.
 


### PR DESCRIPTION
## Summary

- Annotates all function arguments and return types across all 8 extractor modules (`base_recording_extractor.py`, `csv_recording_extractor.py`, `dandi_nwb_recording_extractor.py`, `detect_acquisition_formats.py`, `doric_recording_extractor.py`, `npm_recording_extractor.py`, `nwb_recording_extractor.py`, `tdt_recording_extractor.py`)
- Satisfies ruff `ANN` rules added in #346; `pre-commit run ruff` passes cleanly on all changed files
- Uses `object` instead of `Any` (ANN401-compliant), `str | Path` for path arguments, `np.ndarray` for arrays, `h5py.File/Group/Dataset` for HDF5 types

## Test plan

- [x] `pre-commit run ruff --files src/guppy/extractors/*.py` — Passed
- [x] `pytest tests/unit/extractors/ -v -m "not dandi_live"` — 627 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)