### PR TITLE
Add line-plot-style customization controls to the heatmap tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v2.0.0-alpha8 (Upcoming)
 
 ## Features
+- Brought the visualization dashboard's Heat Map tab up to parity with the PSTH line plots: numeric X (Time) and Y (Trials) axis-limit boxes that snap to zoom/pan, editable colour-scale (clim) limits that recolour the datashaded data (not just the colorbar), and an independent "Hide minor tick marks" toggle. [PR #372](https://github.com/LernerLab/GuPPy/pull/372)
 
 ## Fixes
 

--- a/src/guppy/frontend/parameterized_plotter.py
+++ b/src/guppy/frontend/parameterized_plotter.py
@@ -170,6 +170,15 @@ class ParameterizedPlotter(param.Parameterized):
     overlay_Y = param.Range(default=None)
     trials_X = param.Range(default=None)
     trials_Y = param.Range(default=None)
+    # Heat map axis + color-scale ranges, mirroring the per-line-plot pattern.
+    # heatmap_X/Y are driven live by the zoom/pan hook (kept OUT of @param.depends);
+    # heatmap_clim IS in @param.depends because a colour-scale change has no live-pan
+    # equivalent and must re-render. All three auto-fit on selection change.
+    heatmap_X = param.Range(default=None)
+    heatmap_Y = param.Range(default=None)
+    heatmap_clim = param.Range(default=None)
+    # Independent of the PSTH hide_minor_ticks toggle.
+    hide_minor_ticks_heatmap = param.Boolean(default=False)
 
     x = param.ObjectSelector(default=None)
     y = param.ObjectSelector(default=None)
@@ -203,6 +212,7 @@ class ParameterizedPlotter(param.Parameterized):
         self.cont_X = (self.x_min, self.x_max)
         self.overlay_X = (self.x_min, self.x_max)
         self.trials_X = (self.x_min, self.x_max)
+        self.heatmap_X = (self.x_min, self.x_max)
 
         # Live Bokeh figure per plot, recorded by _range_sync_hook on each render.
         # Range params are deliberately NOT in the plot methods' @param.depends
@@ -220,6 +230,7 @@ class ParameterizedPlotter(param.Parameterized):
         ("cont", "cont_X", "cont_Y"),
         ("overlay", "overlay_X", "overlay_Y"),
         ("trials", "trials_X", "trials_Y"),
+        ("heatmap", "heatmap_X", "heatmap_Y"),
     )
 
     @staticmethod
@@ -289,19 +300,25 @@ class ParameterizedPlotter(param.Parameterized):
 
         return hook
 
-    def _hide_minor_ticks_hook(self, plot: object, element: object) -> None:
-        """HoloViews ``hooks`` callback that hides the Bokeh axis minor ticks when requested.
+    def _hide_minor_ticks_hook(self, attr: str) -> Callable[[object, object], None]:
+        """Build a HoloViews ``hooks`` callback that hides the Bokeh axis minor ticks.
 
-        Attached to a plot via ``.opts(hooks=[...])``, this removes the small tick marks
-        between the axis numbers on both axes when ``hide_minor_ticks`` is set. When it is
-        not set the freshly rendered figure keeps Bokeh's default minor ticks, so no
-        restore step is needed.
+        Attached to a plot via ``.opts(hooks=[...])``, the returned hook removes the
+        small tick marks between the axis numbers on both axes when the boolean param
+        named ``attr`` is set. When it is not set the freshly rendered figure keeps
+        Bokeh's default minor ticks, so no restore step is needed. The param name is a
+        factory argument so the PSTH plots and the heatmap can each drive their own
+        independent toggle (``hide_minor_ticks`` vs ``hide_minor_ticks_heatmap``).
         """
-        if not self.hide_minor_ticks:
-            return
-        figure = plot.state
-        figure.xaxis.minor_tick_line_color = None
-        figure.yaxis.minor_tick_line_color = None
+
+        def hook(plot: object, element: object) -> None:
+            if not getattr(self, attr):
+                return
+            figure = plot.state
+            figure.xaxis.minor_tick_line_color = None
+            figure.yaxis.minor_tick_line_color = None
+
+        return hook
 
     def _reset_y_on_selection_change(self, plot_key: str, y_name: str, selection: object) -> None:
         """Clear a plot's Y range when its data selection changes, forcing a re-autofit.
@@ -515,7 +532,10 @@ class ParameterizedPlotter(param.Parameterized):
             op_filename = os.path.join(op, str(arr) + "_mean")
 
             plot_combine = plot_combine.opts(
-                hooks=[self._range_sync_hook("overlay", "overlay_X", "overlay_Y"), self._hide_minor_ticks_hook]
+                hooks=[
+                    self._range_sync_hook("overlay", "overlay_X", "overlay_Y"),
+                    self._hide_minor_ticks_hook("hide_minor_ticks"),
+                ]
             )
             self.results_psth["plot_combine"] = plot_combine
             self.results_psth["op_combine"] = op_filename
@@ -570,7 +590,12 @@ class ParameterizedPlotter(param.Parameterized):
                 )
             )
 
-            img = img.opts(hooks=[self._range_sync_hook("cont", "cont_X", "cont_Y"), self._hide_minor_ticks_hook])
+            img = img.opts(
+                hooks=[
+                    self._range_sync_hook("cont", "cont_X", "cont_Y"),
+                    self._hide_minor_ticks_hook("hide_minor_ticks"),
+                ]
+            )
             op = make_dir(self.filepath)
             op_filename = os.path.join(op, self.event_selector + "_" + self.y)
             self.results_psth["plot"] = img
@@ -616,7 +641,12 @@ class ParameterizedPlotter(param.Parameterized):
                 (xpoints[index], ypoints[index], err[index], err[index])
             )  # .opts(**ropts_spread) #vdims=['y', 'yerrpos', 'yerrneg']
             plot = (plot_curve * plot_spread).opts({"Curve": ropts_curve, "Spread": ropts_spread})
-            plot = plot.opts(hooks=[self._range_sync_hook("cont", "cont_X", "cont_Y"), self._hide_minor_ticks_hook])
+            plot = plot.opts(
+                hooks=[
+                    self._range_sync_hook("cont", "cont_X", "cont_Y"),
+                    self._hide_minor_ticks_hook("hide_minor_ticks"),
+                ]
+            )
             op = make_dir(self.filepath)
             op_filename = os.path.join(op, self.event_selector + "_" + self.y)
             self.results_psth["plot"] = plot
@@ -640,7 +670,12 @@ class ParameterizedPlotter(param.Parameterized):
                 ylabel=self.Y_Label,
             )
             plot = hv.Curve((xpoints, ypoints)).opts({"Curve": ropts_curve})
-            plot = plot.opts(hooks=[self._range_sync_hook("cont", "cont_X", "cont_Y"), self._hide_minor_ticks_hook])
+            plot = plot.opts(
+                hooks=[
+                    self._range_sync_hook("cont", "cont_X", "cont_Y"),
+                    self._hide_minor_ticks_hook("hide_minor_ticks"),
+                ]
+            )
             op = make_dir(self.filepath)
             op_filename = os.path.join(op, self.event_selector + "_" + self.y)
             self.results_psth["plot"] = plot
@@ -729,7 +764,10 @@ class ParameterizedPlotter(param.Parameterized):
         for extra_layer in layers[1:]:
             result = result * extra_layer
         result = result.opts(
-            hooks=[self._range_sync_hook("trials", "trials_X", "trials_Y"), self._hide_minor_ticks_hook]
+            hooks=[
+                self._range_sync_hook("trials", "trials_X", "trials_Y"),
+                self._hide_minor_ticks_hook("hide_minor_ticks"),
+            ]
         )
 
         op = make_dir(self.filepath)
@@ -739,7 +777,15 @@ class ParameterizedPlotter(param.Parameterized):
         return result
 
     # function to show heatmaps for each event
-    @param.depends("event_selector_heatmap", "color_map", "height_heatmap", "width_heatmap", "heatmap_y")
+    @param.depends(
+        "event_selector_heatmap",
+        "color_map",
+        "height_heatmap",
+        "width_heatmap",
+        "heatmap_y",
+        "heatmap_clim",
+        "hide_minor_ticks_heatmap",
+    )
     def heatmap(self) -> hv.Element:
         """Render a trial heatmap for the selected event.
 
@@ -749,6 +795,13 @@ class ParameterizedPlotter(param.Parameterized):
             A ``QuadMesh`` (single trial) or a datashaded ``QuadMesh`` overlay
             (multiple trials), coloured by the selected colour map.
         """
+        # Refit the colour scale and the Trials axis whenever the event or trial
+        # selection changes; a manual clim/zoom persists across renders that keep
+        # the same selection (same convention as the PSTH Y-range auto-fit).
+        selection = (self.event_selector_heatmap, tuple(self.heatmap_y))
+        self._reset_y_on_selection_change("heatmap_Y", "heatmap_Y", selection)
+        self._reset_y_on_selection_change("heatmap_clim", "heatmap_clim", selection)
+
         height = self.height_heatmap
         width = self.width_heatmap
         df_hm = self.df_new[self.event_selector_heatmap]
@@ -776,7 +829,17 @@ class ParameterizedPlotter(param.Parameterized):
             event_ts_for_each_event = np.arange(1, z_score.shape[0] + 1)
             yticks = list(event_ts_for_each_event)
 
-        clim = (np.nanmin(z_score), np.nanmax(z_score))
+        # Auto-fit the colour scale and Trials axis to the current selection on
+        # first render (or after a selection change reset them above). ``trial_numbers``
+        # is captured before the single-trial duplication below so the Y range and
+        # ticks reflect the real trials, and its 0.5 padding gives the lone-trial case
+        # a non-degenerate range.
+        trial_numbers = event_ts_for_each_event
+        if self.heatmap_clim is None:
+            self.heatmap_clim = (float(np.nanmin(z_score)), float(np.nanmax(z_score)))
+        if self.heatmap_Y is None:
+            self.heatmap_Y = (float(trial_numbers.min()) - 0.5, float(trial_numbers.max()) + 0.5)
+        clim = self.heatmap_clim
         font_size = {"labels": 16, "yticks": 6}
 
         # A single-trial heatmap (e.g. a group average with only one contributing
@@ -799,17 +862,32 @@ class ParameterizedPlotter(param.Parameterized):
             fontsize=font_size,
             yticks=yticks,
             invert_yaxis=True,
+            xlim=self.heatmap_X,
+            ylim=self.heatmap_Y,
         )
         dummy_image = hv.QuadMesh((time[0:100], event_ts_for_each_event, z_score[:, 0:100])).opts(
             colorbar=True, cmap=process_cmap(self.color_map, provider="matplotlib"), clim=clim
         )
         actual_image = hv.QuadMesh((time, event_ts_for_each_event, z_score))
 
-        dynspread_img = datashade(actual_image, cmap=process_cmap(self.color_map, provider="matplotlib")).opts(
-            **ropts
-        )  # clims=self.C_Limit, cnorm='log'
+        # Shade the data with the SAME linear colour limits as the dummy colorbar so
+        # the legend actually matches the pixels. Without clims/cnorm here, datashade
+        # auto-normalizes the data to its own min/max (and eq-hist), so the colour-scale
+        # boxes would move only the colorbar and never recolour the data.
+        dynspread_img = datashade(
+            actual_image,
+            cmap=process_cmap(self.color_map, provider="matplotlib"),
+            cnorm="linear",
+            clims=clim,
+        ).opts(**ropts)
         image = ((dummy_image * dynspread_img).opts(opts.QuadMesh(width=int(width), height=int(height)))).opts(
             shared_axes=False
+        )
+        image = image.opts(
+            hooks=[
+                self._range_sync_hook("heatmap", "heatmap_X", "heatmap_Y"),
+                self._hide_minor_ticks_hook("hide_minor_ticks_heatmap"),
+            ]
         )
 
         op = make_dir(self.filepath)

--- a/src/guppy/frontend/visualization_dashboard.py
+++ b/src/guppy/frontend/visualization_dashboard.py
@@ -292,24 +292,38 @@ class VisualizationDashboard:
         height_heatmap = pn.Param(
             self.plotter.param.height_heatmap, widgets={"height_heatmap": {"type": pn.widgets.Select, "width": 150}}
         )
-        save_hm = pn.Param(self.plotter.param.save_hm, widgets={"save_hm": {"type": pn.widgets.Button, "width": 150}})
-        save_options_heatmap = pn.Param(
-            self.plotter.param.save_options_heatmap,
-            widgets={"save_options_heatmap": {"type": pn.widgets.Select, "width": 150}},
+        hide_minor_ticks_heatmap = pn.Param(
+            self.plotter.param.hide_minor_ticks_heatmap,
+            widgets={"hide_minor_ticks_heatmap": {"type": pn.widgets.Checkbox, "name": "Hide minor tick marks"}},
         )
 
-        return pn.Column(
-            "## " + self.basename,
-            pn.Row(
-                event_selector_heatmap,
-                color_map,
-                width_heatmap,
-                height_heatmap,
-                save_options_heatmap,
-                pn.Column(pn.Spacer(height=25), save_hm),
-            ),
-            pn.Row(self.plotter.heatmap, heatmap_y_parameters),
+        # Independent save controls (format selector + button), matching the PSTH plots.
+        save_hm = self._save_controls(options_name="save_options_heatmap", action_name="save_hm")
+
+        # Numeric axis limits (X/Y snap to Bokeh zoom/pan) and the colour-scale (clim)
+        # limits, all reusing the PSTH tab's _range_number_inputs helper. The X/Y boxes
+        # move the live figure in place; the colour-scale boxes re-render (heatmap_clim
+        # is in heatmap()'s @param.depends), for which move_figure_to_range is a no-op.
+        axis_limits = pn.Row(
+            self._range_number_inputs(name="heatmap_X", label="X"),
+            self._range_number_inputs(name="heatmap_Y", label="Y"),
         )
+        color_limits = self._range_number_inputs(name="heatmap_clim", label="Color scale")
+
+        heatmap_card = pn.Card(
+            pn.Row(event_selector_heatmap, color_map, width_heatmap, height_heatmap),
+            hide_minor_ticks_heatmap,
+            pn.pane.Markdown("**Axis limits**"),
+            axis_limits,
+            pn.pane.Markdown("**Color scale limits**"),
+            color_limits,
+            save_hm,
+            pn.Row(self.plotter.heatmap, heatmap_y_parameters),
+            title="Trial heatmap",
+            collapsed=False,
+        )
+
+        return pn.Column("## " + self.basename, heatmap_card)
 
     def build_template(self) -> pn.template.MaterialTemplate:
         """Build and return the Panel template without serving it."""

--- a/tests/unit/frontend/test_parameterized_plotter.py
+++ b/tests/unit/frontend/test_parameterized_plotter.py
@@ -134,6 +134,49 @@ def single_trial_plotter(tmp_path, panel_extension):
     )
 
 
+@pytest.fixture
+def varied_heatmap_plotter(tmp_path, panel_extension):
+    """Plotter whose heatmap trials hold non-constant values.
+
+    The default ``plotter`` fixture fills every trial with zeros, so a colour-scale
+    change maps every cell to the same colour and cannot reveal whether the clim
+    reached the data. This fixture gives each of three trials a distinct linear ramp
+    so different colour limits produce visibly different shaded pixels.
+    """
+    columns = ["trial_1", "trial_2", "trial_3", "bin_1", "timestamps", "mean", "err", "bin_err_1"]
+    n_timepoints = 30
+    timestamps = np.linspace(-5.0, 10.0, n_timepoints)
+    ramp = np.linspace(-2.0, 2.0, n_timepoints)
+
+    def make_event_dataframe():
+        values = {"timestamps": timestamps}
+        for offset, column in enumerate(["trial_1", "trial_2", "trial_3"]):
+            values[column] = ramp + offset
+        for column in ("bin_1", "mean", "err", "bin_err_1"):
+            values[column] = ramp
+        return pd.DataFrame(values, columns=columns)
+
+    events = ["event1", "event2"]
+    columns_dict = {event: columns for event in events}
+    df_new = pd.concat([make_event_dataframe() for event in events], keys=events, axis=1)
+
+    return ParameterizedPlotter(
+        event_selector_objects=events,
+        event_selector_heatmap_objects=events,
+        selector_for_multipe_events_plot_objects=events,
+        color_map_objects=["plasma", "viridis"],
+        x_objects=["timestamps"],
+        y_objects=["trial_1", "mean"],
+        heatmap_y_objects=["1 - trial_1", "2 - trial_2", "3 - trial_3", "All"],
+        psth_y_objects=None,
+        filepath=str(tmp_path),
+        columns_dict=columns_dict,
+        df_new=df_new,
+        x_min=-5.0,
+        x_max=10.0,
+    )
+
+
 class TestParameterizedPlotter:
     def test_constructs(self, plotter):
         assert isinstance(plotter, ParameterizedPlotter)
@@ -478,6 +521,103 @@ class TestParameterizedPlotter:
 
         assert plotter.overlay_X == (-5.0, 10.0)
         assert plotter.trials_X == (-5.0, 10.0)
+
+    # ---- heatmap customization (parity with the PSTH line plots) ----
+
+    def test_heatmap_x_range_initialized_from_x_min_x_max(self, plotter):
+        # The heatmap X (Time) range is seeded with the padded PSTH window like the line plots.
+        assert plotter.heatmap_X == (-5.0, 10.0)
+
+    def test_heatmap_y_and_clim_start_unset_for_autofit(self, plotter):
+        # Trials axis and colour scale start None so the first render auto-fits them.
+        assert plotter.heatmap_Y is None
+        assert plotter.heatmap_clim is None
+
+    def test_hide_minor_ticks_heatmap_defaults_to_false(self, plotter):
+        assert plotter.hide_minor_ticks_heatmap is False
+
+    def test_range_plots_includes_heatmap(self, plotter):
+        assert ("heatmap", "heatmap_X", "heatmap_Y") in plotter._RANGE_PLOTS
+
+    def test_move_figure_to_range_moves_heatmap_figure(self, plotter):
+        figure = _FakeFigure()
+        plotter._figures["heatmap"] = figure
+
+        plotter.heatmap_X = (0.0, 3.0)
+        plotter.heatmap_Y = (1.0, 5.0)
+        plotter.move_figure_to_range("heatmap_X")
+
+        assert (figure.x_range.start, figure.x_range.end) == (0.0, 3.0)
+        assert (figure.y_range.start, figure.y_range.end) == (1.0, 5.0)
+
+    def test_heatmap_autofits_clim_and_y_on_render(self, plotter):
+        image = plotter.heatmap()
+
+        assert image is not None
+        assert plotter.heatmap_clim is not None
+        assert plotter.heatmap_Y is not None
+
+    def test_heatmap_honours_clim_override(self, plotter):
+        # A user-set colour scale survives a render whose selection is unchanged.
+        plotter.heatmap()  # first render stores the selection and auto-fits clim
+        plotter.heatmap_clim = (-1.5, 2.5)
+
+        plotter.heatmap()
+
+        assert plotter.heatmap_clim == (-1.5, 2.5)
+
+    def test_heatmap_refits_clim_on_selection_change(self, plotter):
+        # Changing the trial selection discards a stale colour scale and refits to the new data.
+        plotter.heatmap()
+        plotter.heatmap_clim = (999.0, 1000.0)
+
+        plotter.heatmap_y = ["1 - trial_1", "2 - trial_2"]
+        plotter.heatmap()
+
+        assert plotter.heatmap_clim != (999.0, 1000.0)
+        assert plotter.heatmap_clim[1] < 999.0
+
+    def test_heatmap_color_limits_recolor_the_data_not_just_the_colorbar(self, varied_heatmap_plotter):
+        # Regression: the colour-scale limits must drive the datashaded pixels, not only
+        # the dummy colorbar. Two different clims over the same data must yield different
+        # shaded image data.
+        plotter = varied_heatmap_plotter
+
+        def shaded_image(clim):
+            plotter.heatmap_clim = clim
+            figure = hv.render(plotter.heatmap())
+            for renderer in figure.renderers:
+                data = getattr(renderer, "data_source", None)
+                if data is not None and "image" in data.data:
+                    return np.asarray(data.data["image"][0])
+            raise AssertionError("no datashaded image glyph found")
+
+        wide = shaded_image((-3.0, 3.0))
+        narrow = shaded_image((-0.2, 0.2))
+        assert not np.array_equal(wide, narrow)
+
+    def test_minor_ticks_shown_by_default_on_heatmap(self, plotter):
+        figure = hv.render(plotter.heatmap())
+        assert figure.xaxis[0].minor_tick_line_color is not None
+        assert figure.yaxis[0].minor_tick_line_color is not None
+
+    def test_hide_minor_ticks_removes_them_on_heatmap(self, plotter):
+        plotter.hide_minor_ticks_heatmap = True
+        figure = hv.render(plotter.heatmap())
+        assert figure.xaxis[0].minor_tick_line_color is None
+        assert figure.yaxis[0].minor_tick_line_color is None
+
+    def test_heatmap_axis_ranges_not_in_dependencies(self, plotter):
+        # heatmap_X/Y are hook-driven, so they must stay out of heatmap()'s @param.depends
+        # (a zoom/pan must not trigger a re-render that fights the gesture).
+        dependencies = {dependency.name for dependency in plotter.param.method_dependencies("heatmap")}
+        assert dependencies.isdisjoint({"heatmap_X", "heatmap_Y"})
+
+    def test_heatmap_clim_and_ticks_in_dependencies(self, plotter):
+        # A colour-scale or tick-visibility change has no live-figure equivalent, so both
+        # must re-render.
+        dependencies = {dependency.name for dependency in plotter.param.method_dependencies("heatmap")}
+        assert {"heatmap_clim", "hide_minor_ticks_heatmap"}.issubset(dependencies)
 
     def test_default_overlay_color_overrides_is_empty(self, plotter):
         assert plotter.overlay_color_overrides == {}

--- a/tests/unit/frontend/test_visualization_dashboard.py
+++ b/tests/unit/frontend/test_visualization_dashboard.py
@@ -158,8 +158,29 @@ class TestVisualizationDashboard:
         assert plotter.hide_minor_ticks is True
 
     def test_heatmap_tab_embeds_heatmap(self, dashboard, plotter):
-        # Panel wraps the heatmap reactive method in a ParamMethod inside a pn.Row.
-        heatmap_row = dashboard._heatmap_tab.objects[-1]
-        assert isinstance(heatmap_row, pn.Row)
-        wrapped_methods = [obj.object for obj in heatmap_row.objects if hasattr(obj, "object") and callable(obj.object)]
-        assert plotter.heatmap in wrapped_methods
+        # The heatmap reactive method is wrapped in a ParamMethod pane nested inside the
+        # heatmap Card, so search the tab recursively (as the PSTH tab test does).
+        panes = dashboard._heatmap_tab.select(
+            lambda obj: hasattr(obj, "object") and callable(getattr(obj, "object", None))
+        )
+        assert plotter.heatmap in [pane.object for pane in panes]
+
+    def test_heatmap_tab_uses_number_inputs_for_axis_and_color_limits(self, dashboard):
+        # X + Y + colour-scale = 3 ranges x (min, max) = 6 FloatInput boxes.
+        number_inputs = list(dashboard._heatmap_tab.select(pn.widgets.FloatInput))
+        assert len(number_inputs) == 6
+
+    def test_heatmap_tab_has_hide_minor_ticks_checkbox(self, dashboard, plotter):
+        checkboxes = {box.name: box for box in dashboard._heatmap_tab.select(pn.widgets.Checkbox)}
+        assert "Hide minor tick marks" in checkboxes
+
+        checkbox = checkboxes["Hide minor tick marks"]
+        assert checkbox.value is False  # ticks shown by default
+
+        checkbox.value = True
+        assert plotter.hide_minor_ticks_heatmap is True
+
+    def test_heatmap_tab_has_save_controls(self, dashboard):
+        assert list(dashboard._heatmap_tab.select(pn.widgets.Button))
+        selects = {select.name for select in dashboard._heatmap_tab.select(pn.widgets.Select)}
+        assert "Save format" in selects


### PR DESCRIPTION
Brings the visualization dashboard's Heat Map tab up to parity with the customization added to the PSTH line plots in [#365](https://github.com/LernerLab/GuPPy/pull/365) / [#370](https://github.com/LernerLab/GuPPy/pull/370).

Adds to the Heat Map tab:
- Numeric **X (Time)** and **Y (Trials)** axis-limit boxes that stay in sync with Bokeh zoom/pan.
- Editable **colour-scale (clim) limits** — previously the colour intensity range was silently auto-fit to the data with no override.
- An independent **hide-minor-ticks** toggle.

All three ranges auto-fit on selection change. The colour-scale limits are applied to the datashaded data (`cnorm="linear"`, `clims=...`), not just the dummy colorbar, so the legend and the pixels share the same range and the boxes actually recolour the data.

Reuses the existing PSTH helpers (`_range_sync_hook`, `move_figure_to_range`, `_range_number_inputs`, `_reset_y_on_selection_change`, the Card layout); the hide-minor-ticks hook became a small factory parameterized by the toggle name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)