### PR TITLE
Add type hints to orchestration layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added numpydoc-style docstrings to all public functions in the testing layer (`src/guppy/testing/`). [PR #318](https://github.com/LernerLab/GuPPy/pull/318)
 - Added parameterized output directories: step 2 accepts a user-supplied run name, steps 1 and 3–6 honour a per-session run-name filter, and `GuPPyParamtersUsed.json` is written into the selected output directories so multiple parameter sets can coexist in one session. [PR #325](https://github.com/LernerLab/GuPPy/pull/325)
 - Added type hint checks to pre-commit. [PR #346](https://github.com/LernerLab/GuPPy/pull/346)
+- Added type hints to all functions in the orchestration layer (`src/guppy/orchestration/`). [PR #350](https://github.com/LernerLab/GuPPy/pull/350)
 
 ## Fixes
 - Fixed bug with step five, which was causing the baseline uncorrected HDF5 file to not exist. [PR #241](https://github.com/LernerLab/GuPPy/pull/241)

--- a/src/guppy/orchestration/home.py
+++ b/src/guppy/orchestration/home.py
@@ -17,7 +17,7 @@ from ..frontend.sidebar import Sidebar
 logger = logging.getLogger(__name__)
 
 
-def readRawData(inputParameters):
+def readRawData(inputParameters: dict[str, object]) -> None:
     """
     Launch the raw-data extraction step in a subprocess.
 
@@ -29,7 +29,7 @@ def readRawData(inputParameters):
     subprocess.call([sys.executable, "-m", "guppy.orchestration.read_raw_data", json.dumps(inputParameters)])
 
 
-def preprocess(inputParameters):
+def preprocess(inputParameters: dict[str, object]) -> None:
     """
     Launch the preprocessing step (timestamp correction, z-score) in a subprocess.
 
@@ -41,7 +41,7 @@ def preprocess(inputParameters):
     subprocess.call([sys.executable, "-m", "guppy.orchestration.preprocess", json.dumps(inputParameters)])
 
 
-def psthComputation(inputParameters):
+def psthComputation(inputParameters: dict[str, object]) -> None:
     """
     Launch the PSTH computation step in a subprocess.
 
@@ -53,7 +53,7 @@ def psthComputation(inputParameters):
     subprocess.call([sys.executable, "-m", "guppy.orchestration.psth", json.dumps(inputParameters)])
 
 
-def build_homepage(*, start_path=None):
+def build_homepage(*, start_path: str | None = None) -> pn.template.BootstrapTemplate:
     """
     Build and return the GuPPy Panel web-application template.
 
@@ -77,7 +77,7 @@ def build_homepage(*, start_path=None):
 
     # ------------------------------------------------------------------------------------------------------------------
     # onclick closure functions for sidebar buttons
-    def _getInputParametersOrNotify(*, require_selected_outputs: bool = False):
+    def _getInputParametersOrNotify(*, require_selected_outputs: bool = False) -> dict[str, object] | None:
         try:
             input_parameters = parameter_form.getInputParameters()
             if require_selected_outputs:
@@ -87,13 +87,13 @@ def build_homepage(*, start_path=None):
             pn.state.notifications.error(str(e), duration=0)
             return None
 
-    def onclickProcess(event=None):
+    def onclickProcess(event: object = None) -> None:
         inputParameters = _getInputParametersOrNotify()
         if inputParameters is None:
             return
         save_parameters(inputParameters=inputParameters)
 
-    def onclickStorenames(event=None):
+    def onclickStorenames(event: object = None) -> None:
         inputParameters = _getInputParametersOrNotify()
         if inputParameters is None:
             return
@@ -103,7 +103,7 @@ def build_homepage(*, start_path=None):
         parameter_form.refresh_individual_outputs()
         parameter_form.refresh_group_outputs()
 
-    def onclickVisualization(event=None):
+    def onclickVisualization(event: object = None) -> None:
         inputParameters = _getInputParametersOrNotify(require_selected_outputs=True)
         if inputParameters is None:
             return
@@ -112,7 +112,7 @@ def build_homepage(*, start_path=None):
         except ValueError as e:
             pn.state.notifications.error(str(e), duration=0)
 
-    def onclickreaddata(event=None):
+    def onclickreaddata(event: object = None) -> None:
         inputParameters = _getInputParametersOrNotify(require_selected_outputs=True)
         if inputParameters is None:
             return
@@ -123,7 +123,7 @@ def build_homepage(*, start_path=None):
         if error_msg:
             pn.state.notifications.error(error_msg, duration=0)
 
-    def onclickpreprocess(event=None):
+    def onclickpreprocess(event: object = None) -> None:
         inputParameters = _getInputParametersOrNotify(require_selected_outputs=True)
         if inputParameters is None:
             return
@@ -134,7 +134,7 @@ def build_homepage(*, start_path=None):
         if error_msg:
             pn.state.notifications.error(error_msg, duration=0)
 
-    def onclickpsth(event=None):
+    def onclickpsth(event: object = None) -> None:
         inputParameters = _getInputParametersOrNotify(require_selected_outputs=True)
         if inputParameters is None:
             return

--- a/src/guppy/orchestration/preprocess.py
+++ b/src/guppy/orchestration/preprocess.py
@@ -52,7 +52,7 @@ if not os.getenv("CI") and not headless:
     plt.switch_backend("TKAgg")
 
 
-def execute_preprocessing_visualization(filepath, visualization_type: Literal["z_score", "dff"]):
+def execute_preprocessing_visualization(filepath: str, visualization_type: Literal["z_score", "dff"]) -> None:
     """
     Plot z-score or dF/F signals for all channel pairs in a session output directory.
 
@@ -77,7 +77,7 @@ def execute_preprocessing_visualization(filepath, visualization_type: Literal["z
         fig, ax = visualize_preprocessing(suptitle=name, title=basename, x=x, y=y)
 
 
-def visualizeControlAndSignal(filepath, removeArtifacts):
+def visualizeControlAndSignal(filepath: str, removeArtifacts: bool) -> list:
     """
     Build artifact-removal widgets for each control/signal pair in a session directory.
 
@@ -135,7 +135,7 @@ def visualizeControlAndSignal(filepath, removeArtifacts):
     return widgets
 
 
-def execute_timestamp_correction(folderNames, inputParameters):
+def execute_timestamp_correction(folderNames: list[str], inputParameters: dict[str, object]) -> None:
     """
     Apply timestamp correction to all session output directories.
 
@@ -206,7 +206,7 @@ def execute_timestamp_correction(folderNames, inputParameters):
         logger.info(f"Timestamps corrections finished for {filepath}")
 
 
-def execute_zscore(folderNames, inputParameters):
+def execute_zscore(folderNames: list[str], inputParameters: dict[str, object]) -> None:
     """
     Compute z-score and dF/F for all channel pairs across session output directories.
 
@@ -297,7 +297,7 @@ def execute_zscore(folderNames, inputParameters):
     logger.info("Z-score computation completed.")
 
 
-def visualize_z_score(inputParameters, folderNames):
+def visualize_z_score(inputParameters: dict[str, object], folderNames: list[str]) -> None:
     """
     Display control/signal plots and z-score/dF/F visualizations for all sessions.
 
@@ -344,7 +344,7 @@ def visualize_z_score(inputParameters, folderNames):
     logger.info("Visualization of z-score and dF/F completed.")
 
 
-def execute_artifact_removal(folderNames, inputParameters):
+def execute_artifact_removal(folderNames: list[str], inputParameters: dict[str, object]) -> None:
     """
     Apply artifact removal to all session output directories.
 
@@ -405,7 +405,7 @@ def execute_artifact_removal(folderNames, inputParameters):
     logger.info("Artifact removal completed.")
 
 
-def visualize_artifact_removal(folderNames, inputParameters):
+def visualize_artifact_removal(folderNames: list[str], inputParameters: dict[str, object]) -> None:
     """
     Display control/signal plots after artifact removal for all sessions.
 
@@ -437,7 +437,7 @@ def visualize_artifact_removal(folderNames, inputParameters):
     logger.info("Visualization of artifact removal completed.")
 
 
-def execute_combine_data(folderNames, inputParameters, storesList):
+def execute_combine_data(folderNames: list[str], inputParameters: dict[str, object], storesList: np.ndarray) -> list:
     """
     Concatenate data from multiple session files and save the result to the first output folder.
 
@@ -517,7 +517,7 @@ def execute_combine_data(folderNames, inputParameters, storesList):
     return op
 
 
-def extractTsAndSignal(inputParameters):
+def extractTsAndSignal(inputParameters: dict[str, object]) -> None:
     """
     Orchestrate the full preprocessing pipeline (timestamp correction, z-score, artifact removal).
 
@@ -576,7 +576,7 @@ def extractTsAndSignal(inputParameters):
 
 
 @subprocess_main_handler
-def main(input_parameters):
+def main(input_parameters: dict[str, object]) -> None:
     """Subprocess entry point for the preprocessing step.
 
     Parameters

--- a/src/guppy/orchestration/psth.py
+++ b/src/guppy/orchestration/psth.py
@@ -39,7 +39,7 @@ from ..utils.validation import validate_peak_windows, validate_window_bounds
 logger = logging.getLogger(__name__)
 
 
-def execute_compute_psth(filepath, event, inputParameters):
+def execute_compute_psth(filepath: str, event: str, inputParameters: dict[str, object]) -> None:
     """Compute and save the PSTH for a single event in one session output folder.
 
     Parameters
@@ -122,7 +122,7 @@ def execute_compute_psth(filepath, event, inputParameters):
         logger.info(f"PSTH for event {event} computed.")
 
 
-def execute_compute_psth_peak_and_area(filepath, event, inputParameters):
+def execute_compute_psth_peak_and_area(filepath: str, event: str, inputParameters: dict[str, object]) -> None:
     """Compute and save PSTH peak and area for a single event.
 
     Parameters
@@ -178,7 +178,7 @@ def execute_compute_psth_peak_and_area(filepath, event, inputParameters):
         logger.info(f"Peak and Area for PSTH mean signal for event {event} computed.")
 
 
-def execute_compute_cross_correlation(filepath, event, inputParameters):
+def execute_compute_cross_correlation(filepath: str, event: str, inputParameters: dict[str, object]) -> None:
     """Compute and save cross-correlation between brain regions for a single event.
 
     Parameters
@@ -243,7 +243,7 @@ def execute_compute_cross_correlation(filepath, event, inputParameters):
                 logger.info(f"Cross-correlation for event {event} computed.")
 
 
-def orchestrate_psth(inputParameters):
+def orchestrate_psth(inputParameters: dict[str, object]) -> None:
     """Run PSTH, peak/area, and cross-correlation for each individual session.
 
     Parameters
@@ -293,7 +293,7 @@ def orchestrate_psth(inputParameters):
         logger.info(f"PSTH, Area and Peak are computed for all events in {folderNames[i]}.")
 
 
-def execute_psth_combined(inputParameters):
+def execute_psth_combined(inputParameters: dict[str, object]) -> None:
     """Run PSTH computation for combined (multi-session) data.
 
     Parameters
@@ -328,7 +328,7 @@ def execute_psth_combined(inputParameters):
         inputParameters["step"] += 1
 
 
-def _validate_storenames_consistent_for_group(storesListPath):
+def _validate_storenames_consistent_for_group(storesListPath: np.ndarray) -> None:
     """Check that every session output directory exposes the same storenames.
 
     Group averaging only produces meaningful results when all sessions share the
@@ -366,7 +366,7 @@ def _validate_storenames_consistent_for_group(storesListPath):
     )
 
 
-def _validate_psth_window_parameters(inputParameters):
+def _validate_psth_window_parameters(inputParameters: dict[str, object]) -> None:
     """Upfront PSTH-window validation, run before any HDF5 IO.
 
     Why: peak-window ordering used to surface only deep inside
@@ -396,7 +396,7 @@ def _validate_psth_window_parameters(inputParameters):
     )
 
 
-def execute_average_for_group(inputParameters):
+def execute_average_for_group(inputParameters: dict[str, object]) -> None:
     """Average PSTH results across all selected sessions in the group.
 
     Parameters
@@ -459,7 +459,7 @@ def execute_average_for_group(inputParameters):
         inputParameters["step"] += 1
 
 
-def psthForEachStorename(inputParameters):
+def psthForEachStorename(inputParameters: dict[str, object]) -> dict[str, object]:
     """Entry point for step-5 PSTH computation: validates parameters and dispatches to the appropriate sub-routine.
 
     Parameters
@@ -510,7 +510,7 @@ def psthForEachStorename(inputParameters):
 
 
 @subprocess_main_handler
-def main(input_parameters):
+def main(input_parameters: dict[str, object]) -> None:
     """Run step-5 PSTH computation and chain to the transients step.
 
     Parameters

--- a/src/guppy/orchestration/read_raw_data.py
+++ b/src/guppy/orchestration/read_raw_data.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import multiprocessing as mp
+import multiprocessing.sharedctypes
 import os
 import sys
 import threading
@@ -25,7 +26,9 @@ from guppy.utils.utils import select_output_dirs
 logger = logging.getLogger(__name__)
 
 
-def _progress_poller(samples_done, stop_event, *, file_path):
+def _progress_poller(
+    samples_done: mp.sharedctypes.Synchronized, stop_event: threading.Event, *, file_path: str
+) -> None:
     """Periodically flush the shared samples counter into ``PB_STEPS_FILE``.
 
     Runs in the parent process while the multiprocessing pool drains. Each
@@ -40,7 +43,7 @@ def _progress_poller(samples_done, stop_event, *, file_path):
             last_written = current
 
 
-def _group_events_by_extractor(event_to_extractor, events):
+def _group_events_by_extractor(event_to_extractor: dict, events: np.ndarray) -> dict:
     """Partition ``events`` by their owning extractor instance, preserving order.
 
     Single-extractor sessions produce one group; mixed-modality sessions produce
@@ -58,7 +61,7 @@ def _group_events_by_extractor(event_to_extractor, events):
     return {extractor: event_list for extractor, event_list in grouped.values()}
 
 
-def _build_event_to_extractor(*, folder_path, storesList, inputParameters):
+def _build_event_to_extractor(*, folder_path: str, storesList: np.ndarray, inputParameters: dict[str, object]) -> dict:
     """
     Build a mapping from event name to the extractor instance that owns it.
 
@@ -126,7 +129,7 @@ def _build_event_to_extractor(*, folder_path, storesList, inputParameters):
     return event_to_extractor
 
 
-def orchestrate_read_raw_data(inputParameters):
+def orchestrate_read_raw_data(inputParameters: dict[str, object]) -> None:
     """Read raw acquisition data for all sessions and save to HDF5.
 
     Parameters
@@ -236,7 +239,7 @@ def orchestrate_read_raw_data(inputParameters):
     logger.info("#" * 400)
 
 
-def _load_stores_list(output_dir):
+def _load_stores_list(output_dir: str) -> np.ndarray:
     """Load the storesList CSV (preferring the cached copy if it exists)."""
     cached_path = os.path.join(output_dir, ".cache_storesList.csv")
     source_path = cached_path if os.path.exists(cached_path) else os.path.join(output_dir, "storesList.csv")
@@ -244,7 +247,7 @@ def _load_stores_list(output_dir):
 
 
 @subprocess_main_handler
-def main(input_parameters):
+def main(input_parameters: dict[str, object]) -> None:
     """Subprocess entry point for step-3 raw-data extraction.
 
     Parameters

--- a/src/guppy/orchestration/save_parameters.py
+++ b/src/guppy/orchestration/save_parameters.py
@@ -8,7 +8,7 @@ from guppy.utils.utils import discover_output_dirs, select_output_dirs
 logger = logging.getLogger(__name__)
 
 
-def save_parameters(inputParameters: dict):
+def save_parameters(inputParameters: dict[str, object]) -> None:
     """
     Write the analysis configuration JSON to each selected output directory.
 

--- a/src/guppy/orchestration/storenames.py
+++ b/src/guppy/orchestration/storenames.py
@@ -38,7 +38,7 @@ pn.extension()
 logger = logging.getLogger(__name__)
 
 
-def show_dir(filepath, run_name=None):
+def show_dir(filepath: str, run_name: str | None = None) -> str:
     """Return the path of an output directory without creating it.
 
     Parameters
@@ -69,7 +69,7 @@ def show_dir(filepath, run_name=None):
     return op
 
 
-def make_dir(filepath, run_name=None, run_name_policy="create"):
+def make_dir(filepath: str, run_name: str | None = None, run_name_policy: str = "create") -> str:
     """Create and return an output directory.
 
     Parameters
@@ -115,7 +115,14 @@ def make_dir(filepath, run_name=None, run_name_policy="create"):
     return op
 
 
-def _fetchValues(text, storenames, storename_dropdowns, storename_textboxes, storenames_config, isosbestic_control=False):
+def _fetchValues(
+    text: object,
+    storenames: list,
+    storename_dropdowns: dict,
+    storename_textboxes: dict,
+    storenames_config: dict,
+    isosbestic_control: bool = False,
+) -> str:
     if not storename_dropdowns or not len(storenames) > 0:
         return "####Alert !! \n No storenames selected."
 
@@ -194,7 +201,7 @@ def _fetchValues(text, storenames, storename_dropdowns, storename_textboxes, sto
     return "#### No alerts !!"
 
 
-def _save(storenames_config, select_location):
+def _save(storenames_config: dict, select_location: str) -> str:
     arr1, arr2 = np.asarray(storenames_config["storenames"]), np.asarray(storenames_config["names_for_storenames"])
 
     empty_indices = np.where(arr2 == "")[0].tolist()
@@ -261,7 +268,9 @@ def _save(storenames_config, select_location):
     return "#### No alerts !!"
 
 
-def build_storenames_template(events, flags, folder_path, isosbestic_control=False):
+def build_storenames_template(
+    events: list[str], flags: list[str], folder_path: str, isosbestic_control: bool = False
+) -> pn.template.BootstrapTemplate:
     """Build and return the Storenames GUI Panel template without serving it.
 
     Parameters
@@ -295,7 +304,7 @@ def build_storenames_template(events, flags, folder_path, isosbestic_control=Fal
     # ------------------------------------------------------------------------------------------------------------------
     # onclick closure functions
     # on clicking overwrite_button, following function is executed
-    def overwrite_button_actions(event):
+    def overwrite_button_actions(event: object) -> None:
         if event.new == "over_write_file":
             options = discover_output_dirs(folder_path)
             storenames_selector.set_select_location_options(options=options)
@@ -304,7 +313,7 @@ def build_storenames_template(events, flags, folder_path, isosbestic_control=Fal
             options = [show_dir(folder_path, run_name=run_name or None)]
             storenames_selector.set_select_location_options(options=options)
 
-    def run_name_input_changed(event):
+    def run_name_input_changed(event: object) -> None:
         if storenames_selector.get_overwrite_mode() != "create_new_file":
             return
         run_name = event.new or None
@@ -316,7 +325,7 @@ def build_storenames_template(events, flags, folder_path, isosbestic_control=Fal
         storenames_selector.set_select_location_options(options=options)
         storenames_selector.set_alert_message("#### No alerts !!")
 
-    def fetchValues(event):
+    def fetchValues(event: object) -> None:
         global storenames
         storenames_config = dict()
         alert_message = _fetchValues(
@@ -331,7 +340,7 @@ def build_storenames_template(events, flags, folder_path, isosbestic_control=Fal
         storenames_selector.set_literal_input_2(storenames_config=storenames_config)
 
     # on clicking 'Select Storenames' button, following function is executed
-    def update_values(event):
+    def update_values(event: object) -> None:
         global storenames, vars_list
 
         arr = storenames_selector.get_take_widgets()
@@ -358,7 +367,7 @@ def build_storenames_template(events, flags, folder_path, isosbestic_control=Fal
         )
 
     # on clicking save button, following function is executed
-    def save_button(event=None):
+    def save_button(event: object = None) -> None:
         global storenames
         storenames_config = storenames_selector.get_literal_input_2()
         select_location = storenames_selector.get_select_location()
@@ -383,7 +392,9 @@ def build_storenames_template(events, flags, folder_path, isosbestic_control=Fal
     return template
 
 
-def build_storenames_page(inputParameters, events, flags, folder_path):
+def build_storenames_page(
+    inputParameters: dict[str, object], events: list[str], flags: list[str], folder_path: str
+) -> None:
     """Write storesList.csv for one session, headlessly or via the Panel GUI.
 
     In headless mode (``storenames_map`` key present in ``inputParameters``)
@@ -425,7 +436,9 @@ def build_storenames_page(inputParameters, events, flags, folder_path):
     template.show(port=number)
 
 
-def read_header(inputParameters, num_ch, folder_path, headless):
+def read_header(
+    inputParameters: dict[str, object], num_ch: int, folder_path: str, headless: bool
+) -> tuple[list[str], list[str]]:
     """Discover events and feature flags for a single session folder.
 
     Parameters
@@ -499,7 +512,7 @@ def read_header(inputParameters, num_ch, folder_path, headless):
     return events, flags
 
 
-def orchestrate_storenames_page(inputParameters):
+def orchestrate_storenames_page(inputParameters: dict[str, object]) -> None:
     """Run the step-2 storenames configuration for every selected session folder.
 
     Parameters

--- a/src/guppy/orchestration/transients.py
+++ b/src/guppy/orchestration/transients.py
@@ -26,7 +26,9 @@ from ..visualization.transients import visualize_peaks
 logger = logging.getLogger(__name__)
 
 
-def findFreqAndAmp(filepath, inputParameters, window=15, numProcesses=mp.cpu_count()):
+def findFreqAndAmp(
+    filepath: str, inputParameters: dict[str, object], window: int = 15, numProcesses: int = mp.cpu_count()
+) -> None:
     """Detect transients and compute their frequency and amplitude for one output directory.
 
     Parameters
@@ -77,7 +79,7 @@ def findFreqAndAmp(filepath, inputParameters, window=15, numProcesses=mp.cpu_cou
     logger.info("Frequency and amplitude of transients in z_score data are calculated.")
 
 
-def execute_visualize_peaks(folderNames, inputParameters):
+def execute_visualize_peaks(folderNames: list[str], inputParameters: dict[str, object]) -> None:
     """Plot detected transient peaks for each individual session.
 
     Parameters
@@ -114,7 +116,7 @@ def execute_visualize_peaks(folderNames, inputParameters):
     plt.show()
 
 
-def execute_visualize_peaks_combined(folderNames, inputParameters):
+def execute_visualize_peaks_combined(folderNames: list[str], inputParameters: dict[str, object]) -> None:
     """Plot detected transient peaks for combined (multi-session) data.
 
     Parameters
@@ -155,7 +157,7 @@ def execute_visualize_peaks_combined(folderNames, inputParameters):
     plt.show()
 
 
-def executeFindFreqAndAmp(inputParameters):
+def executeFindFreqAndAmp(inputParameters: dict[str, object]) -> None:
     """Entry point for step-5 transient analysis: dispatches to the appropriate sub-routine.
 
     Parameters
@@ -198,7 +200,9 @@ def executeFindFreqAndAmp(inputParameters):
     logger.info("Transients in z-score data found and frequency and amplitude are calculated.")
 
 
-def execute_find_freq_and_amp(inputParameters, folderNames, moving_window, numProcesses):
+def execute_find_freq_and_amp(
+    inputParameters: dict[str, object], folderNames: list[str], moving_window: int, numProcesses: int
+) -> None:
     """Compute transient frequency and amplitude for each individual session.
 
     Parameters
@@ -228,7 +232,9 @@ def execute_find_freq_and_amp(inputParameters, folderNames, moving_window, numPr
         logger.info("Transients in z-score data found and frequency and amplitude are calculated.")
 
 
-def execute_find_freq_and_amp_combined(inputParameters, folderNames, moving_window, numProcesses):
+def execute_find_freq_and_amp_combined(
+    inputParameters: dict[str, object], folderNames: list[str], moving_window: int, numProcesses: int
+) -> None:
     """Compute transient frequency and amplitude for combined (multi-session) data.
 
     Parameters
@@ -257,7 +263,7 @@ def execute_find_freq_and_amp_combined(inputParameters, folderNames, moving_wind
         inputParameters["step"] += 1
 
 
-def execute_average_for_group(inputParameters, folderNamesForAvg):
+def execute_average_for_group(inputParameters: dict[str, object], folderNamesForAvg: list[str]) -> None:
     """Average transient frequency and amplitude results across all group sessions.
 
     Parameters
@@ -291,7 +297,7 @@ def execute_average_for_group(inputParameters, folderNamesForAvg):
 
 
 @subprocess_main_handler
-def main(input_parameters):
+def main(input_parameters: dict[str, object]) -> None:
     """Subprocess entry point for the transient-analysis step.
 
     Parameters

--- a/src/guppy/orchestration/visualize.py
+++ b/src/guppy/orchestration/visualize.py
@@ -14,7 +14,7 @@ from ..utils.utils import get_all_stores_for_combining_data, read_Df, select_out
 logger = logging.getLogger(__name__)
 
 
-def helper_plots(filepath, event, name, inputParameters):
+def helper_plots(filepath: str, event: list[str], name: list[str] | str, inputParameters: dict[str, object]) -> None:
     """Build and display the interactive PSTH visualization dashboard for one output directory.
 
     Parameters
@@ -146,7 +146,7 @@ def helper_plots(filepath, event, name, inputParameters):
     dashboard.show()
 
 
-def createPlots(filepath, event, inputParameters):
+def createPlots(filepath: str, event: np.ndarray, inputParameters: dict[str, object]) -> None:
     """Assemble PSTH data from an output directory and delegate to ``helper_plots``.
 
     Parameters
@@ -202,7 +202,7 @@ def createPlots(filepath, event, inputParameters):
         helper_plots(filepath, event, name_arr, inputParameters)
 
 
-def _validate_metric_against_step5_outputs(inputParameters):
+def _validate_metric_against_step5_outputs(inputParameters: dict[str, object]) -> None:
     """Cross-check the visualization metric selection against step-5 PSTH outputs on disk.
 
     Step 5 only writes PSTH ``.h5`` files for the metric(s) selected via
@@ -270,7 +270,7 @@ def _validate_metric_against_step5_outputs(inputParameters):
         )
 
 
-def _validate_average_visualization_preconditions(inputParameters):
+def _validate_average_visualization_preconditions(inputParameters: dict[str, object]) -> None:
     """Ensure the prerequisites for 'Visualize Average Results' are satisfied.
 
     Catches the three user-facing failure modes documented in issue #274:
@@ -331,7 +331,7 @@ def _validate_average_visualization_preconditions(inputParameters):
         )
 
 
-def visualizeResults(inputParameters):
+def visualizeResults(inputParameters: dict[str, object]) -> None:
     """Entry point for step-6 visualization: validate preconditions and open dashboards.
 
     Parameters


### PR DESCRIPTION
## Summary

- Annotates all function arguments and return types across all 8 orchestration modules to satisfy ruff `ANN` rules added in #346
- Key type choices: `dict[str, object]` for `inputParameters` (ANN401-compliant), Panel callback `event` parameters typed as `object`, `pn.template.BootstrapTemplate` for template returns, `mp.sharedctypes.Synchronized` for shared-memory counters
- `pre-commit run ruff` passes cleanly on all changed files

## Test plan

- [x] `pre-commit run ruff --files src/guppy/orchestration/*.py` — Passed
- [x] `pytest tests/unit/orchestration/ -v` — 130 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)