### PR TITLE
Add type hints to analysis layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added numpydoc-style docstrings to all public functions in the testing layer (`src/guppy/testing/`). [PR #318](https://github.com/LernerLab/GuPPy/pull/318)
 - Added parameterized output directories: step 2 accepts a user-supplied run name, steps 1 and 3–6 honour a per-session run-name filter, and `GuPPyParamtersUsed.json` is written into the selected output directories so multiple parameter sets can coexist in one session. [PR #325](https://github.com/LernerLab/GuPPy/pull/325)
 - Added type hint checks to pre-commit. [PR #346](https://github.com/LernerLab/GuPPy/pull/346)
+- Added type hints to all functions in the analysis layer (`src/guppy/analysis/`). [PR #349](https://github.com/LernerLab/GuPPy/pull/349)
 
 ## Fixes
 - Fixed bug with step five, which was causing the baseline uncorrected HDF5 file to not exist. [PR #241](https://github.com/LernerLab/GuPPy/pull/241)

--- a/src/guppy/analysis/artifact_removal.py
+++ b/src/guppy/analysis/artifact_removal.py
@@ -6,15 +6,15 @@ logger = logging.getLogger(__name__)
 
 
 def remove_artifacts(
-    timeForLightsTurnOn,
-    storesList,
-    pair_name_to_tsNew,
-    pair_name_to_sampling_rate,
-    pair_name_to_coords,
-    name_to_data,
-    compound_name_to_ttl_timestamps,
-    method,
-):
+    timeForLightsTurnOn: float,
+    storesList: np.ndarray,
+    pair_name_to_tsNew: dict[str, np.ndarray],
+    pair_name_to_sampling_rate: dict[str, float],
+    pair_name_to_coords: dict[str, np.ndarray],
+    name_to_data: dict[str, np.ndarray],
+    compound_name_to_ttl_timestamps: dict[str, np.ndarray],
+    method: str,
+) -> tuple[dict[str, np.ndarray], dict[str, np.ndarray] | None, dict[str, np.ndarray]]:
     """
     Remove artifacts from photometry data using the specified method.
 
@@ -78,8 +78,12 @@ def remove_artifacts(
 
 
 def addingNaNtoChunksWithArtifacts(
-    storesList, pair_name_to_tsNew, pair_name_to_coords, name_to_data, compound_name_to_ttl_timestamps
-):
+    storesList: np.ndarray,
+    pair_name_to_tsNew: dict[str, np.ndarray],
+    pair_name_to_coords: dict[str, np.ndarray],
+    name_to_data: dict[str, np.ndarray],
+    compound_name_to_ttl_timestamps: dict[str, np.ndarray],
+) -> tuple[dict[str, np.ndarray], dict[str, np.ndarray]]:
     """
     Replace artifact chunks in control/signal data with NaN values.
 
@@ -134,14 +138,14 @@ def addingNaNtoChunksWithArtifacts(
 
 
 def processTimestampsForArtifacts(
-    timeForLightsTurnOn,
-    storesList,
-    pair_name_to_tsNew,
-    pair_name_to_sampling_rate,
-    pair_name_to_coords,
-    name_to_data,
-    compound_name_to_ttl_timestamps,
-):
+    timeForLightsTurnOn: float,
+    storesList: np.ndarray,
+    pair_name_to_tsNew: dict[str, np.ndarray],
+    pair_name_to_sampling_rate: dict[str, float],
+    pair_name_to_coords: dict[str, np.ndarray],
+    name_to_data: dict[str, np.ndarray],
+    compound_name_to_ttl_timestamps: dict[str, np.ndarray],
+) -> tuple[dict[str, np.ndarray], dict[str, np.ndarray], dict[str, np.ndarray]]:
     """
     Concatenate non-artifact chunks and realign all timestamps.
 
@@ -221,7 +225,9 @@ def processTimestampsForArtifacts(
     )
 
 
-def eliminateData(*, data, ts, coords, timeForLightsTurnOn, sampling_rate):
+def eliminateData(
+    *, data: np.ndarray, ts: np.ndarray, coords: np.ndarray, timeForLightsTurnOn: float, sampling_rate: float
+) -> tuple[np.ndarray, np.ndarray]:
     """
     Concatenate non-artifact data chunks and realign their timestamps.
 
@@ -272,7 +278,9 @@ def eliminateData(*, data, ts, coords, timeForLightsTurnOn, sampling_rate):
     return arr, ts_arr
 
 
-def eliminateTs(*, ts, tsNew, coords, timeForLightsTurnOn, sampling_rate):
+def eliminateTs(
+    *, ts: np.ndarray, tsNew: np.ndarray, coords: np.ndarray, timeForLightsTurnOn: float, sampling_rate: float
+) -> np.ndarray:
     """
     Realign TTL timestamps to match concatenated non-artifact photometry chunks.
 
@@ -316,7 +324,7 @@ def eliminateTs(*, ts, tsNew, coords, timeForLightsTurnOn, sampling_rate):
     return ts_arr
 
 
-def addingNaNValues(*, data, ts, coords):
+def addingNaNValues(*, data: np.ndarray, ts: np.ndarray, coords: np.ndarray) -> np.ndarray:
     """
     Set data samples outside the good-chunk windows to NaN.
 
@@ -351,7 +359,7 @@ def addingNaNValues(*, data, ts, coords):
     return data
 
 
-def removeTTLs(*, ts, coords):
+def removeTTLs(*, ts: np.ndarray, coords: np.ndarray) -> np.ndarray:
     """
     Keep only TTL timestamps that fall within good-chunk windows.
 

--- a/src/guppy/analysis/combine_data.py
+++ b/src/guppy/analysis/combine_data.py
@@ -10,7 +10,12 @@ from .io_utils import (
 logger = logging.getLogger(__name__)
 
 
-def eliminateData(filepath_to_timestamps, filepath_to_data, timeForLightsTurnOn, sampling_rate):
+def eliminateData(
+    filepath_to_timestamps: dict[str, np.ndarray],
+    filepath_to_data: dict[str, np.ndarray],
+    timeForLightsTurnOn: float,
+    sampling_rate: float,
+) -> tuple[np.ndarray, np.ndarray]:
     """
     Concatenate data from multiple session files and realign their timestamps.
 
@@ -55,7 +60,12 @@ def eliminateData(filepath_to_timestamps, filepath_to_data, timeForLightsTurnOn,
     return arr, ts_arr
 
 
-def eliminateTs(filepath_to_timestamps, filepath_to_ttl_timestamps, timeForLightsTurnOn, sampling_rate):
+def eliminateTs(
+    filepath_to_timestamps: dict[str, np.ndarray],
+    filepath_to_ttl_timestamps: dict[str, np.ndarray],
+    timeForLightsTurnOn: float,
+    sampling_rate: float,
+) -> np.ndarray:
     """
     Realign TTL timestamps to match concatenated multi-session photometry timestamps.
 
@@ -102,10 +112,10 @@ def combine_data(
     pair_name_to_filepath_to_timestamps: dict[str, dict[str, np.ndarray]],
     display_name_to_filepath_to_data: dict[str, dict[str, np.ndarray]],
     compound_name_to_filepath_to_ttl_timestamps: dict[str, dict[str, np.ndarray]],
-    timeForLightsTurnOn,
-    storesList,
-    sampling_rate,
-):
+    timeForLightsTurnOn: float,
+    storesList: np.ndarray,
+    sampling_rate: float,
+) -> tuple[dict[str, np.ndarray], dict[str, np.ndarray], dict[str, np.ndarray]]:
     """
     Combine photometry data and TTL timestamps from multiple session files.
 

--- a/src/guppy/analysis/compute_psth.py
+++ b/src/guppy/analysis/compute_psth.py
@@ -7,22 +7,22 @@ logger = logging.getLogger(__name__)
 
 
 def compute_psth(
-    z_score,
-    event,
-    filepath,
-    nSecPrev,
-    nSecPost,
-    timeInterval,
-    bin_psth_trials,
-    use_time_or_trials,
-    baselineStart,
-    baselineEnd,
-    naming,
-    just_use_signal,
-    sampling_rate,
-    ts,
-    corrected_timestamps,
-):
+    z_score: np.ndarray,
+    event: str,
+    filepath: str,
+    nSecPrev: float,
+    nSecPost: float,
+    timeInterval: float,
+    bin_psth_trials: float,
+    use_time_or_trials: str,
+    baselineStart: float,
+    baselineEnd: float,
+    naming: str,
+    just_use_signal: bool,
+    sampling_rate: float,
+    ts: np.ndarray,
+    corrected_timestamps: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, list[object], np.ndarray]:
     """
     Build a peri-stimulus time histogram (PSTH) matrix for one event.
 
@@ -193,7 +193,7 @@ def compute_psth(
     return psth, psth_baselineUncorrected, columns, ts
 
 
-def rowFormation(z_score, thisIndex, nTsPrev, nTsPost):
+def rowFormation(z_score: np.ndarray, thisIndex: int, nTsPrev: int, nTsPost: int) -> np.ndarray:
     """
     Extract one PSTH trial from the z-score array, padding with NaN at boundaries.
 
@@ -239,7 +239,7 @@ def rowFormation(z_score, thisIndex, nTsPrev, nTsPost):
     return res
 
 
-def baselineCorrection(arr, timeAxis, baselineStart, baselineEnd):
+def baselineCorrection(arr: np.ndarray, timeAxis: np.ndarray, baselineStart: float, baselineEnd: float) -> np.ndarray:
     """
     Subtract the mean baseline from a single PSTH trial.
 

--- a/src/guppy/analysis/control_channel.py
+++ b/src/guppy/analysis/control_channel.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 # This function just creates placeholder Control-HDF5 files that are then immediately overwritten later on in the pipeline.
 # TODO: Refactor this function to avoid unnecessary file creation.
-def add_control_channel(filepath, arr):
+def add_control_channel(filepath: str, arr: np.ndarray) -> np.ndarray:
     """
     Add synthetic control-channel entries to the storesList when no isosbestic control exists.
 
@@ -81,7 +81,7 @@ def add_control_channel(filepath, arr):
     return arr
 
 
-def create_control_channel(filepath, arr, window=5001):
+def create_control_channel(filepath: str, arr: np.ndarray, window: int = 5001) -> None:
     """
     Fit a synthetic control channel from the signal channel and save it.
 
@@ -118,7 +118,7 @@ def create_control_channel(filepath, arr, window=5001):
 
 
 # TODO: figure out why a control channel is created for both timestamp correction and z-score steps.
-def helper_create_control_channel(signal, timestamps, window):
+def helper_create_control_channel(signal: np.ndarray, timestamps: np.ndarray, window: int) -> np.ndarray:
     """
     Fit an exponential control channel to the signal using curve fitting.
 
@@ -159,7 +159,7 @@ def helper_create_control_channel(signal, timestamps, window):
     return control
 
 
-def curveFitFn(x, a, b, c):
+def curveFitFn(x: np.ndarray, a: float, b: float, c: float) -> np.ndarray:
     """
     Evaluate the exponential model ``a + b * exp(-x / c)``.
 

--- a/src/guppy/analysis/cross_correlation.py
+++ b/src/guppy/analysis/cross_correlation.py
@@ -6,7 +6,7 @@ from scipy import signal
 logger = logging.getLogger(__name__)
 
 
-def compute_cross_correlation(arr_A, arr_B, sample_rate):
+def compute_cross_correlation(arr_A: list[np.ndarray], arr_B: list[np.ndarray], sample_rate: float) -> np.ndarray:
     """
     Compute normalized cross-correlations between paired trial arrays.
 

--- a/src/guppy/analysis/io_utils.py
+++ b/src/guppy/analysis/io_utils.py
@@ -12,7 +12,7 @@ from ..utils.utils import takeOnlyDirs
 logger = logging.getLogger(__name__)
 
 
-def find_files(path, glob_path, ignore_case=False):
+def find_files(path: str, glob_path: str, ignore_case: bool = False) -> list[str]:
     """
     List files in ``path`` matching a glob pattern, optionally case-insensitively.
 
@@ -48,7 +48,7 @@ def find_files(path, glob_path, ignore_case=False):
     return [os.path.join(path, n) for n in str_path if rule.match(n)]
 
 
-def check_TDT(filepath):
+def check_TDT(filepath: str) -> bool:
     """
     Return True if ``filepath`` contains TDT ``.tsq`` files.
 
@@ -69,7 +69,7 @@ def check_TDT(filepath):
         return False
 
 
-def decide_naming_convention(filepath):
+def decide_naming_convention(filepath: str) -> np.ndarray:
     """
     Find and pair control/signal HDF5 files in ``filepath``.
 
@@ -103,7 +103,7 @@ def decide_naming_convention(filepath):
     return path
 
 
-def fetchCoords(filepath, naming, data):
+def fetchCoords(filepath: str, naming: str, data: np.ndarray) -> np.ndarray:
     """
     Load artifact-removal boundary coordinates for a channel pair.
 
@@ -143,7 +143,9 @@ def fetchCoords(filepath, naming, data):
     return coords
 
 
-def get_coords(filepath, name, tsNew, removeArtifacts):  # TODO: Make less redundant with fetchCoords
+def get_coords(
+    filepath: str, name: str, tsNew: np.ndarray, removeArtifacts: bool
+) -> np.ndarray:  # TODO: Make less redundant with fetchCoords
     """
     Return artifact-removal boundary coordinates, or a single full-span window.
 
@@ -172,7 +174,7 @@ def get_coords(filepath, name, tsNew, removeArtifacts):  # TODO: Make less redun
     return coords
 
 
-def check_storeslistfile(folderNames):
+def check_storeslistfile(folderNames: list[str]) -> np.ndarray:
     """
     Merge storesList CSVs from all session output directories.
 
@@ -205,7 +207,7 @@ def check_storeslistfile(folderNames):
     return storesList
 
 
-def write_combined_stores_list(op, storesList):
+def write_combined_stores_list(op: list[object], storesList: np.ndarray) -> None:
     """
     Write a combined storesList CSV to each output directory.
 
@@ -221,7 +223,7 @@ def write_combined_stores_list(op, storesList):
         np.savetxt(os.path.join(filepath, "combine_storesList.csv"), storesList, fmt="%s", delimiter=",")
 
 
-def get_control_and_signal_channel_names(storesList):
+def get_control_and_signal_channel_names(storesList: np.ndarray) -> np.ndarray:
     """
     Extract and pair control/signal display names from a storesList array.
 
@@ -282,7 +284,7 @@ def get_control_and_signal_channel_names(storesList):
     return channels_arr
 
 
-def make_dir_for_cross_correlation(filepath):
+def make_dir_for_cross_correlation(filepath: str) -> str:
     """
     Create and return the cross-correlation output subdirectory.
 
@@ -302,7 +304,7 @@ def make_dir_for_cross_correlation(filepath):
     return op
 
 
-def makeAverageDir(filepath):
+def makeAverageDir(filepath: str) -> str:
     """
     Create and return the group-average output subdirectory.
 

--- a/src/guppy/analysis/psth_average.py
+++ b/src/guppy/analysis/psth_average.py
@@ -18,7 +18,7 @@ from ..utils.utils import read_Df
 logger = logging.getLogger(__name__)
 
 
-def averageForGroup(folderNames, event, inputParameters):
+def averageForGroup(folderNames: list[str], event: str, inputParameters: dict[str, object]) -> None:
     """
     Average PSTH, peak/AUC, and cross-correlation results across a group of sessions.
 
@@ -203,7 +203,7 @@ def averageForGroup(folderNames, event, inputParameters):
     logger.info("Group of data averaged.")
 
 
-def psth_shape_check(psth):
+def psth_shape_check(psth: list[np.ndarray]) -> list[np.ndarray]:
     """
     Pad or truncate PSTH trial arrays so they all share the same length.
 
@@ -236,7 +236,7 @@ def psth_shape_check(psth):
     return psth
 
 
-def read_Df_area_peak(filepath, name):
+def read_Df_area_peak(filepath: str, name: str) -> pd.DataFrame:
     """
     Read a peak/AUC HDF5 file and return its DataFrame.
 

--- a/src/guppy/analysis/psth_peak_and_area.py
+++ b/src/guppy/analysis/psth_peak_and_area.py
@@ -1,5 +1,6 @@
 import logging
 from collections import OrderedDict
+from collections.abc import Sequence
 
 import numpy as np
 
@@ -8,7 +9,13 @@ from ..utils.validation import validate_peak_windows
 logger = logging.getLogger(__name__)
 
 
-def compute_psth_peak_and_area(psth_mean, timestamps, sampling_rate, peak_startPoint, peak_endPoint):
+def compute_psth_peak_and_area(
+    psth_mean: np.ndarray,
+    timestamps: np.ndarray,
+    sampling_rate: float,
+    peak_startPoint: Sequence[float],
+    peak_endPoint: Sequence[float],
+) -> OrderedDict:
     """
     Compute peak amplitude and area under the curve for each peak window.
 

--- a/src/guppy/analysis/psth_utils.py
+++ b/src/guppy/analysis/psth_utils.py
@@ -10,7 +10,7 @@ import pandas as pd
 logger = logging.getLogger(__name__)
 
 
-def create_Df_for_psth(filepath, event, name, psth, columns):
+def create_Df_for_psth(filepath: str, event: str, name: str, psth: np.ndarray, columns: list[object]) -> None:
     """
     Build a PSTH DataFrame (with mean/error columns) and save it as an HDF5 file.
 
@@ -61,7 +61,9 @@ def create_Df_for_psth(filepath, event, name, psth, columns):
     df.to_hdf(op, key="df", mode="w")
 
 
-def create_Df_for_cross_correlation(filepath, event, name, psth, columns):
+def create_Df_for_cross_correlation(
+    filepath: str, event: str, name: str, psth: np.ndarray, columns: list[object]
+) -> None:
     """
     Build a cross-correlation DataFrame (with mean/error columns) and save it as an HDF5 file.
 
@@ -110,7 +112,7 @@ def create_Df_for_cross_correlation(filepath, event, name, psth, columns):
     df.to_hdf(op, key="df", mode="w")
 
 
-def getCorrCombinations(filepath, inputParameters):
+def getCorrCombinations(filepath: str, inputParameters: dict[str, object]) -> tuple[list[str], list[str]]:
     """
     Determine which channel pairs to cross-correlate in a session directory.
 

--- a/src/guppy/analysis/standard_io.py
+++ b/src/guppy/analysis/standard_io.py
@@ -15,7 +15,9 @@ from .io_utils import (
 logger = logging.getLogger(__name__)
 
 
-def read_control_and_signal(filepath, storesList):
+def read_control_and_signal(
+    filepath: str, storesList: np.ndarray
+) -> tuple[dict[str, np.ndarray], dict[str, np.ndarray], dict[str, np.ndarray], dict[str, np.ndarray | None]]:
     """
     Load control and signal channel arrays from HDF5 files.
 
@@ -79,7 +81,7 @@ def read_control_and_signal(filepath, storesList):
     return name_to_data, name_to_timestamps, name_to_sampling_rate, name_to_npoints
 
 
-def read_ttl(filepath, storesList):
+def read_ttl(filepath: str, storesList: np.ndarray) -> dict[str, np.ndarray]:
     """
     Load TTL event timestamps from HDF5 files, skipping control/signal channels.
 
@@ -110,8 +112,12 @@ def read_ttl(filepath, storesList):
 
 
 def write_corrected_timestamps(
-    filepath, corrected_name_to_timestamps, name_to_timestamps, name_to_sampling_rate, name_to_correctionIndex
-):
+    filepath: str,
+    corrected_name_to_timestamps: dict[str, np.ndarray],
+    name_to_timestamps: dict[str, np.ndarray],
+    name_to_sampling_rate: dict[str, np.ndarray],
+    name_to_correctionIndex: dict[str, np.ndarray],
+) -> None:
     """
     Write timestamp-correction HDF5 datasets for all channel pairs.
 
@@ -141,7 +147,7 @@ def write_corrected_timestamps(
         write_hdf5(sampling_rate, "timeCorrection_" + name_1, filepath, "sampling_rate")
 
 
-def write_corrected_data(filepath, name_to_corrected_data):
+def write_corrected_data(filepath: str, name_to_corrected_data: dict[str, np.ndarray]) -> None:
     """
     Write corrected data arrays to HDF5 files.
 
@@ -157,9 +163,9 @@ def write_corrected_data(filepath, name_to_corrected_data):
 
 
 def write_corrected_ttl_timestamps(
-    filepath,
-    compound_name_to_corrected_ttl_timestamps,
-):
+    filepath: str,
+    compound_name_to_corrected_ttl_timestamps: dict[str, np.ndarray],
+) -> None:
     """
     Write corrected TTL timestamp arrays to HDF5 files.
 
@@ -176,7 +182,9 @@ def write_corrected_ttl_timestamps(
     logger.info("Timestamps corrections applied to the data and event timestamps.")
 
 
-def read_corrected_data(control_path, signal_path, filepath, name):
+def read_corrected_data(
+    control_path: str, signal_path: str, filepath: str, name: str
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """
     Load corrected control, signal, and timestamp arrays for one channel pair.
 
@@ -207,7 +215,14 @@ def read_corrected_data(control_path, signal_path, filepath, name):
     return control, signal, tsNew
 
 
-def write_zscore(filepath, name, z_score, dff, control_fit, temp_control_arr):
+def write_zscore(
+    filepath: str,
+    name: str,
+    z_score: np.ndarray,
+    dff: np.ndarray,
+    control_fit: np.ndarray,
+    temp_control_arr: np.ndarray | None,
+) -> None:
     """
     Write z-score, dF/F, and fitted-control arrays to HDF5 files.
 
@@ -233,7 +248,9 @@ def write_zscore(filepath, name, z_score, dff, control_fit, temp_control_arr):
         write_hdf5(temp_control_arr, "control_" + name, filepath, "data")
 
 
-def read_corrected_timestamps_pairwise(filepath):
+def read_corrected_timestamps_pairwise(
+    filepath: str,
+) -> tuple[dict[str, np.ndarray], dict[str, float]]:
     """
     Load corrected timestamps and sampling rates for all channel pairs.
 
@@ -272,7 +289,7 @@ def read_corrected_timestamps_pairwise(filepath):
     return pair_name_to_tsNew, pair_name_to_sampling_rate
 
 
-def read_coords_pairwise(filepath, pair_name_to_tsNew):
+def read_coords_pairwise(filepath: str, pair_name_to_tsNew: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
     """
     Load artifact-removal boundary coordinates for all channel pairs.
 
@@ -309,7 +326,9 @@ def read_coords_pairwise(filepath, pair_name_to_tsNew):
     return pair_name_to_coords
 
 
-def read_corrected_data_dict(filepath, storesList):  # TODO: coordinate with read_corrected_data
+def read_corrected_data_dict(
+    filepath: str, storesList: np.ndarray
+) -> dict[str, np.ndarray]:  # TODO: coordinate with read_corrected_data
     """
     Load corrected control and signal data arrays into a flat dict.
 
@@ -339,7 +358,7 @@ def read_corrected_data_dict(filepath, storesList):  # TODO: coordinate with rea
     return name_to_corrected_data
 
 
-def read_corrected_ttl_timestamps(filepath, storesList):
+def read_corrected_ttl_timestamps(filepath: str, storesList: np.ndarray) -> dict[str, np.ndarray]:
     """
     Load corrected TTL timestamps for all non-channel stores.
 
@@ -382,7 +401,9 @@ def read_corrected_ttl_timestamps(filepath, storesList):
     return compound_name_to_ttl_timestamps
 
 
-def write_artifact_corrected_timestamps(filepath, pair_name_to_corrected_timestamps):
+def write_artifact_corrected_timestamps(
+    filepath: str, pair_name_to_corrected_timestamps: dict[str, np.ndarray]
+) -> None:
     """
     Write artifact-corrected timestamp arrays to the ``timeCorrection_*`` HDF5 keys.
 
@@ -398,11 +419,11 @@ def write_artifact_corrected_timestamps(filepath, pair_name_to_corrected_timesta
 
 
 def write_artifact_removal(
-    filepath,
-    name_to_corrected_data,
-    pair_name_to_corrected_timestamps,
-    compound_name_to_corrected_ttl_timestamps=None,
-):
+    filepath: str,
+    name_to_corrected_data: dict[str, np.ndarray],
+    pair_name_to_corrected_timestamps: dict[str, np.ndarray] | None,
+    compound_name_to_corrected_ttl_timestamps: dict[str, np.ndarray] | None = None,
+) -> None:
     """
     Write all artifact-removal outputs (data, TTL timestamps, and optionally timestamps) to HDF5.
 
@@ -423,7 +444,9 @@ def write_artifact_removal(
         write_artifact_corrected_timestamps(filepath, pair_name_to_corrected_timestamps)
 
 
-def read_timestamps_for_combining_data(filepaths_to_combine):
+def read_timestamps_for_combining_data(
+    filepaths_to_combine: list[str],
+) -> dict[str, dict[str, np.ndarray]]:
     """
     Load corrected timestamps from all session files for the combine-data step.
 
@@ -459,7 +482,9 @@ def read_timestamps_for_combining_data(filepaths_to_combine):
     return pair_name_to_filepath_to_timestamps
 
 
-def read_data_for_combining_data(filepaths_to_combine, storesList):
+def read_data_for_combining_data(
+    filepaths_to_combine: list[str], storesList: np.ndarray
+) -> dict[str, dict[str, np.ndarray]]:
     """
     Load corrected channel data from all session files for the combine-data step.
 
@@ -505,7 +530,9 @@ def read_data_for_combining_data(filepaths_to_combine, storesList):
     return display_name_to_filepath_to_data
 
 
-def read_ttl_timestamps_for_combining_data(filepaths_to_combine, storesList):
+def read_ttl_timestamps_for_combining_data(
+    filepaths_to_combine: list[str], storesList: np.ndarray
+) -> dict[str, dict[str, np.ndarray]]:
     """
     Load corrected TTL timestamps from all session files for the combine-data step.
 
@@ -554,7 +581,12 @@ def read_ttl_timestamps_for_combining_data(filepaths_to_combine, storesList):
     return compound_name_to_filepath_to_ttl_timestamps
 
 
-def write_combined_data(output_filepath, pair_name_to_tsNew, display_name_to_data, compound_name_to_ttl_timestamps):
+def write_combined_data(
+    output_filepath: str,
+    pair_name_to_tsNew: dict[str, np.ndarray],
+    display_name_to_data: dict[str, np.ndarray],
+    compound_name_to_ttl_timestamps: dict[str, np.ndarray],
+) -> None:
     """
     Write combined multi-session data (timestamps, channel data, TTLs) to HDF5.
 
@@ -577,7 +609,7 @@ def write_combined_data(output_filepath, pair_name_to_tsNew, display_name_to_dat
         write_hdf5(ts, compound_name, output_filepath, "ts")
 
 
-def write_peak_and_area_to_hdf5(filepath, arr, name, index=[]):
+def write_peak_and_area_to_hdf5(filepath: str, arr: object, name: str, index: list[object] = []) -> None:
     """
     Save peak and area-under-curve metrics to an HDF5 file.
 
@@ -601,7 +633,7 @@ def write_peak_and_area_to_hdf5(filepath, arr, name, index=[]):
     df.to_hdf(op, key="df", mode="w")
 
 
-def write_peak_and_area_to_csv(filepath, arr, name, index=[]):
+def write_peak_and_area_to_csv(filepath: str, arr: object, name: str, index: list[object] = []) -> None:
     """
     Save peak and area-under-curve metrics to a CSV file.
 
@@ -622,7 +654,9 @@ def write_peak_and_area_to_csv(filepath, arr, name, index=[]):
     df.to_csv(op)
 
 
-def write_freq_and_amp_to_hdf5(filepath, arr, name, index=[], columns=[]):
+def write_freq_and_amp_to_hdf5(
+    filepath: str, arr: object, name: str, index: list[object] = [], columns: list[object] = []
+) -> None:
     """
     Save transient frequency and amplitude metrics to an HDF5 file.
 
@@ -648,7 +682,9 @@ def write_freq_and_amp_to_hdf5(filepath, arr, name, index=[], columns=[]):
     df.to_hdf(op, key="df", mode="w")
 
 
-def write_freq_and_amp_to_csv(filepath, arr, name, index=[], columns=[]):
+def write_freq_and_amp_to_csv(
+    filepath: str, arr: object, name: str, index: list[object] = [], columns: list[object] = []
+) -> None:
     """
     Save transient frequency and amplitude metrics to a CSV file.
 
@@ -670,7 +706,7 @@ def write_freq_and_amp_to_csv(filepath, arr, name, index=[], columns=[]):
     df.to_csv(op)
 
 
-def read_freq_and_amp_from_hdf5(filepath, name):
+def read_freq_and_amp_from_hdf5(filepath: str, name: str) -> pd.DataFrame:
     """
     Load transient frequency and amplitude metrics from an HDF5 file.
 
@@ -692,7 +728,9 @@ def read_freq_and_amp_from_hdf5(filepath, name):
     return df
 
 
-def write_transients_to_hdf5(filepath, name, z_score, ts, peaksInd):
+def write_transients_to_hdf5(
+    filepath: str, name: str, z_score: np.ndarray, ts: np.ndarray, peaksInd: np.ndarray
+) -> None:
     """
     Write transient detection outputs (z-score, timestamps, peak indices) to HDF5.
 
@@ -715,7 +753,7 @@ def write_transients_to_hdf5(filepath, name, z_score, ts, peaksInd):
     write_hdf5(peaksInd, event, filepath, "peaksInd")
 
 
-def read_transients_from_hdf5(filepath, name):
+def read_transients_from_hdf5(filepath: str, name: str) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """
     Load transient detection outputs from HDF5.
 

--- a/src/guppy/analysis/timestamp_correction.py
+++ b/src/guppy/analysis/timestamp_correction.py
@@ -8,15 +8,15 @@ logger = logging.getLogger(__name__)
 
 
 def correct_timestamps(
-    timeForLightsTurnOn,
-    storesList,
-    name_to_timestamps,
-    name_to_data,
-    name_to_sampling_rate,
-    name_to_npoints,
-    name_to_timestamps_ttl,
-    mode,
-):
+    timeForLightsTurnOn: float,
+    storesList: np.ndarray,
+    name_to_timestamps: dict[str, np.ndarray],
+    name_to_data: dict[str, np.ndarray],
+    name_to_sampling_rate: dict[str, np.ndarray],
+    name_to_npoints: dict[str, np.ndarray | None],
+    name_to_timestamps_ttl: dict[str, np.ndarray],
+    mode: str,
+) -> tuple[dict[str, np.ndarray], dict[str, np.ndarray], dict[str, np.ndarray], dict[str, np.ndarray]]:
     """
     Apply timestamp correction to all channels and TTL stores.
 
@@ -77,14 +77,14 @@ def correct_timestamps(
 
 
 def timestampCorrection(
-    timeForLightsTurnOn,
-    storesList,
-    name_to_timestamps,
-    name_to_data,
-    name_to_sampling_rate,
-    name_to_npoints,
-    mode,
-):
+    timeForLightsTurnOn: float,
+    storesList: np.ndarray,
+    name_to_timestamps: dict[str, np.ndarray],
+    name_to_data: dict[str, np.ndarray],
+    name_to_sampling_rate: dict[str, np.ndarray],
+    name_to_npoints: dict[str, np.ndarray | None],
+    mode: str,
+) -> tuple[dict[str, np.ndarray], dict[str, np.ndarray], dict[str, np.ndarray]]:
     """
     Trim and realign control/signal timestamps, discarding samples before ``timeForLightsTurnOn``.
 
@@ -170,13 +170,13 @@ def timestampCorrection(
 
 
 def decide_naming_and_applyCorrection_ttl(
-    timeForLightsTurnOn,
-    storesList,
-    name_to_timestamps_ttl,
-    name_to_timestamps,
-    name_to_data,
-    mode,
-):
+    timeForLightsTurnOn: float,
+    storesList: np.ndarray,
+    name_to_timestamps_ttl: dict[str, np.ndarray],
+    name_to_timestamps: dict[str, np.ndarray],
+    name_to_data: dict[str, np.ndarray],
+    mode: str,
+) -> dict[str, np.ndarray]:
     """
     Apply timestamp correction to all TTL stores and pair them with channel suffixes.
 
@@ -230,11 +230,11 @@ def decide_naming_and_applyCorrection_ttl(
 
 
 def applyCorrection_ttl(
-    timeForLightsTurnOn,
-    timeRecStart,
-    ttl_timestamps,
-    mode,
-):
+    timeForLightsTurnOn: float,
+    timeRecStart: float,
+    ttl_timestamps: np.ndarray,
+    mode: str,
+) -> np.ndarray:
     """
     Shift TTL timestamps to align with the corrected photometry time base.
 
@@ -267,7 +267,7 @@ def applyCorrection_ttl(
     return corrected_ttl_timestamps
 
 
-def check_cntrl_sig_length(channels_arr, name_to_data):
+def check_cntrl_sig_length(channels_arr: np.ndarray, name_to_data: dict[str, np.ndarray]) -> list[str]:
     """
     Identify the shorter channel in each control/signal pair.
 

--- a/src/guppy/analysis/transients.py
+++ b/src/guppy/analysis/transients.py
@@ -9,7 +9,15 @@ from scipy.signal import argrelextrema
 logger = logging.getLogger(__name__)
 
 
-def analyze_transients(ts, window, numProcesses, highAmpFilt, transientsThresh, sampling_rate, z_score):
+def analyze_transients(
+    ts: np.ndarray,
+    window: float,
+    numProcesses: int,
+    highAmpFilt: float,
+    transientsThresh: float,
+    sampling_rate: float,
+    z_score: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """
     Detect transient events in a z-score signal using a two-threshold MAD approach.
 
@@ -61,7 +69,9 @@ def analyze_transients(ts, window, numProcesses, highAmpFilt, transientsThresh, 
     return z_score, ts, peaksInd, peaks_occurrences, arr
 
 
-def processChunks(arrValues, arrIndexes, highAmpFilt, transientsThresh):
+def processChunks(
+    arrValues: np.ndarray, arrIndexes: np.ndarray, highAmpFilt: float, transientsThresh: float
+) -> tuple[np.ndarray, float, float, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """
     Apply the two-threshold MAD transient-detection algorithm to one chunk.
 
@@ -120,7 +130,7 @@ def processChunks(arrValues, arrIndexes, highAmpFilt, transientsThresh):
     return peaks, mad, filteredOutMad, medianY, filteredOutMedianY, firstThresholdY, secondThresholdY
 
 
-def createChunks(z_score, sampling_rate, window):
+def createChunks(z_score: np.ndarray, sampling_rate: float, window: float) -> tuple[np.ndarray, np.ndarray]:
     """
     Pad and reshape the z-score array into equal-length chunks for parallel processing.
 
@@ -170,7 +180,9 @@ def createChunks(z_score, sampling_rate, window):
     return z_score_chunks, z_score_chunks_index
 
 
-def calculate_freq_amp(arr, z_score, z_score_chunks_index, timestamps):
+def calculate_freq_amp(
+    arr: np.ndarray, z_score: np.ndarray, z_score_chunks_index: np.ndarray, timestamps: np.ndarray
+) -> tuple[float, np.ndarray, np.ndarray]:
     """
     Aggregate per-chunk transient results into global frequency and amplitude statistics.
 

--- a/src/guppy/analysis/transients_average.py
+++ b/src/guppy/analysis/transients_average.py
@@ -16,7 +16,7 @@ from .standard_io import (
 logger = logging.getLogger(__name__)
 
 
-def averageForGroup(folderNames, inputParameters):
+def averageForGroup(folderNames: list[str], inputParameters: dict[str, object]) -> None:
     """
     Combine transient frequency and amplitude results across a group of sessions.
 

--- a/src/guppy/analysis/z_score.py
+++ b/src/guppy/analysis/z_score.py
@@ -10,17 +10,17 @@ logger = logging.getLogger(__name__)
 
 
 def compute_z_score(
-    control,
-    signal,
-    tsNew,
-    coords,
-    artifactsRemovalMethod,
-    filter_window,
-    isosbestic_control,
-    zscore_method,
-    baseline_start,
-    baseline_end,
-):
+    control: np.ndarray,
+    signal: np.ndarray,
+    tsNew: np.ndarray,
+    coords: np.ndarray,
+    artifactsRemovalMethod: str,
+    filter_window: int,
+    isosbestic_control: bool,
+    zscore_method: str,
+    baseline_start: float,
+    baseline_end: float,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray | None]:
     """
     Compute the z-score and dF/F for a control/signal channel pair.
 
@@ -107,7 +107,9 @@ def compute_z_score(
     return z_score_arr, norm_data_arr, control_fit_arr, temp_control_arr
 
 
-def execute_controlFit_dff(control, signal, isosbestic_control, filter_window):
+def execute_controlFit_dff(
+    control: np.ndarray, signal: np.ndarray, isosbestic_control: bool, filter_window: int
+) -> tuple[np.ndarray, np.ndarray]:
     """
     Filter channels, fit the control to the signal, and compute dF/F.
 
@@ -144,7 +146,7 @@ def execute_controlFit_dff(control, signal, isosbestic_control, filter_window):
     return norm_data, control_fit
 
 
-def deltaFF(signal, control):
+def deltaFF(signal: np.ndarray, control: np.ndarray) -> np.ndarray:
     """
     Compute dF/F as ``(signal - control) / control * 100``.
 
@@ -169,7 +171,7 @@ def deltaFF(signal, control):
     return normData
 
 
-def controlFit(control, signal):
+def controlFit(control: np.ndarray, signal: np.ndarray) -> np.ndarray:
     """
     Fit a linear model from control to signal and return the fitted values.
 
@@ -191,7 +193,7 @@ def controlFit(control, signal):
     return arr
 
 
-def filterSignal(filter_window, signal):
+def filterSignal(filter_window: int, signal: np.ndarray) -> np.ndarray:
     """
     Apply a moving-average (uniform FIR) filter to a signal array.
 
@@ -221,7 +223,9 @@ def filterSignal(filter_window, signal):
         )
 
 
-def z_score_computation(dff, timestamps, zscore_method, baseline_start, baseline_end):
+def z_score_computation(
+    dff: np.ndarray, timestamps: np.ndarray, zscore_method: str, baseline_start: float, baseline_end: float
+) -> np.ndarray:
     """
     Convert a dF/F array to z-scores using the specified method.
 


### PR DESCRIPTION
## Summary

- Annotates all function arguments and return types across all 15 analysis modules to satisfy ruff `ANN` rules added in #346
- Key type choices: `dict[str, object]` for `inputParameters` (ANN401-compliant), `np.ndarray` for arrays, `X | None` for optional parameters (Python 3.10+ syntax), `Sequence[float]` from `collections.abc` for read-only sequences
- `pre-commit run ruff` passes cleanly on all changed files

## Test plan

- [x] `pre-commit run ruff --files src/guppy/analysis/*.py` — Passed
- [x] `pytest tests/unit/analysis/ -v` — 187 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)