### PR TITLE
Ensure Temporal alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Added type hints to all functions in the utils, visualization, testing, and root layers. [PR #347](https://github.com/LernerLab/GuPPy/pull/347)
 
 ## Fixes
+- Stored event timestamps now share the recording-start time basis with the continuous `timestampNew` stream instead of being re-zeroed to `timeForLightsTurnOn`, so all series can be co-registered without per-stream offset bookkeeping (PSTH results are unchanged). Resolves [#355](https://github.com/LernerLab/GuPPy/issues/355).
 - Fixed bug with step five, which was causing the baseline uncorrected HDF5 file to not exist. [PR #241](https://github.com/LernerLab/GuPPy/pull/241)
 
 ## Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Added type hints to all functions in the utils, visualization, testing, and root layers. [PR #347](https://github.com/LernerLab/GuPPy/pull/347)
 
 ## Fixes
-- Stored event timestamps now share the recording-start time basis with the continuous `timestampNew` stream instead of being re-zeroed to `timeForLightsTurnOn`, so all series can be co-registered without per-stream offset bookkeeping (PSTH results are unchanged). Resolves [#355](https://github.com/LernerLab/GuPPy/issues/355).
+- Stored event timestamps now share the recording-start time basis with the continuous `timestampNew` stream instead of being re-zeroed to `timeForLightsTurnOn`, so all series can be co-registered without per-stream offset bookkeeping (PSTH results are unchanged). Resolves [#355](https://github.com/LernerLab/GuPPy/issues/355). [PR #356](https://github.com/LernerLab/GuPPy/pull/356)
 - Fixed bug with step five, which was causing the baseline uncorrected HDF5 file to not exist. [PR #241](https://github.com/LernerLab/GuPPy/pull/241)
 
 ## Improvements

--- a/src/guppy/analysis/artifact_removal.py
+++ b/src/guppy/analysis/artifact_removal.py
@@ -306,6 +306,8 @@ def eliminateTs(
     ts_arr = np.array([])
     tsNew_arr = np.array([])
     for i in range(coords.shape[0]):
+        # tsNew (continuous) and ts (events) are both on the recording-start basis, matching
+        # the basis of the artifact-removal coords, so both windowing comparisons are consistent.
         tsNew_index = np.where((tsNew > coords[i, 0]) & (tsNew < coords[i, 1]))[0]
         ts_index = np.where((ts > coords[i, 0]) & (ts < coords[i, 1]))[0]
 

--- a/src/guppy/analysis/combine_data.py
+++ b/src/guppy/analysis/combine_data.py
@@ -92,6 +92,9 @@ def eliminateTs(
     for filepath in filepaths:
         tsNew = filepath_to_timestamps[filepath]
         ts = filepath_to_ttl_timestamps[filepath]
+        # Both tsNew (continuous) and ts (events) are on the recording-start basis, so the
+        # same per-session shift keeps them mutually aligned. Inter-session bridging below
+        # uses differences only, which are basis-invariant.
         if len(tsNew_arr) == 0:
             sub = tsNew[0] - timeForLightsTurnOn
             tsNew_arr = np.concatenate((tsNew_arr, tsNew - sub))

--- a/src/guppy/analysis/compute_psth.py
+++ b/src/guppy/analysis/compute_psth.py
@@ -57,7 +57,9 @@ def compute_psth(
     ts : np.ndarray
         Event timestamp array (s).
     corrected_timestamps : np.ndarray
-        Full corrected photometry timestamp array used for time-based binning.
+        Full corrected photometry timestamp array (recording-start basis). Its first
+        value is the signal start used to map event times to z-score sample indices,
+        and the array is also used for time-based binning.
 
     Returns
     -------
@@ -83,11 +85,14 @@ def compute_psth(
     timeAxis = np.linspace(nSecPrev, nSecPost + increment, totalTs + 1)
     timeAxisNew = np.concatenate((timeAxis, timeAxis[::-1]))
 
-    # reject timestamps for which baseline cannot be calculated because of nan values
+    # reject timestamps for which baseline cannot be calculated because of nan values.
+    # Events are on the recording-start basis (same as corrected_timestamps), so the
+    # time available before an event is measured from the signal start, corrected_timestamps[0].
+    stream_start = corrected_timestamps[0]
     new_ts = []
     for i in range(ts.shape[0]):
-        thisTime = ts[i]  # -1 not needed anymore
-        if thisTime < abs(baselineStart):
+        thisTime = ts[i]
+        if (thisTime - stream_start) < abs(baselineStart):
             continue
         else:
             new_ts.append(ts[i])
@@ -119,8 +124,11 @@ def compute_psth(
 
     # for each timestamp, create trial which will be saved in a PSTH vector
     for i in range(nTs):
-        thisTime = ts[i]  # -timeForLightsTurnOn
-        thisIndex = int(round(thisTime * sampling_rate))
+        thisTime = ts[i]
+        # Events share the recording-start basis with the continuous stream, so map an
+        # event time to its positional index in z_score relative to the signal start
+        # (z_score[0] corresponds to corrected_timestamps[0]).
+        thisIndex = int(round((thisTime - stream_start) * sampling_rate))
         # nSecPrev (and therefore nTsPrev) is negative by convention; flip to a positive
         # sample count for rowFormation, which expects nTsPrev as a positive lookback length.
         arr = rowFormation(z_score, thisIndex, -1 * nTsPrev, nTsPost)

--- a/src/guppy/analysis/compute_psth.py
+++ b/src/guppy/analysis/compute_psth.py
@@ -22,6 +22,7 @@ def compute_psth(
     sampling_rate: float,
     ts: np.ndarray,
     corrected_timestamps: np.ndarray,
+    timeForLightsTurnOn: float,
 ) -> tuple[np.ndarray, np.ndarray, list[object], np.ndarray]:
     """
     Build a peri-stimulus time histogram (PSTH) matrix for one event.
@@ -57,9 +58,12 @@ def compute_psth(
     ts : np.ndarray
         Event timestamp array (s).
     corrected_timestamps : np.ndarray
-        Full corrected photometry timestamp array (recording-start basis). Its first
-        value is the signal start used to map event times to z-score sample indices,
-        and the array is also used for time-based binning.
+        Full corrected photometry timestamp array (recording-start basis), used for
+        time-based binning.
+    timeForLightsTurnOn : float
+        Lights-on offset (s). Events are stored on the recording-start basis while
+        ``z_score[0]`` corresponds to the lights-on instant, so event times are mapped
+        to z-score sample indices relative to ``timeForLightsTurnOn``.
 
     Returns
     -------
@@ -86,13 +90,12 @@ def compute_psth(
     timeAxisNew = np.concatenate((timeAxis, timeAxis[::-1]))
 
     # reject timestamps for which baseline cannot be calculated because of nan values.
-    # Events are on the recording-start basis (same as corrected_timestamps), so the
-    # time available before an event is measured from the signal start, corrected_timestamps[0].
-    stream_start = corrected_timestamps[0]
+    # Events are on the recording-start basis; z_score[0] is the lights-on instant, so the
+    # time available before an event is measured relative to timeForLightsTurnOn.
     new_ts = []
     for i in range(ts.shape[0]):
         thisTime = ts[i]
-        if (thisTime - stream_start) < abs(baselineStart):
+        if (thisTime - timeForLightsTurnOn) < abs(baselineStart):
             continue
         else:
             new_ts.append(ts[i])
@@ -125,10 +128,9 @@ def compute_psth(
     # for each timestamp, create trial which will be saved in a PSTH vector
     for i in range(nTs):
         thisTime = ts[i]
-        # Events share the recording-start basis with the continuous stream, so map an
-        # event time to its positional index in z_score relative to the signal start
-        # (z_score[0] corresponds to corrected_timestamps[0]).
-        thisIndex = int(round((thisTime - stream_start) * sampling_rate))
+        # Events are on the recording-start basis; z_score[0] corresponds to the lights-on
+        # instant, so subtract timeForLightsTurnOn to get the positional index into z_score.
+        thisIndex = int(round((thisTime - timeForLightsTurnOn) * sampling_rate))
         # nSecPrev (and therefore nTsPrev) is negative by convention; flip to a positive
         # sample count for rowFormation, which expects nTsPrev as a positive lookback length.
         arr = rowFormation(z_score, thisIndex, -1 * nTsPrev, nTsPost)
@@ -146,7 +148,9 @@ def compute_psth(
 
     if use_time_or_trials == "Time (min)" and bin_psth_trials > 0:
         corrected_timestamps = np.divide(corrected_timestamps, 60)
-        ts_min = np.divide(ts, 60)
+        # Bins are built from the continuous timestamps (recording-start basis); shift events
+        # by timeForLightsTurnOn so both sit on the lights-on origin the bin edges assume.
+        ts_min = np.divide(ts - timeForLightsTurnOn, 60)
         bin_steps = np.arange(corrected_timestamps[0], corrected_timestamps[-1] + bin_psth_trials, bin_psth_trials)
         indices_each_step = dict()
         for i in range(1, bin_steps.shape[0]):

--- a/src/guppy/analysis/timestamp_correction.py
+++ b/src/guppy/analysis/timestamp_correction.py
@@ -236,12 +236,20 @@ def applyCorrection_ttl(
     mode: str,
 ) -> np.ndarray:
     """
-    Shift TTL timestamps to align with the corrected photometry time base.
+    Shift TTL timestamps onto the recording-start time base.
+
+    Events are placed on the same recording-start basis as the continuous
+    ``timestampNew`` stream (see :func:`timestampCorrection`): for TDT the
+    recording start (``timeRecStart``) is subtracted; for CSV the timestamps are
+    already recording-relative and are returned unchanged. Events are *not*
+    re-zeroed to ``timeForLightsTurnOn`` — keeping both streams on one shared
+    origin so consumers can co-register them without per-stream offset bookkeeping.
 
     Parameters
     ----------
     timeForLightsTurnOn : float
-        Seconds offset for the new time zero.
+        Seconds offset of the lights-on instant; retained for API compatibility
+        but no longer used to shift events.
     timeRecStart : float
         Absolute start time of the recording (TDT only; ignored for CSV).
     ttl_timestamps : np.ndarray
@@ -252,18 +260,15 @@ def applyCorrection_ttl(
     Returns
     -------
     corrected_ttl_timestamps : np.ndarray
-        TTL timestamps shifted to the corrected time base.
+        TTL timestamps on the recording-start time base.
     """
     corrected_ttl_timestamps = ttl_timestamps
     if mode == "tdt":
         res = (corrected_ttl_timestamps >= timeRecStart).all()
+        # When all TTLs are on the recording clock, rebase them to recording start.
+        # Otherwise they are not on the recording clock; leave them as-is (rare path).
         if res == True:
             corrected_ttl_timestamps = np.subtract(corrected_ttl_timestamps, timeRecStart)
-            corrected_ttl_timestamps = np.subtract(corrected_ttl_timestamps, timeForLightsTurnOn)
-        else:
-            corrected_ttl_timestamps = np.subtract(corrected_ttl_timestamps, timeForLightsTurnOn)
-    elif mode == "csv":
-        corrected_ttl_timestamps = np.subtract(corrected_ttl_timestamps, timeForLightsTurnOn)
     return corrected_ttl_timestamps
 
 

--- a/src/guppy/orchestration/psth.py
+++ b/src/guppy/orchestration/psth.py
@@ -63,6 +63,7 @@ def execute_compute_psth(filepath: str, event: str, inputParameters: dict[str, o
     nSecPrev, nSecPost = inputParameters["nSecPrev"], inputParameters["nSecPost"]
     baselineStart, baselineEnd = inputParameters["baselineCorrectionStart"], inputParameters["baselineCorrectionEnd"]
     timeInterval = inputParameters["timeInterval"]
+    timeForLightsTurnOn = inputParameters["timeForLightsTurnOn"]
 
     if selectForComputePsth == "z_score":
         path = glob.glob(os.path.join(filepath, "z_score_*"))
@@ -89,9 +90,10 @@ def execute_compute_psth(filepath: str, event: str, inputParameters: dict[str, o
 
         sampling_rate = read_hdf5("timeCorrection_" + name_1, filepath, "sampling_rate")[0]
         ts = read_hdf5(event + "_" + name_1, filepath, "ts")
-        # compute_psth needs the continuous timestamps unconditionally: its first value
-        # is the signal start used to map event times onto z-score sample indices.
-        corrected_timestamps = read_hdf5("timeCorrection_" + name_1, filepath, "timestampNew")
+        if use_time_or_trials == "Time (min)" and bin_psth_trials > 0:
+            corrected_timestamps = read_hdf5("timeCorrection_" + name_1, filepath, "timestampNew")
+        else:
+            corrected_timestamps = None
         psth, psth_baselineUncorrected, cols, ts = compute_psth(
             z_score,
             event,
@@ -108,6 +110,7 @@ def execute_compute_psth(filepath: str, event: str, inputParameters: dict[str, o
             sampling_rate,
             ts,
             corrected_timestamps,
+            timeForLightsTurnOn,
         )
         write_hdf5(ts, event + "_" + name_1, filepath, "ts")
 

--- a/src/guppy/orchestration/psth.py
+++ b/src/guppy/orchestration/psth.py
@@ -89,10 +89,9 @@ def execute_compute_psth(filepath: str, event: str, inputParameters: dict[str, o
 
         sampling_rate = read_hdf5("timeCorrection_" + name_1, filepath, "sampling_rate")[0]
         ts = read_hdf5(event + "_" + name_1, filepath, "ts")
-        if use_time_or_trials == "Time (min)" and bin_psth_trials > 0:
-            corrected_timestamps = read_hdf5("timeCorrection_" + name_1, filepath, "timestampNew")
-        else:
-            corrected_timestamps = None
+        # compute_psth needs the continuous timestamps unconditionally: its first value
+        # is the signal start used to map event times onto z-score sample indices.
+        corrected_timestamps = read_hdf5("timeCorrection_" + name_1, filepath, "timestampNew")
         psth, psth_baselineUncorrected, cols, ts = compute_psth(
             z_score,
             event,

--- a/src/guppy/testing/consistency.py
+++ b/src/guppy/testing/consistency.py
@@ -37,6 +37,7 @@ def compare_output_folders(
     name_map: dict[str, str | None] | None = None,
     rtol: float = 1e-5,
     atol: float = 1e-8,
+    event_ts_offset: float = 0.0,
 ) -> None:
     """
     Assert that every file in ``expected_dir`` exists in ``actual_dir`` and is
@@ -65,6 +66,14 @@ def compare_output_folders(
         Relative tolerance for numeric comparisons (default 1e-5).
     atol : float
         Absolute tolerance for numeric comparisons (default 1e-8).
+    event_ts_offset : float
+        Seconds added to reference event timestamps before comparison (default 0.0).
+        Reconciles the issue-#355 basis change: current event timestamps are on the
+        recording-start basis while the reference holds the old lights-on basis, so
+        ``current == reference + timeForLightsTurnOn``. Pass the run's
+        ``timeForLightsTurnOn`` to compare event-timestamp HDF5 datasets (key ``ts``)
+        and PSTH/peak_AUC event-time labels up to this known constant shift. All other
+        data (signals, continuous timestamps, peak/area) still compares exactly.
 
     Raises
     ------
@@ -103,9 +112,9 @@ def compare_output_folders(
 
         ext = Path(rel_path).suffix.lower()
         if ext in {".hdf5", ".h5"}:
-            _compare_hdf5(actual_path, expected_path, rel_path, mismatches, rtol, atol)
+            _compare_hdf5(actual_path, expected_path, rel_path, mismatches, rtol, atol, event_ts_offset)
         elif ext == ".csv":
-            _compare_csv(actual_path, expected_path, rel_path, mismatches, rtol, atol)
+            _compare_csv(actual_path, expected_path, rel_path, mismatches, rtol, atol, event_ts_offset)
         elif ext == ".json":
             _compare_json(actual_path, expected_path, rel_path, mismatches)
         # Unknown extensions are skipped silently.
@@ -124,9 +133,9 @@ def compare_output_folders(
 _PANDAS_AXIS_KEYS = {"axis0", "axis1", "block0_items"}
 
 
-def _normalize_psth_label(label: str) -> str:
+def _normalize_psth_label(label: str, *, bare_offset: float = 0.0, prefixed_offset: float = 0.0) -> str:
     """
-    Canonicalize a single PSTH timestamp label.
+    Canonicalize a single PSTH timestamp label, optionally adding a time offset.
 
     Two forms are handled:
     - Bare float (``"138.238440990448"``): reformatted directly.
@@ -135,27 +144,38 @@ def _normalize_psth_label(label: str) -> str:
 
     Both are rounded to 10 significant figures to eliminate platform-level
     float-repr noise.  Labels that match neither form are returned unchanged.
+
+    ``bare_offset`` and ``prefixed_offset`` shift the parsed float before
+    reformatting. They are used to reconcile the issue-#355 event-timestamp basis
+    change: reference (pre-change) event labels are on the lights-on basis, current
+    labels on the recording-start basis (= reference + ``timeForLightsTurnOn``).
+    Bare-float labels are always event timestamps; prefixed-float labels are event
+    timestamps only in ``peak_AUC`` files (elsewhere the suffix is a session-run
+    index such as ``..._output_1``), so the caller offsets bare and prefixed forms
+    independently.
     """
     if _BARE_FLOAT_RE.match(label):
-        return f"{float(label):.10g}"
+        return f"{float(label) + bare_offset:.10g}"
     m = _PREFIXED_FLOAT_RE.match(label)
     if m:
-        return f"{m.group(1)}_{float(m.group(2)):.10g}"
+        return f"{m.group(1)}_{float(m.group(2)) + prefixed_offset:.10g}"
     return label
 
 
-def _normalize_psth_index(idx: pd.Index) -> pd.Index:
+def _normalize_psth_index(idx: pd.Index, *, bare_offset: float = 0.0, prefixed_offset: float = 0.0) -> pd.Index:
     """Apply :func:`_normalize_psth_label` to every element of a pandas Index."""
-    return pd.Index([_normalize_psth_label(str(lbl)) for lbl in idx])
+    return pd.Index(
+        [_normalize_psth_label(str(lbl), bare_offset=bare_offset, prefixed_offset=prefixed_offset) for lbl in idx]
+    )
 
 
-def _normalize_psth_str_array(arr: np.ndarray) -> np.ndarray:
+def _normalize_psth_str_array(arr: np.ndarray, *, bare_offset: float = 0.0, prefixed_offset: float = 0.0) -> np.ndarray:
     """Apply :func:`_normalize_psth_label` to every element of a string/bytes array."""
     flat = []
     for item in arr.flat:
         if isinstance(item, (bytes, np.bytes_)):
             item = item.decode("utf-8", errors="replace")
-        flat.append(_normalize_psth_label(str(item)))
+        flat.append(_normalize_psth_label(str(item), bare_offset=bare_offset, prefixed_offset=prefixed_offset))
     return np.array(flat, dtype=object).reshape(arr.shape)
 
 
@@ -178,10 +198,11 @@ def _compare_hdf5(
     mismatches: list[str],
     rtol: float,
     atol: float,
+    event_ts_offset: float = 0.0,
 ) -> None:
     """Compare all datasets in two HDF5 files, accumulating mismatches."""
     with h5py.File(actual_path, "r") as actual_f, h5py.File(expected_path, "r") as expected_f:
-        _walk_hdf5_group(actual_f, expected_f, rel_path, "", mismatches, rtol, atol)
+        _walk_hdf5_group(actual_f, expected_f, rel_path, "", mismatches, rtol, atol, event_ts_offset)
 
 
 def _walk_hdf5_group(
@@ -192,6 +213,7 @@ def _walk_hdf5_group(
     mismatches: list[str],
     rtol: float,
     atol: float,
+    event_ts_offset: float = 0.0,
 ) -> None:
     """Recursively walk HDF5 groups, comparing all datasets."""
     for key in expected_group.keys():
@@ -207,12 +229,16 @@ def _walk_hdf5_group(
             if not isinstance(actual_item, h5py.Group):
                 mismatches.append(f"{rel_path}: '{item_path}' is a group in expected but a dataset in actual")
             else:
-                _walk_hdf5_group(actual_item, expected_item, rel_path, item_path, mismatches, rtol, atol)
+                _walk_hdf5_group(
+                    actual_item, expected_item, rel_path, item_path, mismatches, rtol, atol, event_ts_offset
+                )
         elif isinstance(expected_item, h5py.Dataset):
             if not isinstance(actual_item, h5py.Dataset):
                 mismatches.append(f"{rel_path}: '{item_path}' is a dataset in expected but a group in actual")
             else:
-                _compare_hdf5_dataset(actual_item, expected_item, rel_path, item_path, mismatches, rtol, atol)
+                _compare_hdf5_dataset(
+                    actual_item, expected_item, rel_path, item_path, mismatches, rtol, atol, event_ts_offset
+                )
 
 
 def _compare_hdf5_dataset(
@@ -223,6 +249,7 @@ def _compare_hdf5_dataset(
     mismatches: list[str],
     rtol: float,
     atol: float,
+    event_ts_offset: float = 0.0,
 ) -> None:
     """Compare two HDF5 datasets, handling numeric and string dtypes."""
     actual_data = actual_ds[()]
@@ -243,7 +270,8 @@ def _compare_hdf5_dataset(
     if expected_data.dtype.kind in {"S", "U", "O"}:
         item_name = item_path.split("/")[-1]
         filename = Path(rel_path).name
-        is_psth_file = "z_score" in filename or "peak_AUC" in filename or "dff" in filename
+        is_peak_auc = "peak_AUC" in filename
+        is_psth_file = "z_score" in filename or is_peak_auc or "dff" in filename
         if is_psth_file and item_name in _PANDAS_AXIS_KEYS and expected_data.size > 0:
             # Probe the first element: if it looks like a PSTH timestamp label,
             # normalize float-repr noise before comparing.
@@ -251,9 +279,17 @@ def _compare_hdf5_dataset(
             if isinstance(first, (bytes, np.bytes_)):
                 first = first.decode("utf-8", errors="replace")
             if _PSTH_LABEL_RE.match(str(first)):
+                # Bare floats are always event timestamps. Prefixed floats are event
+                # timestamps only in the peak_AUC index axis (axis1, e.g.
+                # "<session>_<event_ts>"); elsewhere the suffix is a structural index
+                # (peak_AUC columns "peak_pos_1", group session names "..._output_1").
+                # Shift the reference (expected) labels into the current basis accordingly.
+                prefixed_offset = event_ts_offset if (is_peak_auc and item_name == "axis1") else 0.0
                 if not np.array_equal(
                     _normalize_psth_str_array(actual_data),
-                    _normalize_psth_str_array(expected_data),
+                    _normalize_psth_str_array(
+                        expected_data, bare_offset=event_ts_offset, prefixed_offset=prefixed_offset
+                    ),
                 ):
                     mismatches.append(f"{rel_path}: '{item_path}' string data differs")
                 return
@@ -261,7 +297,11 @@ def _compare_hdf5_dataset(
             mismatches.append(f"{rel_path}: '{item_path}' string data differs")
         return
 
-    # Numeric datasets: tolerance-based comparison with NaN == NaN.
+    # Numeric datasets: tolerance-based comparison with NaN == NaN. Event-timestamp
+    # datasets (key "ts") moved from the lights-on to the recording-start basis, so the
+    # reference is shifted up by event_ts_offset (the run's timeForLightsTurnOn).
+    if item_path.split("/")[-1] == "ts":
+        expected_data = expected_data + event_ts_offset
     if not np.allclose(actual_data, expected_data, rtol=rtol, atol=atol, equal_nan=True):
         mismatches.append(f"{rel_path}: '{item_path}' numeric data differs")
 
@@ -273,16 +313,20 @@ def _compare_csv(
     mismatches: list[str],
     rtol: float,
     atol: float,
+    event_ts_offset: float = 0.0,
 ) -> None:
     """Compare two CSV files as DataFrames."""
     actual_df = pd.read_csv(actual_path, index_col=0)
     expected_df = pd.read_csv(expected_path, index_col=0)
 
-    # peak_AUC CSVs use PSTH timestamp labels as row indices; normalize
-    # float-repr noise before comparing.
+    # peak_AUC CSVs use PSTH timestamp labels (prefixed event times) as row indices;
+    # normalize float-repr noise and shift the reference index into the current
+    # recording-start basis before comparing.
     if "peak_AUC" in Path(rel_path).name:
         actual_df.index = _normalize_psth_index(actual_df.index)
-        expected_df.index = _normalize_psth_index(expected_df.index)
+        expected_df.index = _normalize_psth_index(
+            expected_df.index, bare_offset=event_ts_offset, prefixed_offset=event_ts_offset
+        )
 
     try:
         pd.testing.assert_frame_equal(actual_df, expected_df, check_exact=False, rtol=rtol, atol=atol, check_names=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import json
 import multiprocessing
 import os
 import sys
@@ -32,8 +33,22 @@ STUBBED_TESTING_DATA = Path(PROJECT_ROOT) / "stubbed_testing_data"
 TESTING_DATA = Path(PROJECT_ROOT) / "testing_data"
 
 
+def event_ts_offset_for(base_dir: str | Path) -> float:
+    """Return the ``timeForLightsTurnOn`` used in a pipeline run under ``base_dir``.
+
+    This is the constant by which current event timestamps and PSTH event-time labels
+    shifted relative to the (older, lights-on-basis) reference outputs (issue #355).
+    Pass it as ``event_ts_offset`` to :func:`compare_output_folders` so the consistency
+    suite tolerates exactly that known shift while comparing all other data exactly.
+    """
+    matches = sorted(Path(base_dir).rglob("GuPPyParamtersUsed.json"))
+    assert matches, f"No GuPPyParamtersUsed.json found under {base_dir}"
+    with open(matches[0]) as params_file:
+        return json.load(params_file)["timeForLightsTurnOn"]
+
+
 @pytest.fixture(scope="session")
-def panel_extension():
+def panel_extension() -> None:
     """Call pn.extension() exactly once for the entire test session.
 
     Panel requires this before any widget instantiation.

--- a/tests/consistency/test_consistency_artifact_removal.py
+++ b/tests/consistency/test_consistency_artifact_removal.py
@@ -4,7 +4,7 @@ import shutil
 
 import numpy as np
 import pytest
-from conftest import TESTING_DATA
+from conftest import TESTING_DATA, event_ts_offset_for
 
 from guppy.testing import compare_output_folders
 from guppy.testing.api import step2, step3, step4, step5
@@ -120,4 +120,5 @@ def test_consistency(
     compare_output_folders(
         actual_dir=actual_output_dir,
         expected_dir=str(standard_output_dir),
+        event_ts_offset=event_ts_offset_for(tmp_base),
     )

--- a/tests/consistency/test_consistency_combined_data.py
+++ b/tests/consistency/test_consistency_combined_data.py
@@ -3,7 +3,7 @@ import os
 import shutil
 
 import pytest
-from conftest import TESTING_DATA
+from conftest import TESTING_DATA, event_ts_offset_for
 
 from guppy.testing import compare_output_folders
 from guppy.testing.api import step2, step3, step4, step5
@@ -85,4 +85,5 @@ def test_consistency(tmp_path):
         compare_output_folders(
             actual_dir=actual_output_dir,
             expected_dir=str(standard_output_dir),
+            event_ts_offset=event_ts_offset_for(tmp_base),
         )

--- a/tests/consistency/test_consistency_csv.py
+++ b/tests/consistency/test_consistency_csv.py
@@ -3,7 +3,7 @@ import os
 import shutil
 
 import pytest
-from conftest import TESTING_DATA
+from conftest import TESTING_DATA, event_ts_offset_for
 
 from guppy.testing import compare_output_folders
 from guppy.testing.api import step2, step3, step4, step5
@@ -76,4 +76,5 @@ def test_consistency(
     compare_output_folders(
         actual_dir=actual_output_dir,
         expected_dir=str(standard_output_dir),
+        event_ts_offset=event_ts_offset_for(tmp_base),
     )

--- a/tests/consistency/test_consistency_dff.py
+++ b/tests/consistency/test_consistency_dff.py
@@ -3,7 +3,7 @@ import os
 import shutil
 
 import pytest
-from conftest import TESTING_DATA
+from conftest import TESTING_DATA, event_ts_offset_for
 
 from guppy.testing import compare_output_folders
 from guppy.testing.api import step2, step3, step4, step5
@@ -62,4 +62,5 @@ def test_consistency_dff(tmp_path):
     compare_output_folders(
         actual_dir=actual_output_dir,
         expected_dir=str(standard_output_dir),
+        event_ts_offset=event_ts_offset_for(tmp_base),
     )

--- a/tests/consistency/test_consistency_doric.py
+++ b/tests/consistency/test_consistency_doric.py
@@ -3,7 +3,7 @@ import os
 import shutil
 
 import pytest
-from conftest import TESTING_DATA
+from conftest import TESTING_DATA, event_ts_offset_for
 
 from guppy.testing import compare_output_folders
 from guppy.testing.api import step2, step3, step4, step5
@@ -122,5 +122,6 @@ def test_consistency(
     compare_output_folders(
         actual_dir=actual_output_dir,
         expected_dir=str(standard_output_dir),
+        event_ts_offset=event_ts_offset_for(tmp_base),
         **compare_kwargs,
     )

--- a/tests/consistency/test_consistency_group_analysis.py
+++ b/tests/consistency/test_consistency_group_analysis.py
@@ -3,7 +3,7 @@ import os
 import shutil
 
 import pytest
-from conftest import TESTING_DATA
+from conftest import TESTING_DATA, event_ts_offset_for
 
 from guppy.testing import compare_output_folders
 from guppy.testing.api import step2, step3, step4, step5
@@ -84,4 +84,5 @@ def test_consistency_group_analysis(tmp_path):
     compare_output_folders(
         actual_dir=actual_output_dir,
         expected_dir=str(standard_output_dir),
+        event_ts_offset=event_ts_offset_for(tmp_base),
     )

--- a/tests/consistency/test_consistency_no_isosbestic.py
+++ b/tests/consistency/test_consistency_no_isosbestic.py
@@ -3,7 +3,7 @@ import os
 import shutil
 
 import pytest
-from conftest import TESTING_DATA
+from conftest import TESTING_DATA, event_ts_offset_for
 
 from guppy.testing import compare_output_folders
 from guppy.testing.api import step2, step3, step4, step5
@@ -64,5 +64,6 @@ def test_consistency_no_isosbestic(tmp_path):
     compare_output_folders(
         actual_dir=actual_output_dir,
         expected_dir=str(standard_output_dir),
+        event_ts_offset=event_ts_offset_for(tmp_base),
         atol=1e-07,
     )

--- a/tests/consistency/test_consistency_npm.py
+++ b/tests/consistency/test_consistency_npm.py
@@ -3,7 +3,7 @@ import os
 import shutil
 
 import pytest
-from conftest import TESTING_DATA
+from conftest import TESTING_DATA, event_ts_offset_for
 
 from guppy.testing import compare_output_folders
 from guppy.testing.api import step2, step3, step4, step5
@@ -117,4 +117,5 @@ def test_consistency(
     compare_output_folders(
         actual_dir=actual_output_dir,
         expected_dir=str(standard_output_dir),
+        event_ts_offset=event_ts_offset_for(tmp_base),
     )

--- a/tests/consistency/test_consistency_tdt.py
+++ b/tests/consistency/test_consistency_tdt.py
@@ -3,7 +3,7 @@ import os
 import shutil
 
 import pytest
-from conftest import TESTING_DATA
+from conftest import TESTING_DATA, event_ts_offset_for
 
 from guppy.testing import compare_output_folders
 from guppy.testing.api import step2, step3, step4, step5
@@ -97,5 +97,6 @@ def test_consistency(
     compare_output_folders(
         actual_dir=actual_output_dir,
         expected_dir=str(standard_output_dir),
+        event_ts_offset=event_ts_offset_for(tmp_base),
         name_map=name_map,
     )

--- a/tests/consistency/test_consistency_zscore_method.py
+++ b/tests/consistency/test_consistency_zscore_method.py
@@ -3,7 +3,7 @@ import os
 import shutil
 
 import pytest
-from conftest import TESTING_DATA
+from conftest import TESTING_DATA, event_ts_offset_for
 
 from guppy.testing import compare_output_folders
 from guppy.testing.api import step2, step3, step4, step5
@@ -81,4 +81,5 @@ def test_consistency_zscore_method(
     compare_output_folders(
         actual_dir=actual_output_dir,
         expected_dir=str(standard_output_dir),
+        event_ts_offset=event_ts_offset_for(tmp_base),
     )

--- a/tests/unit/analysis/test_compute_psth.py
+++ b/tests/unit/analysis/test_compute_psth.py
@@ -102,6 +102,9 @@ def test_compute_psth_single_timestamp_no_corrections_returns_expected_row():
     # baselineCorrection passthrough → psth[0,:] = all 3.0
     z_score = np.ones(100) * 3.0
     ts = np.array([5.0])
+    # Continuous timestamps on the recording-start basis; signal starts at t=0.0,
+    # so event 5.0s maps to z_score index round((5.0 - 0.0) * 10) = 50.
+    corrected_timestamps = np.arange(0.0, 10.0, 0.1)
     psth, _, columns, returned_ts = compute_psth(
         z_score=z_score,
         event="test",
@@ -117,7 +120,7 @@ def test_compute_psth_single_timestamp_no_corrections_returns_expected_row():
         just_use_signal=False,
         sampling_rate=10.0,
         ts=ts,
-        corrected_timestamps=ts,
+        corrected_timestamps=corrected_timestamps,
     )
     np.testing.assert_allclose(psth[0, :], np.full(21, 3.0))
     # Last row is the time axis; first value is nSecPrev = -1.0
@@ -127,9 +130,11 @@ def test_compute_psth_single_timestamp_no_corrections_returns_expected_row():
 
 
 def test_compute_psth_early_timestamps_filtered_by_baseline_window():
-    # ts[0]=1.0 < abs(baselineStart=-2.0)=2.0 → dropped; ts[1]=5.0 >= 2.0 → kept
+    # Signal starts at t=0.0 (corrected_timestamps[0]); time-before-event = ts - 0.0.
+    # ts[0]=1.0 → 1.0 < abs(baselineStart=-2.0)=2.0 → dropped; ts[1]=5.0 → 5.0 >= 2.0 → kept
     z_score = np.ones(200) * 1.0
     ts = np.array([1.0, 5.0])
+    corrected_timestamps = np.arange(0.0, 20.0, 0.1)
     _, _, _, returned_ts = compute_psth(
         z_score=z_score,
         event="test",
@@ -145,7 +150,7 @@ def test_compute_psth_early_timestamps_filtered_by_baseline_window():
         just_use_signal=False,
         sampling_rate=10.0,
         ts=ts,
-        corrected_timestamps=ts,
+        corrected_timestamps=corrected_timestamps,
     )
     np.testing.assert_array_equal(returned_ts, np.array([5.0]))
 
@@ -155,6 +160,7 @@ def test_compute_psth_burst_timestamps_within_time_interval_are_dropped():
     # ts[2]=8.0: 8.0-5.0=3.0 >= 1.0 → kept
     z_score = np.ones(200) * 1.0
     ts = np.array([5.0, 5.5, 8.0])
+    corrected_timestamps = np.arange(0.0, 20.0, 0.1)
     _, _, _, returned_ts = compute_psth(
         z_score=z_score,
         event="test",
@@ -170,7 +176,7 @@ def test_compute_psth_burst_timestamps_within_time_interval_are_dropped():
         just_use_signal=False,
         sampling_rate=10.0,
         ts=ts,
-        corrected_timestamps=ts,
+        corrected_timestamps=corrected_timestamps,
     )
     np.testing.assert_array_equal(returned_ts, np.array([5.0, 8.0]))
 
@@ -181,6 +187,7 @@ def test_compute_psth_binning_by_trials_produces_correct_bin_mean_and_sem():
     # psth rows: 4 trial + 2 mean + 2 sem + 1 timeAxis = 9 rows
     z_score = np.ones(200) * 3.0
     ts = np.array([5.0, 6.0, 7.0, 8.0])
+    corrected_timestamps = np.arange(0.0, 20.0, 0.1)
     psth, _, columns, _ = compute_psth(
         z_score=z_score,
         event="test",
@@ -196,7 +203,7 @@ def test_compute_psth_binning_by_trials_produces_correct_bin_mean_and_sem():
         just_use_signal=False,
         sampling_rate=10.0,
         ts=ts,
-        corrected_timestamps=ts,
+        corrected_timestamps=corrected_timestamps,
     )
     # Row 4: mean of first bin (trials 0 and 1, all 3.0)
     np.testing.assert_allclose(psth[4, :], np.full(21, 3.0))
@@ -212,6 +219,7 @@ def test_compute_psth_just_use_signal_true_z_scores_each_trial():
     rng = np.random.default_rng(seed=42)
     z_score = rng.standard_normal(200)
     ts = np.array([10.0])
+    corrected_timestamps = np.arange(0.0, 20.0, 0.1)
     psth, _, _, _ = compute_psth(
         z_score=z_score,
         event="test",
@@ -227,7 +235,64 @@ def test_compute_psth_just_use_signal_true_z_scores_each_trial():
         just_use_signal=True,
         sampling_rate=10.0,
         ts=ts,
-        corrected_timestamps=ts,
+        corrected_timestamps=corrected_timestamps,
     )
     np.testing.assert_allclose(np.nanmean(psth[0, :]), 0.0, atol=1e-10)
     np.testing.assert_allclose(np.nanstd(psth[0, :]), 1.0, atol=1e-10)
+
+
+def test_compute_psth_index_is_relative_to_corrected_timestamps_origin():
+    # Events live on the recording-start basis (same as corrected_timestamps), so the
+    # extracted z_score window is anchored at round((ts - corrected_timestamps[0]) * sr),
+    # NOT round(ts * sr). A ramp z_score lets us read back the anchor sample.
+    z_score = np.arange(200, dtype=float)
+    ts = np.array([10.0])
+    sampling_rate = 10.0
+    # Signal starts at t=5.0s → event 10.0s is 5.0s into the signal → index round(5.0*10)=50.
+    corrected_timestamps = np.arange(5.0, 25.0, 0.1)
+    psth, _, _, _ = compute_psth(
+        z_score=z_score,
+        event="test",
+        filepath="",
+        nSecPrev=-1.0,
+        nSecPost=1.0,
+        timeInterval=0.0,
+        bin_psth_trials=0,
+        use_time_or_trials="none",
+        baselineStart=0,
+        baselineEnd=0,
+        naming="",
+        just_use_signal=False,
+        sampling_rate=sampling_rate,
+        ts=ts,
+        corrected_timestamps=corrected_timestamps,
+    )
+    # The event sample (slice z_score[thisIndex-11 : thisIndex+10]) lands at row position 11:
+    # z_score[50] = 50.0.
+    np.testing.assert_allclose(psth[0, 11], 50.0)
+
+
+def test_compute_psth_index_shifts_with_corrected_timestamps_origin():
+    # Same event, a different signal-start origin shifts the extracted window by the offset.
+    z_score = np.arange(200, dtype=float)
+    ts = np.array([10.0])
+    # Signal starts at t=0.0s → event 10.0s is 10.0s in → index round(10.0*10)=100 → z_score[100]=100.0.
+    corrected_timestamps = np.arange(0.0, 20.0, 0.1)
+    psth, _, _, _ = compute_psth(
+        z_score=z_score,
+        event="test",
+        filepath="",
+        nSecPrev=-1.0,
+        nSecPost=1.0,
+        timeInterval=0.0,
+        bin_psth_trials=0,
+        use_time_or_trials="none",
+        baselineStart=0,
+        baselineEnd=0,
+        naming="",
+        just_use_signal=False,
+        sampling_rate=10.0,
+        ts=ts,
+        corrected_timestamps=corrected_timestamps,
+    )
+    np.testing.assert_allclose(psth[0, 11], 100.0)

--- a/tests/unit/analysis/test_compute_psth.py
+++ b/tests/unit/analysis/test_compute_psth.py
@@ -102,8 +102,7 @@ def test_compute_psth_single_timestamp_no_corrections_returns_expected_row():
     # baselineCorrection passthrough → psth[0,:] = all 3.0
     z_score = np.ones(100) * 3.0
     ts = np.array([5.0])
-    # Continuous timestamps on the recording-start basis; signal starts at t=0.0,
-    # so event 5.0s maps to z_score index round((5.0 - 0.0) * 10) = 50.
+    # timeForLightsTurnOn=0.0, so event 5.0s maps to z_score index round((5.0 - 0.0) * 10) = 50.
     corrected_timestamps = np.arange(0.0, 10.0, 0.1)
     psth, _, columns, returned_ts = compute_psth(
         z_score=z_score,
@@ -121,6 +120,7 @@ def test_compute_psth_single_timestamp_no_corrections_returns_expected_row():
         sampling_rate=10.0,
         ts=ts,
         corrected_timestamps=corrected_timestamps,
+        timeForLightsTurnOn=0.0,
     )
     np.testing.assert_allclose(psth[0, :], np.full(21, 3.0))
     # Last row is the time axis; first value is nSecPrev = -1.0
@@ -130,7 +130,7 @@ def test_compute_psth_single_timestamp_no_corrections_returns_expected_row():
 
 
 def test_compute_psth_early_timestamps_filtered_by_baseline_window():
-    # Signal starts at t=0.0 (corrected_timestamps[0]); time-before-event = ts - 0.0.
+    # timeForLightsTurnOn=0.0; time-before-event = ts - 0.0.
     # ts[0]=1.0 → 1.0 < abs(baselineStart=-2.0)=2.0 → dropped; ts[1]=5.0 → 5.0 >= 2.0 → kept
     z_score = np.ones(200) * 1.0
     ts = np.array([1.0, 5.0])
@@ -151,6 +151,7 @@ def test_compute_psth_early_timestamps_filtered_by_baseline_window():
         sampling_rate=10.0,
         ts=ts,
         corrected_timestamps=corrected_timestamps,
+        timeForLightsTurnOn=0.0,
     )
     np.testing.assert_array_equal(returned_ts, np.array([5.0]))
 
@@ -177,6 +178,7 @@ def test_compute_psth_burst_timestamps_within_time_interval_are_dropped():
         sampling_rate=10.0,
         ts=ts,
         corrected_timestamps=corrected_timestamps,
+        timeForLightsTurnOn=0.0,
     )
     np.testing.assert_array_equal(returned_ts, np.array([5.0, 8.0]))
 
@@ -204,6 +206,7 @@ def test_compute_psth_binning_by_trials_produces_correct_bin_mean_and_sem():
         sampling_rate=10.0,
         ts=ts,
         corrected_timestamps=corrected_timestamps,
+        timeForLightsTurnOn=0.0,
     )
     # Row 4: mean of first bin (trials 0 and 1, all 3.0)
     np.testing.assert_allclose(psth[4, :], np.full(21, 3.0))
@@ -236,20 +239,21 @@ def test_compute_psth_just_use_signal_true_z_scores_each_trial():
         sampling_rate=10.0,
         ts=ts,
         corrected_timestamps=corrected_timestamps,
+        timeForLightsTurnOn=0.0,
     )
     np.testing.assert_allclose(np.nanmean(psth[0, :]), 0.0, atol=1e-10)
     np.testing.assert_allclose(np.nanstd(psth[0, :]), 1.0, atol=1e-10)
 
 
-def test_compute_psth_index_is_relative_to_corrected_timestamps_origin():
-    # Events live on the recording-start basis (same as corrected_timestamps), so the
-    # extracted z_score window is anchored at round((ts - corrected_timestamps[0]) * sr),
-    # NOT round(ts * sr). A ramp z_score lets us read back the anchor sample.
+def test_compute_psth_index_is_relative_to_lights_on_origin():
+    # Events live on the recording-start basis while z_score[0] is the lights-on instant,
+    # so the extracted window is anchored at round((ts - timeForLightsTurnOn) * sr), NOT
+    # round(ts * sr). A ramp z_score lets us read back the anchor sample.
     z_score = np.arange(200, dtype=float)
     ts = np.array([10.0])
     sampling_rate = 10.0
-    # Signal starts at t=5.0s → event 10.0s is 5.0s into the signal → index round(5.0*10)=50.
-    corrected_timestamps = np.arange(5.0, 25.0, 0.1)
+    corrected_timestamps = np.arange(0.0, 20.0, 0.1)
+    # timeForLightsTurnOn=5.0 → event 10.0s is 5.0s after lights-on → index round(5.0*10)=50.
     psth, _, _, _ = compute_psth(
         z_score=z_score,
         event="test",
@@ -266,18 +270,19 @@ def test_compute_psth_index_is_relative_to_corrected_timestamps_origin():
         sampling_rate=sampling_rate,
         ts=ts,
         corrected_timestamps=corrected_timestamps,
+        timeForLightsTurnOn=5.0,
     )
     # The event sample (slice z_score[thisIndex-11 : thisIndex+10]) lands at row position 11:
     # z_score[50] = 50.0.
     np.testing.assert_allclose(psth[0, 11], 50.0)
 
 
-def test_compute_psth_index_shifts_with_corrected_timestamps_origin():
-    # Same event, a different signal-start origin shifts the extracted window by the offset.
+def test_compute_psth_index_shifts_with_lights_on_origin():
+    # Same event, a different lights-on origin shifts the extracted window by the offset.
     z_score = np.arange(200, dtype=float)
     ts = np.array([10.0])
-    # Signal starts at t=0.0s → event 10.0s is 10.0s in → index round(10.0*10)=100 → z_score[100]=100.0.
     corrected_timestamps = np.arange(0.0, 20.0, 0.1)
+    # timeForLightsTurnOn=0.0 → event 10.0s is 10.0s in → index round(10.0*10)=100 → z_score[100]=100.0.
     psth, _, _, _ = compute_psth(
         z_score=z_score,
         event="test",
@@ -294,5 +299,6 @@ def test_compute_psth_index_shifts_with_corrected_timestamps_origin():
         sampling_rate=10.0,
         ts=ts,
         corrected_timestamps=corrected_timestamps,
+        timeForLightsTurnOn=0.0,
     )
     np.testing.assert_allclose(psth[0, 11], 100.0)

--- a/tests/unit/analysis/test_timestamp_correction.py
+++ b/tests/unit/analysis/test_timestamp_correction.py
@@ -10,35 +10,34 @@ from guppy.analysis.timestamp_correction import (
 )
 
 
-def test_apply_correction_ttl_tdt_mode_all_above_rec_start_subtracts_both_offsets():
-    # All timestamps >= timeRecStart → subtract both timeRecStart and timeForLightsTurnOn
-    # [10.5-10.0-2.0, 11.0-10.0-2.0, 12.0-10.0-2.0] = [-1.5, -1.0, 0.0]
+def test_apply_correction_ttl_tdt_mode_all_above_rec_start_subtracts_only_rec_start():
+    # All timestamps >= timeRecStart → subtract only timeRecStart (recording-start basis;
+    # timeForLightsTurnOn is no longer subtracted from events)
+    # [10.5-10.0, 11.0-10.0, 12.0-10.0] = [0.5, 1.0, 2.0]
     ttl_timestamps = np.array([10.5, 11.0, 12.0])
     result = applyCorrection_ttl(2.0, 10.0, ttl_timestamps, "tdt")
-    np.testing.assert_allclose(result, np.array([-1.5, -1.0, 0.0]))
+    np.testing.assert_allclose(result, np.array([0.5, 1.0, 2.0]))
 
 
-def test_apply_correction_ttl_tdt_mode_some_below_rec_start_subtracts_only_lights_turn_on():
-    # One timestamp is below timeRecStart → subtract only timeForLightsTurnOn
-    # [9.5-2.0, 11.0-2.0, 12.0-2.0] = [7.5, 9.0, 10.0]
+def test_apply_correction_ttl_tdt_mode_some_below_rec_start_leaves_unchanged():
+    # One timestamp is below timeRecStart (not on the recording clock) → leave unchanged
     ttl_timestamps = np.array([9.5, 11.0, 12.0])
     result = applyCorrection_ttl(2.0, 10.0, ttl_timestamps, "tdt")
-    np.testing.assert_allclose(result, np.array([7.5, 9.0, 10.0]))
+    np.testing.assert_allclose(result, np.array([9.5, 11.0, 12.0]))
 
 
-def test_apply_correction_ttl_csv_mode_subtracts_only_lights_turn_on():
-    # CSV mode always subtracts only timeForLightsTurnOn regardless of timeRecStart
-    # [5.0-3.0, 8.0-3.0, 12.0-3.0] = [2.0, 5.0, 9.0]
+def test_apply_correction_ttl_csv_mode_leaves_timestamps_unchanged():
+    # CSV timestamps are already recording-relative → returned unchanged (no lights-on shift)
     ttl_timestamps = np.array([5.0, 8.0, 12.0])
     result = applyCorrection_ttl(3.0, 0.0, ttl_timestamps, "csv")
-    np.testing.assert_allclose(result, np.array([2.0, 5.0, 9.0]))
+    np.testing.assert_allclose(result, np.array([5.0, 8.0, 12.0]))
 
 
-def test_apply_correction_ttl_tdt_mode_all_at_rec_start_subtracts_both_offsets():
-    # All timestamps >= timeRecStart=100 → [100-100-1, ..., 109-100-1] = [-1, 0, ..., 8]
+def test_apply_correction_ttl_tdt_mode_all_at_rec_start_subtracts_only_rec_start():
+    # All timestamps >= timeRecStart=100 → [100-100, ..., 109-100] = [0, 1, ..., 9]
     ttl_timestamps = np.arange(10, dtype=float) + 100.0
     result = applyCorrection_ttl(1.0, 100.0, ttl_timestamps, "tdt")
-    np.testing.assert_allclose(result, np.arange(-1, 9, dtype=float))
+    np.testing.assert_allclose(result, np.arange(0, 10, dtype=float))
 
 
 def test_check_cntrl_sig_length_control_shorter_returns_control_name():
@@ -111,8 +110,8 @@ def test_timestamp_correction_csv_mode_slices_at_lights_turn_on():
 
 
 def test_decide_naming_applies_csv_correction_to_ttl_and_forms_compound_name():
-    # CSV mode: corrected = TTL - timeForLightsTurnOn
-    # compound_name = "TTL1_dms"; [3-1, 5-1, 7-1] = [2.0, 4.0, 6.0]
+    # CSV mode: events stay on the recording-start basis (unchanged); only the
+    # compound name "TTL1_dms" is formed.
     storesList = np.array([["ctrl0", "sig0", "ttl0"], ["control_dms", "signal_dms", "TTL1"]])
     name_to_timestamps_ttl = {"TTL1": np.array([3.0, 5.0, 7.0])}
     name_to_timestamps = {
@@ -126,7 +125,7 @@ def test_decide_naming_applies_csv_correction_to_ttl_and_forms_compound_name():
     )
 
     assert "TTL1_dms" in result
-    np.testing.assert_array_equal(result["TTL1_dms"], np.array([2.0, 4.0, 6.0]))
+    np.testing.assert_array_equal(result["TTL1_dms"], np.array([3.0, 5.0, 7.0]))
 
 
 # ── correct_timestamps ────────────────────────────────────────────────────────
@@ -213,5 +212,40 @@ def test_correct_timestamps_returns_all_four_outputs_consistent():
     assert "control_dms" in result_ts
     assert result_ts["control_dms"].shape[0] == 4
     assert "TTL1_dms" in result_ttl
-    # CSV TTL: [2.5-1.0, 3.5-1.0] = [1.5, 2.5]
-    np.testing.assert_array_equal(result_ttl["TTL1_dms"], np.array([1.5, 2.5]))
+    # CSV TTL stays on the recording-start basis (unchanged): [2.5, 3.5]
+    np.testing.assert_array_equal(result_ttl["TTL1_dms"], np.array([2.5, 3.5]))
+
+
+def test_events_and_continuous_share_one_recording_start_basis():
+    # Issue #355: continuous timestampNew and event ts must share a single time basis.
+    # The continuous stream is sliced at >= timeForLightsTurnOn (recording basis) and events
+    # are NOT re-zeroed, so an event at recording time T equals the continuous timestamp at
+    # its matching sample index round((T - timestampNew[0]) * sampling_rate).
+    storesList = np.array([["ctrl0", "sig0", "ttl0"], ["control_dms", "signal_dms", "TTL1"]])
+    timestamps = np.arange(0.0, 5.0, 0.1)
+    data = np.arange(timestamps.shape[0], dtype=float)
+    name_to_timestamps = {"control_dms": timestamps.copy(), "signal_dms": timestamps.copy()}
+    name_to_data = {"control_dms": data.copy(), "signal_dms": data.copy()}
+    name_to_sampling_rate = {"control_dms": np.array([10.0]), "signal_dms": np.array([10.0])}
+    name_to_npoints = {"control_dms": None, "signal_dms": None}
+    name_to_timestamps_ttl = {"TTL1": np.array([2.4])}
+
+    corrected_ts, _, _, corrected_ttl = correct_timestamps(
+        1.0,
+        storesList,
+        name_to_timestamps,
+        name_to_data,
+        name_to_sampling_rate,
+        name_to_npoints,
+        name_to_timestamps_ttl,
+        mode="csv",
+    )
+
+    timestampNew = corrected_ts["signal_dms"]
+    event = corrected_ttl["TTL1_dms"][0]
+    # Event is on the recording-start basis (NOT re-zeroed to lights-on at 0.0).
+    np.testing.assert_allclose(event, 2.4)
+    # It falls within the continuous timespan and lands on the matching continuous sample.
+    assert timestampNew[0] <= event <= timestampNew[-1]
+    index = int(round((event - timestampNew[0]) * 10.0))
+    np.testing.assert_allclose(timestampNew[index], event)

--- a/tests/unit/testing/test_consistency.py
+++ b/tests/unit/testing/test_consistency.py
@@ -36,6 +36,23 @@ class TestNormalizationHelpers:
         assert result.shape == (1, 2)
         assert result.tolist() == [["1.2", "session_2.3"]]
 
+    def test_normalize_psth_label_applies_bare_and_prefixed_offsets(self):
+        # Bare event-ts label shifts by bare_offset.
+        assert _normalize_psth_label("138.238440990448", bare_offset=1.0) == "139.238441"
+        # peak_AUC prefixed label shifts its float suffix by prefixed_offset.
+        assert (
+            _normalize_psth_label("sample_data_csv_1_138.238440990448", prefixed_offset=1.0)
+            == "sample_data_csv_1_139.238441"
+        )
+
+    def test_normalize_psth_label_leaves_session_suffix_unchanged_when_prefixed_offset_zero(self):
+        # Session-run suffixes (e.g. ..._output_1) match the prefixed-float regex but must NOT
+        # be shifted: only peak_AUC files pass a nonzero prefixed_offset.
+        assert (
+            _normalize_psth_label("Photo_048_392-200728-121222_output_1", bare_offset=1.0, prefixed_offset=0.0)
+            == "Photo_048_392-200728-121222_output_1"
+        )
+
 
 class TestPathCollection:
     def test_collect_relative_paths_skips_saved_plots_directory(self, tmp_path):
@@ -133,6 +150,104 @@ class TestCompareOutputFolders:
             actual_file.create_dataset("values", data=np.array([1.0, 2.0]))
 
         compare_output_folders(actual_dir=str(actual_directory), expected_dir=str(expected_directory))
+
+    def test_compare_output_folders_event_ts_offset_reconciles_ts_dataset(self, tmp_path):
+        # Event-timestamp arrays (key "ts") moved to the recording-start basis:
+        # actual == reference + timeForLightsTurnOn.
+        expected_directory = tmp_path / "expected"
+        actual_directory = tmp_path / "actual"
+        expected_directory.mkdir()
+        actual_directory.mkdir()
+
+        with h5py.File(expected_directory / "ttl_region.hdf5", "w") as f:
+            f.create_dataset("ts", data=np.array([138.0, 189.0, 269.0]))
+        with h5py.File(actual_directory / "ttl_region.hdf5", "w") as f:
+            f.create_dataset("ts", data=np.array([139.0, 190.0, 270.0]))
+
+        # With the matching offset the shifted reference equals actual.
+        compare_output_folders(
+            actual_dir=str(actual_directory), expected_dir=str(expected_directory), event_ts_offset=1.0
+        )
+        # Without the offset the basis difference is (correctly) flagged.
+        with pytest.raises(AssertionError, match="'ts' numeric data differs"):
+            compare_output_folders(actual_dir=str(actual_directory), expected_dir=str(expected_directory))
+
+    def test_compare_output_folders_event_ts_offset_shifts_psth_bare_labels(self, tmp_path):
+        # z_score trial columns are bare event-ts floats; the reference is shifted into the
+        # current basis by event_ts_offset.
+        expected_directory = tmp_path / "expected"
+        actual_directory = tmp_path / "actual"
+        expected_directory.mkdir()
+        actual_directory.mkdir()
+
+        with h5py.File(expected_directory / "z_score_region.h5", "w") as f:
+            f.create_dataset("axis0", data=np.array([b"138.238440990448", b"189.68911623954773"]))
+        with h5py.File(actual_directory / "z_score_region.h5", "w") as f:
+            f.create_dataset("axis0", data=np.array([b"139.238440990448", b"190.68911623954773"]))
+
+        compare_output_folders(
+            actual_dir=str(actual_directory), expected_dir=str(expected_directory), event_ts_offset=1.0
+        )
+
+    def test_compare_output_folders_event_ts_offset_does_not_shift_group_session_columns(self, tmp_path):
+        # Group-average trial columns are session-run names (..._output_1) that match the
+        # prefixed-float regex. They must compare equal even when event_ts_offset is set,
+        # because a z_score (non-peak_AUC) file uses prefixed_offset=0.
+        expected_directory = tmp_path / "expected"
+        actual_directory = tmp_path / "actual"
+        expected_directory.mkdir()
+        actual_directory.mkdir()
+
+        cols = np.array([b"Photo_048_output_1", b"Photo_63_output_1"])
+        with h5py.File(expected_directory / "rewarded_z_score_region.h5", "w") as f:
+            f.create_dataset("axis0", data=cols)
+        with h5py.File(actual_directory / "rewarded_z_score_region.h5", "w") as f:
+            f.create_dataset("axis0", data=cols)
+
+        compare_output_folders(
+            actual_dir=str(actual_directory), expected_dir=str(expected_directory), event_ts_offset=1.0
+        )
+
+    def test_compare_output_folders_event_ts_offset_shifts_peak_auc_hdf5_index_not_columns(self, tmp_path):
+        # peak_AUC HDF5 stores event-ts labels in the index axis (axis1) and structural
+        # column names (peak_pos_1, area_1) in axis0/block0_items. Only axis1 must shift;
+        # the "_1" column suffixes match the prefixed-float regex but must NOT shift.
+        expected_directory = tmp_path / "expected"
+        actual_directory = tmp_path / "actual"
+        expected_directory.mkdir()
+        actual_directory.mkdir()
+
+        columns = np.array([b"peak_pos_1", b"area_1"])
+        with h5py.File(expected_directory / "peak_AUC_ttl_region.h5", "w") as f:
+            f.create_dataset("axis0", data=columns)
+            f.create_dataset("block0_items", data=columns)
+            f.create_dataset("axis1", data=np.array([b"sample_1_138.238440990448"]))
+        with h5py.File(actual_directory / "peak_AUC_ttl_region.h5", "w") as f:
+            f.create_dataset("axis0", data=columns)
+            f.create_dataset("block0_items", data=columns)
+            f.create_dataset("axis1", data=np.array([b"sample_1_139.238440990448"]))
+
+        compare_output_folders(
+            actual_dir=str(actual_directory), expected_dir=str(expected_directory), event_ts_offset=1.0
+        )
+
+    def test_compare_output_folders_event_ts_offset_shifts_peak_auc_csv_index(self, tmp_path):
+        # peak_AUC row index is prefixed floats whose suffix IS the event ts → shift the suffix.
+        expected_directory = tmp_path / "expected"
+        actual_directory = tmp_path / "actual"
+        expected_directory.mkdir()
+        actual_directory.mkdir()
+
+        pd.DataFrame({"area": [0.5]}, index=["sample_data_csv_1_138.238440990448"]).to_csv(
+            expected_directory / "peak_AUC_ttl_region.csv"
+        )
+        pd.DataFrame({"area": [0.5]}, index=["sample_data_csv_1_139.238440990448"]).to_csv(
+            actual_directory / "peak_AUC_ttl_region.csv"
+        )
+
+        compare_output_folders(
+            actual_dir=str(actual_directory), expected_dir=str(expected_directory), event_ts_offset=1.0
+        )
 
     def test_compare_output_folders_reports_hdf5_string_mismatch_for_non_psth_file(self, tmp_path):
         expected_directory = tmp_path / "expected"


### PR DESCRIPTION
Fixes #355 

This PR ensures that the event timestamps remain on the same time basis as the raw data.

The concatenate method of artifacts removal is left as a separate issue. 