### PR TITLE
Add type hints to frontend layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added numpydoc-style docstrings to all public functions in the testing layer (`src/guppy/testing/`). [PR #318](https://github.com/LernerLab/GuPPy/pull/318)
 - Added parameterized output directories: step 2 accepts a user-supplied run name, steps 1 and 3–6 honour a per-session run-name filter, and `GuPPyParamtersUsed.json` is written into the selected output directories so multiple parameter sets can coexist in one session. [PR #325](https://github.com/LernerLab/GuPPy/pull/325)
 - Added type hint checks to pre-commit. [PR #346](https://github.com/LernerLab/GuPPy/pull/346)
+- Added type hints to all functions in the frontend layer (`src/guppy/frontend/`). [PR #351](https://github.com/LernerLab/GuPPy/pull/351)
 
 ## Fixes
 - Fixed bug with step five, which was causing the baseline uncorrected HDF5 file to not exist. [PR #241](https://github.com/LernerLab/GuPPy/pull/241)

--- a/src/guppy/frontend/artifact_removal.py
+++ b/src/guppy/frontend/artifact_removal.py
@@ -21,7 +21,16 @@ class ArtifactRemovalWidget:
     Boundary coordinates are saved as a ``.npy`` file when the figure is closed.
     """
 
-    def __init__(self, filepath, x, y1, y2, y3, plot_name, removeArtifacts):
+    def __init__(
+        self,
+        filepath: str,
+        x: np.ndarray,
+        y1: np.ndarray,
+        y2: np.ndarray,
+        y3: np.ndarray,
+        plot_name: list[str],
+        removeArtifacts: bool,
+    ) -> None:
         self.coords = []  # List to store selected coordinates
         self.filepath = filepath
         self.plot_name = plot_name
@@ -39,7 +48,7 @@ class ArtifactRemovalWidget:
         self.cid = self.fig.canvas.mpl_connect("key_press_event", self._on_key_press)
         self.fig.canvas.mpl_connect("close_event", self._on_close)
 
-    def _on_key_press(self, event):
+    def _on_key_press(self, event: object) -> list[tuple[float, float]] | None:
         """Handle key press events for artifact selection.
 
         Pressing 'space' draws a vertical line at the cursor position to mark artifact boundaries.
@@ -69,7 +78,7 @@ class ArtifactRemovalWidget:
 
             return self.coords
 
-    def _on_close(self, _event):
+    def _on_close(self, _event: object) -> None:
         """Handle figure close event by saving coordinates and cleaning up."""
         if self.coords and len(self.coords) > 0:
             name_1 = self.plot_name[0].split("_")[-1]

--- a/src/guppy/frontend/dandi_selector.py
+++ b/src/guppy/frontend/dandi_selector.py
@@ -25,7 +25,7 @@ _DANDISET_ID_PATTERN = re.compile(r"^\d{6}$")
 _MIRROR_ROOT = os.path.join(tempfile.gettempdir(), "guppy_dandi_mirror")
 
 
-def _build_dandiset_mirror(*, dandiset_id, mirror_parent):
+def _build_dandiset_mirror(*, dandiset_id: str, mirror_parent: str) -> tuple[str, int]:
     """Build (or reuse) a temp directory tree mirroring a dandiset's NWB assets.
 
     For every ``.nwb`` asset path returned by the DANDI API, create the
@@ -72,7 +72,7 @@ class DandiSelector:
         ``None`` if none is selected.
     """
 
-    def __init__(self, *, styles=None, mirror_parent=None):
+    def __init__(self, *, styles: dict[str, str] | None = None, mirror_parent: str | None = None) -> None:
         self.styles = styles or dict(background="WhiteSmoke")
         # Allow tests to inject a tmp_path-based parent; default to the
         # module-level stable location.
@@ -130,7 +130,7 @@ class DandiSelector:
             self.output_root_selector,
         )
 
-    def _make_asset_file_selector(self, root_directory):
+    def _make_asset_file_selector(self, root_directory: str) -> pn.widgets.FileSelector:
         """Construct a fresh ``FileSelector`` rooted at ``root_directory``.
 
         Panel's ``FileSelector`` caches its listing at construction time, so we
@@ -149,15 +149,15 @@ class DandiSelector:
         file_selector._directory.visible = False
         return file_selector
 
-    def _swap_asset_file_selector(self, root_directory):
+    def _swap_asset_file_selector(self, root_directory: str) -> None:
         self.asset_file_selector = self._make_asset_file_selector(root_directory)
         self._asset_file_selector_slot[:] = [self.asset_file_selector]
 
-    def _reset_to_empty(self):
+    def _reset_to_empty(self) -> None:
         self._current_mirror_root = None
         self._swap_asset_file_selector(self._mirror_parent)
 
-    def _on_dandiset_change(self, event):
+    def _on_dandiset_change(self, event: object) -> None:
         dandiset_id = (event.new or "").strip()
         if not dandiset_id:
             self._reset_to_empty()
@@ -185,7 +185,7 @@ class DandiSelector:
         self._swap_asset_file_selector(mirror_root)
         self.status.object = f"\u2705 Dandiset {dandiset_id}: {asset_count} NWB asset(s) loaded."
 
-    def _selected_relative_paths(self):
+    def _selected_relative_paths(self) -> list[str]:
         if self._current_mirror_root is None:
             return []
         selected = []
@@ -198,7 +198,7 @@ class DandiSelector:
         return selected
 
     @property
-    def selected_uris(self):
+    def selected_uris(self) -> list[str]:
         """Return the currently selected DANDI URIs.
 
         Returns
@@ -215,7 +215,7 @@ class DandiSelector:
         return [f"dandi://{dandiset_id}/{path}" for path in self._selected_relative_paths()]
 
     @property
-    def output_root(self):
+    def output_root(self) -> str | None:
         """Return the local output directory selected by the user.
 
         Returns

--- a/src/guppy/frontend/frontend_utils.py
+++ b/src/guppy/frontend/frontend_utils.py
@@ -6,7 +6,7 @@ from random import randint
 logger = logging.getLogger(__name__)
 
 
-def default_root_path():
+def default_root_path() -> str:
     """Starting directory for the GUI's directory pickers.
 
     Honors ``GUPPY_BASE_DIR`` (used by headless tests and the testing API to
@@ -25,7 +25,7 @@ def default_root_path():
 _CHROME_UNSAFE_PORTS = {5060, 5061}
 
 
-def scanPortsAndFind(start_port=5000, end_port=5200, host="127.0.0.1"):
+def scanPortsAndFind(start_port: int = 5000, end_port: int = 5200, host: str = "127.0.0.1") -> int:
     """Find an available TCP port by randomly sampling the given range.
 
     Skips ports that browsers refuse to connect to (Chrome unsafe-port list)

--- a/src/guppy/frontend/input_parameters.py
+++ b/src/guppy/frontend/input_parameters.py
@@ -16,7 +16,7 @@ from ..utils.validation import (
 logger = logging.getLogger(__name__)
 
 
-def checkSameLocation(arr, abspath):
+def checkSameLocation(arr: list[str], abspath: object) -> str:
     """Check that all paths in ``arr`` share the same parent directory.
 
     Parameters
@@ -37,7 +37,7 @@ def checkSameLocation(arr, abspath):
     return validate_same_parent_directory(paths=list(arr))
 
 
-def getAbsPath(files_1, files_2):
+def getAbsPath(files_1: pn.widgets.FileSelector, files_2: pn.widgets.FileSelector) -> str:
     """Return the common parent directory of the selected folders.
 
     Parameters
@@ -75,7 +75,7 @@ class ParameterForm:
         the path does not exist.
     """
 
-    def __init__(self, *, template, start_path=None):
+    def __init__(self, *, template: object, start_path: str | None = None) -> None:
         self.template = template
         self.folder_path = start_path if start_path and os.path.isdir(start_path) else default_root_path()
         self.styles = dict(background="WhiteSmoke")
@@ -87,7 +87,7 @@ class ParameterForm:
         self.files_1.param.watch(self._retarget_outputs_selector, "value")
         self.files_2.param.watch(self._rebuild_group_selected_outputs_widgets, "value")
 
-    def setup_individual_parameters(self):
+    def setup_individual_parameters(self) -> None:
         """Build all widgets for the individual-analysis card and store them as instance attributes."""
         # Individual analysis components
         self.mark_down_1 = pn.pane.Markdown(
@@ -398,12 +398,12 @@ class ParameterForm:
             self.widget, title="Individual Analysis", styles=self.styles, width=1000, collapsed=True
         )
 
-    def _on_source_mode_change(self, event):
+    def _on_source_mode_change(self, event: object) -> None:
         is_dandi = event.new == "dandi"
         self.files_1.visible = not is_dandi
         self.dandi_selector.panel.visible = is_dandi
 
-    def _collect_selected_outputs(self):
+    def _collect_selected_outputs(self) -> dict[str, list[str]]:
         """Group the FileSelector's selected output dirs by parent session."""
         grouped: dict[str, list[str]] = {}
         for path in self.outputs_selector.value or []:
@@ -411,7 +411,7 @@ class ParameterForm:
             grouped.setdefault(session, []).append(parse_run_name(path))
         return grouped
 
-    def validate_selected_outputs_for_consumers(self):
+    def validate_selected_outputs_for_consumers(self) -> None:
         """Ensure every selected session that has output dirs on disk also has at least one selected.
 
         Run this from the click handlers for steps 3–6 (which consume existing
@@ -431,7 +431,7 @@ class ParameterForm:
                 "_output_<run> directory per selected session."
             )
 
-    def _retarget_outputs_selector(self, event):
+    def _retarget_outputs_selector(self, event: object) -> None:
         """Root the existing-runs FileSelector so all selected sessions' `_output_*` dirs are reachable.
 
         - Zero sessions: fall back to ``default_root_path()``.
@@ -465,7 +465,7 @@ class ParameterForm:
         # back to the stale _cwd — visible to the user as "selection resets the directory".
         self.outputs_selector._update_files()
 
-    def _rebuild_group_selected_outputs_widgets(self, event):
+    def _rebuild_group_selected_outputs_widgets(self, event: object) -> None:
         """Rebuild the per-session group-run-name Selects when files_2 changes."""
         self._rebuild_per_session_widgets(
             sessions=event.new,
@@ -474,11 +474,11 @@ class ParameterForm:
             scope="group",
         )
 
-    def refresh_individual_outputs(self):
+    def refresh_individual_outputs(self) -> None:
         """Re-list the outputs FileSelector so newly-created run dirs (e.g. from step 2) appear."""
         self.outputs_selector._refresh()
 
-    def refresh_group_outputs(self):
+    def refresh_group_outputs(self) -> None:
         """Re-discover output directories for the currently-selected group sessions."""
         self._rebuild_per_session_widgets(
             sessions=self.files_2.value,
@@ -488,7 +488,7 @@ class ParameterForm:
         )
 
     @staticmethod
-    def _make_outputs_placeholder(scope):
+    def _make_outputs_placeholder(scope: str) -> pn.pane.Markdown:
         text = (
             "**Run-name filter:** No output directories yet — run step 2 first."
             if scope == "individual"
@@ -497,7 +497,9 @@ class ParameterForm:
         return pn.pane.Markdown(text, width=520)
 
     @classmethod
-    def _rebuild_per_session_widgets(cls, sessions, target_box, store, scope):
+    def _rebuild_per_session_widgets(
+        cls, sessions: list[str] | None, target_box: pn.Column, store: dict[str, pn.widgets.Select], scope: str
+    ) -> None:
         new_objects = []
         new_store = {}
         for session in sessions or []:
@@ -527,7 +529,7 @@ class ParameterForm:
         # box has a stable, always-visible footprint in the layout.
         target_box.objects = new_objects or [cls._make_outputs_placeholder(scope)]
 
-    def _resolve_dandi_sessions(self):
+    def _resolve_dandi_sessions(self) -> tuple[list[str], str, dict[str, str]]:
         """
         Materialize DANDI asset selections into local session directories.
 
@@ -565,7 +567,7 @@ class ParameterForm:
             dandi_uri_map[session_directory] = uri
         return folder_names, output_root, dandi_uri_map
 
-    def setup_group_parameters(self):
+    def setup_group_parameters(self) -> None:
         """Build all widgets for the group-analysis card and store them as instance attributes."""
         self.mark_down_2 = pn.pane.Markdown(
             """**Select folders for the average analysis from the file selector below**""", width=600
@@ -588,7 +590,7 @@ class ParameterForm:
             self.group_analysis_wd_1, title="Group Analysis", styles=self.styles, width=1000, collapsed=True
         )
 
-    def setup_visualization_parameters(self):
+    def setup_visualization_parameters(self) -> None:
         """Build all widgets for the visualization-parameters card and store them as instance attributes."""
         self.visualizeAverageResults = pn.widgets.Select(
             name="Visualize Average Results? (bool)", value=False, options=[True, False], width=435
@@ -603,7 +605,7 @@ class ParameterForm:
             self.visualization_wd, title="Visualization Parameters", styles=self.styles, width=1000, collapsed=True
         )
 
-    def add_to_template(self):
+    def add_to_template(self) -> None:
         """Append the input/output folder, individual, group, and visualization cards to the template's main area."""
         self.template.main.append(self.input_folder_selection)
         self.template.main.append(self.output_folder_selection)
@@ -611,7 +613,7 @@ class ParameterForm:
         self.template.main.append(self.group)
         self.template.main.append(self.visualize)
 
-    def getInputParameters(self):
+    def getInputParameters(self) -> dict[str, object]:
         """Collect and return all current widget values as an input-parameters dictionary.
 
         Returns

--- a/src/guppy/frontend/npm_gui_prompts.py
+++ b/src/guppy/frontend/npm_gui_prompts.py
@@ -26,7 +26,7 @@ def _validate_timestamp_configuration(*, timestamp_column_name: str, time_unit: 
 
 
 # get_multi_event_responses is not covered by tests due to flaky behavior of tkinter messagebox in testing environments.
-def get_multi_event_responses(multiple_event_ttls):  # pragma: no cover
+def get_multi_event_responses(multiple_event_ttls: list[bool]) -> list[bool]:  # pragma: no cover
     """Prompt the user to confirm whether each TTL file contains multiple event types.
 
     Parameters
@@ -63,7 +63,9 @@ def get_multi_event_responses(multiple_event_ttls):  # pragma: no cover
 
 
 # get_timestamp_configuration is not covered by tests due to the use of tkinter GUI elements in the function.
-def get_timestamp_configuration(ts_unit_needs, col_names_ts):  # pragma: no cover
+def get_timestamp_configuration(
+    ts_unit_needs: list[bool], col_names_ts: list[str]
+) -> tuple[list[str], list[str | None]]:  # pragma: no cover
     """Prompt the user to select the timestamp column and time unit for each NPM session.
 
     Parameters

--- a/src/guppy/frontend/parameterized_plotter.py
+++ b/src/guppy/frontend/parameterized_plotter.py
@@ -27,7 +27,7 @@ logging.getLogger("bokeh.io.export").setLevel(logging.ERROR)
 
 
 # remove unnecessary column names
-def remove_cols(cols):
+def remove_cols(cols: list[str]) -> list[str]:
     """Remove bookkeeping columns from a PSTH column list.
 
     Drops ``"err"``, ``"timestamps"``, and any column matching ``bin_err_*``
@@ -52,7 +52,7 @@ def remove_cols(cols):
 
 
 # make a new directory for saving plots
-def make_dir(filepath):
+def make_dir(filepath: str) -> str:
     """Create (if needed) and return the ``saved_plots`` subdirectory under ``filepath``.
 
     Parameters
@@ -72,7 +72,7 @@ def make_dir(filepath):
     return op
 
 
-def _headless_chrome_options():
+def _headless_chrome_options() -> Options:
     options = Options()
     options.add_argument("--headless")
     options.add_argument("--no-sandbox")
@@ -133,7 +133,7 @@ class ParameterizedPlotter(param.Parameterized):
     results_hm = dict()
     results_psth = dict()
 
-    def __init__(self, **params):
+    def __init__(self, **params: object) -> None:
         super().__init__(**params)
         # Bind selector objects from companion params
         self.param.event_selector.objects = self.event_selector_objects
@@ -157,7 +157,7 @@ class ParameterizedPlotter(param.Parameterized):
 
     # function to save heatmaps when save button on heatmap tab is clicked
     @param.depends("save_hm", watch=True)
-    def save_hm_plots(self):
+    def save_hm_plots(self) -> None:
         """Export the current heatmap to disk in the format selected by ``save_options_heatmap``."""
         plot = self.results_hm["plot"]
         op = self.results_hm["op"]
@@ -182,7 +182,7 @@ class ParameterizedPlotter(param.Parameterized):
 
     # function to save PSTH plots when save button on PSTH tab is clicked
     @param.depends("save_psth", watch=True)
-    def save_psth_plot(self):
+    def save_psth_plot(self) -> None:
         """Export the current PSTH plots to disk in the format selected by ``save_options``."""
         plot, op = [], []
         plot.append(self.results_psth["plot_combine"])
@@ -210,7 +210,7 @@ class ParameterizedPlotter(param.Parameterized):
 
     # function to change Y values based on event selection
     @param.depends("event_selector", watch=True)
-    def _update_x_y(self):
+    def _update_x_y(self) -> None:
         x_value = self.columns_dict[self.event_selector]
         y_value = self.columns_dict[self.event_selector]
         self.param["x"].objects = [x_value[-4]]
@@ -219,7 +219,7 @@ class ParameterizedPlotter(param.Parameterized):
         self.y = self.param["y"].objects[-2]
 
     @param.depends("event_selector_heatmap", watch=True)
-    def _update_df(self):
+    def _update_df(self) -> None:
         cols = self.columns_dict[self.event_selector_heatmap]
         trial_no = range(1, len(remove_cols(cols)[:-2]) + 1)
         trial_ts = ["{} - {}".format(i, j) for i, j in zip(trial_no, remove_cols(cols)[:-2])] + ["All"]
@@ -227,7 +227,7 @@ class ParameterizedPlotter(param.Parameterized):
         self.heatmap_y = [trial_ts[-1]]
 
     @param.depends("event_selector", watch=True)
-    def _update_psth_y(self):
+    def _update_psth_y(self) -> None:
         cols = self.columns_dict[self.event_selector]
         trial_no = range(1, len(remove_cols(cols)[:-2]) + 1)
         trial_ts = ["{} - {}".format(i, j) for i, j in zip(trial_no, remove_cols(cols)[:-2])]
@@ -245,7 +245,7 @@ class ParameterizedPlotter(param.Parameterized):
         "Height_Plot",
         "Width_Plot",
     )
-    def update_selector(self):
+    def update_selector(self) -> hv.NdOverlay | None:
         """Render an overlay of mean PSTH curves for all selected events.
 
         Returns
@@ -335,7 +335,7 @@ class ParameterizedPlotter(param.Parameterized):
     @param.depends(
         "event_selector", "x", "y", "Y_Label", "save_options", "Y_Limit", "X_Limit", "Height_Plot", "Width_Plot"
     )
-    def contPlot(self):
+    def contPlot(self) -> hv.Element:
         """Render the selected PSTH view (mean, single trial, or all-trials datashaded overlay).
 
         Returns
@@ -470,7 +470,7 @@ class ParameterizedPlotter(param.Parameterized):
         "Height_Plot",
         "Width_Plot",
     )
-    def plot_specific_trials(self):
+    def plot_specific_trials(self) -> hv.Element | None:
         """Render the user-selected subset of PSTH trials, optionally with their mean.
 
         Returns
@@ -574,7 +574,7 @@ class ParameterizedPlotter(param.Parameterized):
 
     # function to show heatmaps for each event
     @param.depends("event_selector_heatmap", "color_map", "height_heatmap", "width_heatmap", "heatmap_y")
-    def heatmap(self):
+    def heatmap(self) -> hv.Element:
         """Render a trial heatmap for the selected event.
 
         Returns

--- a/src/guppy/frontend/progress.py
+++ b/src/guppy/frontend/progress.py
@@ -9,7 +9,7 @@ PB_STEPS_FILE = os.path.join(os.path.expanduser("~"), "pbSteps.txt")
 PB_ERROR_FILE = os.path.join(os.path.expanduser("~"), "pbError.txt")
 
 
-def subprocess_main_handler(func):
+def subprocess_main_handler(func: object) -> object:
     """Decorate an orchestration subprocess entry point with shared error reporting.
 
     On success, logs the banner separator. On exception, writes the error message
@@ -19,7 +19,7 @@ def subprocess_main_handler(func):
     """
 
     @functools.wraps(func)
-    def wrapper(input_parameters):
+    def wrapper(input_parameters: dict[str, object]) -> object:
         try:
             result = func(input_parameters)
             logger.info("#" * 400)
@@ -34,7 +34,9 @@ def subprocess_main_handler(func):
     return wrapper
 
 
-def readPBIncrementValues(progressBar, *, file_path, error_file_path=PB_ERROR_FILE):  # pragma: no cover
+def readPBIncrementValues(
+    progressBar: object, *, file_path: str, error_file_path: str = PB_ERROR_FILE
+) -> str | None:  # pragma: no cover
     """Read progress bar values from file and update the progress bar widget.
 
     Returns the error message string if the subprocess reported a failure,
@@ -88,7 +90,7 @@ def readPBIncrementValues(progressBar, *, file_path, error_file_path=PB_ERROR_FI
     return error_message
 
 
-def writeToFile(value: str, *, file_path):
+def writeToFile(value: str, *, file_path: str) -> None:
     """Append ``value`` to the file at ``file_path``, creating it if necessary.
 
     Parameters

--- a/src/guppy/frontend/sidebar.py
+++ b/src/guppy/frontend/sidebar.py
@@ -14,13 +14,13 @@ class Sidebar:
         The Panel template whose ``sidebar`` area will receive the widgets.
     """
 
-    def __init__(self, template):
+    def __init__(self, template: object) -> None:
         self.template = template
         self.setup_markdown()
         self.setup_buttons()
         self.setup_progress_bars()
 
-    def setup_markdown(self):
+    def setup_markdown(self) -> None:
         """Create step-label ``Markdown`` panes and store them as instance attributes."""
         self.mark_down_ip = pn.pane.Markdown("""**Step 1 : Save Input Parameters**""", width=300)
         self.mark_down_ip_note = pn.pane.Markdown(
@@ -39,7 +39,7 @@ class Sidebar:
         self.mark_down_psth = pn.pane.Markdown("""**Step 5 : PSTH Computation**""", width=300)
         self.mark_down_visualization = pn.pane.Markdown("""**Step 6 : Visualization**""", width=300)
 
-    def setup_buttons(self):
+    def setup_buttons(self) -> None:
         """Create pipeline-step action buttons and store them as instance attributes."""
         self.open_storenames = pn.widgets.Button(
             name="Open Storenames GUI", button_type="primary", width=300, align="end"
@@ -56,7 +56,7 @@ class Sidebar:
         )
         self.save_button = pn.widgets.Button(name="Save to file...", button_type="primary", width=300, align="end")
 
-    def attach_callbacks(self, button_name_to_onclick_fn: dict):
+    def attach_callbacks(self, button_name_to_onclick_fn: dict[str, object]) -> None:
         """Register click-handler callbacks on sidebar buttons.
 
         Parameters
@@ -69,13 +69,13 @@ class Sidebar:
             button = getattr(self, button_name)
             button.on_click(onclick_fn)
 
-    def setup_progress_bars(self):
+    def setup_progress_bars(self) -> None:
         """Create ``Progress`` indicator widgets for the read, extract, and PSTH steps."""
         self.read_progress = pn.indicators.Progress(name="Progress", value=100, max=100, width=300)
         self.extract_progress = pn.indicators.Progress(name="Progress", value=100, max=100, width=300)
         self.psth_progress = pn.indicators.Progress(name="Progress", value=100, max=100, width=300)
 
-    def add_to_template(self):
+    def add_to_template(self) -> None:
         """Append all sidebar widgets to the template's sidebar area in pipeline order."""
         self.template.sidebar.append(self.mark_down_ip)
         self.template.sidebar.append(self.mark_down_ip_note)

--- a/src/guppy/frontend/storenames_config.py
+++ b/src/guppy/frontend/storenames_config.py
@@ -35,12 +35,12 @@ class StorenamesConfig:
 
     def __init__(
         self,
-        show_config_button,
-        storename_dropdowns,
-        storename_textboxes,
-        storenames,
-        storenames_cache,
-    ):
+        show_config_button: pn.widgets.Button,
+        storename_dropdowns: dict[str, pn.widgets.Select],
+        storename_textboxes: dict[str, pn.widgets.TextInput],
+        storenames: list[str],
+        storenames_cache: dict[str, list[str]],
+    ) -> None:
         self.config_widgets = []
         self._dropdown_help_map = {}
         storename_dropdowns.clear()
@@ -68,14 +68,14 @@ class StorenamesConfig:
             )
         )
 
-    def _on_dropdown_value_change(self, event):
+    def _on_dropdown_value_change(self, event: object) -> None:
         help_pane = self._dropdown_help_map.get(event.obj)
         if help_pane is None:
             return
         dropdown_value = event.new
         help_pane.object = self._get_help_text(dropdown_value=dropdown_value)
 
-    def _get_help_text(self, dropdown_value):
+    def _get_help_text(self, dropdown_value: str) -> str:
         if dropdown_value == "control":
             return "*Type appropriate region name*"
         elif dropdown_value == "signal":
@@ -85,7 +85,7 @@ class StorenamesConfig:
         else:
             return ""
 
-    def _parse_cached_value(self, cached_value):
+    def _parse_cached_value(self, cached_value: str) -> tuple[str, str]:
         # Split an assembled cache entry back into (type, name) for pre-populating widgets
         if cached_value.startswith("control_"):
             return "control", cached_value[len("control_") :]
@@ -96,7 +96,14 @@ class StorenamesConfig:
         else:
             return "", ""
 
-    def setup_storename(self, i, storename, storename_dropdowns, storename_textboxes, storenames_cache):
+    def setup_storename(
+        self,
+        i: int,
+        storename: str,
+        storename_dropdowns: dict[str, pn.widgets.Select],
+        storename_textboxes: dict[str, pn.widgets.TextInput],
+        storenames_cache: dict[str, list[str]],
+    ) -> None:
         """Build and register a configuration row for a single storename.
 
         Parameters

--- a/src/guppy/frontend/storenames_instructions.py
+++ b/src/guppy/frontend/storenames_instructions.py
@@ -23,7 +23,7 @@ class StorenamesInstructions:
         heading above the instructions.
     """
 
-    def __init__(self, folder_path):
+    def __init__(self, folder_path: str) -> None:
         # instructions about how to save the storeslist file
         self.mark_down = pn.pane.Markdown(
             """
@@ -78,7 +78,7 @@ class StorenamesInstructionsNPM(StorenamesInstructions):
         contain ``chev``, ``chod``, or ``chpr`` are loaded for preview.
     """
 
-    def __init__(self, folder_path):
+    def __init__(self, folder_path: str) -> None:
         super().__init__(folder_path=folder_path)
         path_chev = glob.glob(os.path.join(folder_path, "*chev*"))
         path_chod = glob.glob(os.path.join(folder_path, "*chod*"))
@@ -123,8 +123,8 @@ class StorenamesInstructionsNPM(StorenamesInstructions):
             self.plot_pane,
         )
 
-    def _make_plot(self, plot_key):
+    def _make_plot(self, plot_key: str) -> hv.Curve:
         return hv.Curve((self.d[plot_key]["x"], self.d[plot_key]["y"])).opts(width=550)
 
-    def _on_plot_select_change(self, event):
+    def _on_plot_select_change(self, event: object) -> None:
         self.plot_pane.object = self._make_plot(event.new)

--- a/src/guppy/frontend/storenames_selector.py
+++ b/src/guppy/frontend/storenames_selector.py
@@ -20,7 +20,7 @@ class StorenamesSelector:
         options in the cross-selector and multi-choice widgets.
     """
 
-    def __init__(self, allnames):
+    def __init__(self, allnames: list[str]) -> None:
         self.alert = pn.pane.Alert("#### No alerts !!", alert_type="danger", height=80, width=600)
         if len(allnames) == 0:
             self.alert.object = (
@@ -116,7 +116,7 @@ class StorenamesSelector:
             self.path,
         )
 
-    def callback(self, target, event):
+    def callback(self, target: pn.WidgetBox, event: object) -> None:
         """Show or hide the storenames-to-repeat widget box based on the checkbox state.
 
         Parameters
@@ -132,7 +132,7 @@ class StorenamesSelector:
         elif event.new == False:
             target.clear()
 
-    def get_select_location(self):
+    def get_select_location(self) -> str:
         """Return the currently selected overwrite-location option.
 
         Returns
@@ -142,7 +142,7 @@ class StorenamesSelector:
         """
         return self.select_location.value
 
-    def set_select_location_options(self, options):
+    def set_select_location_options(self, options: list[str]) -> None:
         """Replace the options in the overwrite-location selector.
 
         Parameters
@@ -152,7 +152,7 @@ class StorenamesSelector:
         """
         self.select_location.options = options
 
-    def set_alert_message(self, message):
+    def set_alert_message(self, message: str) -> None:
         """Set the text shown in the alert pane.
 
         Parameters
@@ -162,7 +162,7 @@ class StorenamesSelector:
         """
         self.alert.object = message
 
-    def get_literal_input_2(self):  # TODO: come up with a better name for this method.
+    def get_literal_input_2(self) -> dict[str, object]:  # TODO: come up with a better name for this method.
         """Parse and return the JSON storenames mapping from the code editor widget.
 
         Returns
@@ -173,7 +173,9 @@ class StorenamesSelector:
         storenames_config = json.loads(self.literal_input_2.value)
         return storenames_config
 
-    def set_literal_input_2(self, storenames_config):  # TODO: come up with a better name for this method.
+    def set_literal_input_2(
+        self, storenames_config: dict[str, object]
+    ) -> None:  # TODO: come up with a better name for this method.
         """Serialise ``storenames_config`` as pretty-printed JSON and set the code editor value.
 
         Parameters
@@ -183,7 +185,7 @@ class StorenamesSelector:
         """
         self.literal_input_2.value = str(json.dumps(storenames_config, indent=2))
 
-    def get_take_widgets(self):
+    def get_take_widgets(self) -> list[object]:
         """Return the current values of the repeat-storenames widgets.
 
         Returns
@@ -194,7 +196,7 @@ class StorenamesSelector:
         """
         return [w.value for w in self.take_widgets]
 
-    def set_change_widgets(self, value):
+    def set_change_widgets(self, value: object) -> None:
         """Set all ``change_widgets`` to ``value``.
 
         Parameters
@@ -205,7 +207,7 @@ class StorenamesSelector:
         for w in self.change_widgets:
             w.value = value
 
-    def get_cross_selector(self):
+    def get_cross_selector(self) -> list[str]:
         """Return the storenames currently selected in the cross-selector.
 
         Returns
@@ -215,7 +217,7 @@ class StorenamesSelector:
         """
         return self.cross_selector.value
 
-    def set_path(self, value):
+    def set_path(self, value: str) -> None:
         """Set the displayed path in the location text input.
 
         Parameters
@@ -225,7 +227,7 @@ class StorenamesSelector:
         """
         self.path.value = value
 
-    def attach_callbacks(self, button_name_to_onclick_fn: dict):
+    def attach_callbacks(self, button_name_to_onclick_fn: dict[str, object]) -> None:
         """Register click-handler callbacks on selector buttons.
 
         Parameters
@@ -240,7 +242,7 @@ class StorenamesSelector:
                 # Wrap the user callback so we can also remember the current
                 # mode (for get_overwrite_mode) and hide the run-name field in
                 # overwrite mode where it has no effect.
-                def remember_then_call(event, _user_callback=onclick_fn):
+                def remember_then_call(event: object, _user_callback: object = onclick_fn) -> None:
                     self._current_overwrite_mode = event.new
                     self.run_name.visible = event.new == "create_new_file"
                     _user_callback(event)
@@ -249,7 +251,7 @@ class StorenamesSelector:
             else:
                 button.on_click(onclick_fn)
 
-    def attach_run_name_watcher(self, callback):
+    def attach_run_name_watcher(self, callback: object) -> None:
         """Attach a watcher that fires when the run-name TextInput value changes.
 
         Parameters
@@ -260,7 +262,7 @@ class StorenamesSelector:
         """
         self.run_name.param.watch(callback, "value")
 
-    def get_run_name(self):
+    def get_run_name(self) -> str:
         """Return the current value of the run-name TextInput.
 
         Returns
@@ -270,7 +272,7 @@ class StorenamesSelector:
         """
         return self.run_name.value
 
-    def get_overwrite_mode(self):
+    def get_overwrite_mode(self) -> str:
         """Return the current overwrite-vs-create mode.
 
         Returns
@@ -280,7 +282,13 @@ class StorenamesSelector:
         """
         return self._current_overwrite_mode
 
-    def configure_storenames(self, storename_dropdowns, storename_textboxes, storenames, storenames_cache):
+    def configure_storenames(
+        self,
+        storename_dropdowns: dict[str, pn.widgets.Select],
+        storename_textboxes: dict[str, pn.widgets.TextInput],
+        storenames: list[str],
+        storenames_cache: dict[str, list[str]],
+    ) -> None:
         """Build the storename-configuration panel and make it visible.
 
         Parameters

--- a/src/guppy/frontend/visualization_dashboard.py
+++ b/src/guppy/frontend/visualization_dashboard.py
@@ -26,13 +26,13 @@ class VisualizationDashboard:
         Session name displayed as the tab title.
     """
 
-    def __init__(self, *, plotter, basename):
+    def __init__(self, *, plotter: object, basename: str) -> None:
         self.plotter = plotter
         self.basename = basename
         self._psth_tab = self._build_psth_tab()
         self._heatmap_tab = self._build_heatmap_tab()
 
-    def _build_psth_tab(self):
+    def _build_psth_tab(self) -> pn.Column:
         """Build the PSTH tab with controls and plot panels."""
         psth_checkbox = pn.Param(
             self.plotter.param.select_trials_checkbox,
@@ -108,7 +108,7 @@ class VisualizationDashboard:
             self.plotter.plot_specific_trials,
         )
 
-    def _build_heatmap_tab(self):
+    def _build_heatmap_tab(self) -> pn.Column:
         """Build the heatmap tab with controls and plot panels."""
         heatmap_y_parameters = pn.Param(
             self.plotter.param.heatmap_y,
@@ -148,14 +148,14 @@ class VisualizationDashboard:
             pn.Row(self.plotter.heatmap, heatmap_y_parameters),
         )
 
-    def build_template(self):
+    def build_template(self) -> pn.template.MaterialTemplate:
         """Build and return the Panel template without serving it."""
         template = pn.template.MaterialTemplate(title="Visualization GUI")
         app = pn.Tabs(("PSTH", self._psth_tab), ("Heat Map", self._heatmap_tab))
         template.main.append(app)
         return template
 
-    def show(self):
+    def show(self) -> None:
         """Serve the dashboard in a browser on an available port."""
         logger.info("app")
         template = self.build_template()


### PR DESCRIPTION
## Summary

- Annotates all function arguments and return types across all 12 frontend modules to satisfy ruff `ANN` rules added in #346
- Key type choices: `dict[str, object]` for parameter dicts (ANN401-compliant), `object` for Panel/param event callback arguments and opaque template args, concrete Panel types (`pn.Column`, `pn.pane.Markdown`, etc.) for Panel return types, `hv.Element`/`hv.NdOverlay` for HoloViews returns
- `pre-commit run ruff` passes cleanly on all changed files

## Test plan

- [x] `pre-commit run ruff --files src/guppy/frontend/*.py` — Passed
- [x] `pytest tests/unit/frontend/ -v` — 183 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)