### PR TITLE
Remove commented-out code and clarify remaining comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - The Heat Map's first and last trial rows no longer render at half height: the Trials (Y) axis now always spans the full cell edges on every render, and its manual axis-limit boxes (which could clip the edge rows) were removed since the axis only encodes trial number. [PR #374](https://github.com/LernerLab/GuPPy/pull/374)
 
 ## Improvements
+- Removed commented-out dead code throughout `src/guppy/` and clarified the remaining comments. [PR #XXX](https://github.com/LernerLab/GuPPy/pull/XXX)
 
 ## Deprecations and Removals
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - The Heat Map's first and last trial rows no longer render at half height: the Trials (Y) axis now always spans the full cell edges on every render, and its manual axis-limit boxes (which could clip the edge rows) were removed since the axis only encodes trial number. [PR #374](https://github.com/LernerLab/GuPPy/pull/374)
 
 ## Improvements
-- Removed commented-out dead code throughout `src/guppy/` and clarified the remaining comments. [PR #XXX](https://github.com/LernerLab/GuPPy/pull/XXX)
+- Removed commented-out dead code throughout `src/guppy/` and clarified the remaining comments. [PR #376](https://github.com/LernerLab/GuPPy/pull/376)
 
 ## Deprecations and Removals
 

--- a/src/guppy/analysis/artifact_removal.py
+++ b/src/guppy/analysis/artifact_removal.py
@@ -120,7 +120,7 @@ def addingNaNtoChunksWithArtifacts(
             if (
                 "control_" + pair_name.lower() in names_for_storenames[i].lower()
                 or "signal_" + pair_name.lower() in names_for_storenames[i].lower()
-            ):  # changes done
+            ):
                 data = name_to_data[names_for_storenames[i]].reshape(-1)
                 data = addingNaNValues(data=data, ts=tsNew, coords=coords)
                 name_to_corrected_data[names_for_storenames[i]] = data
@@ -191,7 +191,7 @@ def processTimestampsForArtifacts(
             if (
                 "control_" + pair_name.lower() in names_for_storenames[i].lower()
                 or "signal_" + pair_name.lower() in names_for_storenames[i].lower()
-            ):  # changes done
+            ):
                 data = name_to_data[names_for_storenames[i]]
                 data, timestampNew = eliminateData(
                     data=data,
@@ -268,13 +268,11 @@ def eliminateData(
             ts_arr = np.concatenate((ts_arr, new_ts))
         else:
             temp = data[index]
-            # new = temp + (arr[-1]-temp[0])
             temp_ts = ts[index]
             new_ts = temp_ts - (temp_ts[0] - ts_arr[-1])
             arr = np.concatenate((arr, temp))
             ts_arr = np.concatenate((ts_arr, new_ts + (1 / sampling_rate)))
 
-    # logger.info(arr.shape, ts_arr.shape)
     return arr, ts_arr
 
 

--- a/src/guppy/analysis/combine_data.py
+++ b/src/guppy/analysis/combine_data.py
@@ -148,7 +148,6 @@ def combine_data(
     compound_name_to_ttl_timestamps : dict
         Compound TTL name → combined TTL timestamp array.
     """
-    # filepaths_to_combine = [folder1_output_i, folder2_output_i, ...]
     logger.debug("Processing timestamps for combining data...")
 
     names_for_storenames = storesList[1, :]

--- a/src/guppy/analysis/compute_psth.py
+++ b/src/guppy/analysis/compute_psth.py
@@ -123,7 +123,7 @@ def compute_psth(
 
     # initialize PSTH vector
     psth = np.full((nTs, totalTs + 1), np.nan)
-    psth_baselineUncorrected = np.full((nTs, totalTs + 1), np.nan)  # extra
+    psth_baselineUncorrected = np.full((nTs, totalTs + 1), np.nan)
 
     # for each timestamp, create trial which will be saved in a PSTH vector
     for i in range(nTs):
@@ -141,7 +141,7 @@ def compute_psth(
         else:
             arr = arr
 
-        psth_baselineUncorrected[i, :] = arr  # extra
+        psth_baselineUncorrected[i, :] = arr
         psth[i, :] = baselineCorrection(arr, timeAxis, baselineStart, baselineEnd)
 
     columns = list(ts)

--- a/src/guppy/analysis/control_channel.py
+++ b/src/guppy/analysis/control_channel.py
@@ -153,7 +153,6 @@ def helper_create_control_channel(signal: np.ndarray, timestamps: np.ndarray, wi
     except Exception as e:
         logger.error(str(e))
 
-    # logger.info('Curve Fit Parameters : ', popt)
     control = curveFitFn(timestamps, *popt)
 
     return control

--- a/src/guppy/analysis/io_utils.py
+++ b/src/guppy/analysis/io_utils.py
@@ -84,9 +84,9 @@ def decide_naming_convention(filepath: str) -> np.ndarray:
         Shape ``(2, N)`` array where row 0 contains control file paths and
         row 1 contains the matching signal file paths.
     """
-    path_1 = find_files(filepath, "control_*", ignore_case=True)  # glob.glob(os.path.join(filepath, 'control*'))
+    path_1 = find_files(filepath, "control_*", ignore_case=True)
 
-    path_2 = find_files(filepath, "signal_*", ignore_case=True)  # glob.glob(os.path.join(filepath, 'signal*'))
+    path_2 = find_files(filepath, "signal_*", ignore_case=True)
 
     path = sorted(path_1 + path_2, key=str.casefold)
     if len(path) % 2 != 0:

--- a/src/guppy/analysis/psth_average.py
+++ b/src/guppy/analysis/psth_average.py
@@ -80,7 +80,6 @@ def averageForGroup(folderNames: list[str], event: str, inputParameters: dict[st
         bins_cols = []
         temp_path = new_path[i]
         for j in range(len(temp_path)):
-            # logger.info(os.path.join(temp_path[j][0], temp_path[j][1]+'_{}.h5'.format(temp_path[j][2])))
             if not os.path.exists(os.path.join(temp_path[j][0], temp_path[j][1] + "_{}.h5".format(temp_path[j][2]))):
                 continue
             else:
@@ -146,7 +145,7 @@ def averageForGroup(folderNames: list[str], event: str, inputParameters: dict[st
             )
             continue
         index = list(np.concatenate(index))
-        new_df = pd.concat(arr, axis=0)  # os.path.join(filepath, 'peak_AUC_'+name+'.csv')
+        new_df = pd.concat(arr, axis=0)
         new_df.to_csv(os.path.join(op, "peak_AUC_{}_{}.csv".format(temp_path[j][1], temp_path[j][2])), index=index)
         new_df.to_hdf(
             os.path.join(op, "peak_AUC_{}_{}.h5".format(temp_path[j][1], temp_path[j][2])),

--- a/src/guppy/analysis/psth_utils.py
+++ b/src/guppy/analysis/psth_utils.py
@@ -34,10 +34,6 @@ def create_Df_for_psth(filepath: str, event: str, name: str, psth: np.ndarray, c
     else:
         op = os.path.join(filepath, event + ".h5")
 
-    # check if file already exists
-    # if os.path.exists(op):
-    # 	return 0
-
     # removing psth binned trials
     columns = np.array(columns, dtype="str")
     regex = re.compile("bin_*")
@@ -51,8 +47,6 @@ def create_Df_for_psth(filepath: str, event: str, name: str, psth: np.ndarray, c
         err = err.reshape(-1, 1)
         psth = np.hstack((psth, mean))
         psth = np.hstack((psth, err))
-        # timestamps = np.asarray(read_Df(filepath, 'ts_psth', ''))
-        # psth = np.hstack((psth, timestamps))
 
     columns = np.asarray(columns)
     columns = np.append(columns, ["mean", "err"])
@@ -85,10 +79,6 @@ def create_Df_for_cross_correlation(
     else:
         op = os.path.join(filepath, event + ".h5")
 
-    # check if file already exists
-    # if os.path.exists(op):
-    # 	return 0
-
     # removing psth binned trials
     columns = list(np.array(columns, dtype="str"))
     regex = re.compile("bin_*")
@@ -102,8 +92,6 @@ def create_Df_for_cross_correlation(
         err = err.reshape(-1, 1)
         psth = np.hstack((psth, mean))
         psth = np.hstack((psth, err))
-        # timestamps = np.asarray(read_Df(filepath, 'ts_psth', ''))
-        # psth = np.hstack((psth, timestamps))
 
     columns = np.asarray(columns)
     columns = np.append(columns, ["mean", "err"])

--- a/src/guppy/analysis/timestamp_correction.py
+++ b/src/guppy/analysis/timestamp_correction.py
@@ -133,7 +133,6 @@ def timestampCorrection(
     for i in range(channels_arr.shape[1]):
         control_name = channels_arr[0, i]
         signal_name = channels_arr[1, i]
-        # dirname = os.path.dirname(path[i])
         idx = np.where(names_for_storenames == indices[i])[0]
 
         name = names_for_storenames[idx][0]

--- a/src/guppy/analysis/transients.py
+++ b/src/guppy/analysis/transients.py
@@ -123,7 +123,6 @@ def processChunks(
     newPeaks = np.full(arrValues.shape[0], np.nan)
     newPeaks[peaks] = peaks + arrIndexes[0]
 
-    # madY = np.full(arrValues.shape[0], mad)
     medianY = np.full(arrValues.shape[0], median)
     filteredOutMedianY = np.full(arrValues.shape[0], filteredOutMedian)
 
@@ -220,7 +219,6 @@ def calculate_freq_amp(
 
     peaksInd = peaksInd.ravel()
     peaksInd = peaksInd.astype(int)
-    # logger.info(timestamps)
     freq = peaksAmp.shape[0] / ((timestamps[-1] - timestamps[0]) / 60)
 
     return freq, peaksAmp, peaksInd

--- a/src/guppy/analysis/transients_average.py
+++ b/src/guppy/analysis/transients_average.py
@@ -47,7 +47,6 @@ def averageForGroup(folderNames: list[str], inputParameters: dict[str, object]) 
 
         for j in range(len(path_temp)):
             basename = (os.path.basename(path_temp[j])).split(".")[0]
-            # name = name[0]
             temp = [folderNames[i], basename]
             path.append(temp)
 
@@ -66,7 +65,7 @@ def averageForGroup(folderNames: list[str], inputParameters: dict[str, object]) 
     op = makeAverageDir(abspath)
 
     for i in range(len(new_path)):
-        arr = []  # np.zeros((len(new_path[i]), 2))
+        arr = []
         fileName = []
         temp_path = new_path[i]
         for j in range(len(temp_path)):

--- a/src/guppy/analysis/z_score.py
+++ b/src/guppy/analysis/z_score.py
@@ -151,12 +151,12 @@ def execute_controlFit_dff(
     """
 
     if isosbestic_control == False:
-        signal_smooth = filterSignal(filter_window, signal)  # ss.filtfilt(b, a, signal)
+        signal_smooth = filterSignal(filter_window, signal)
         control_fit = controlFit(control, signal_smooth, method=control_fit_method)
         norm_data = deltaFF(signal_smooth, control_fit)
     else:
-        control_smooth = filterSignal(filter_window, control)  # ss.filtfilt(b, a, control)
-        signal_smooth = filterSignal(filter_window, signal)  # ss.filtfilt(b, a, signal)
+        control_smooth = filterSignal(filter_window, control)
+        signal_smooth = filterSignal(filter_window, signal)
         control_fit = controlFit(control_smooth, signal_smooth, method=control_fit_method)
         norm_data = deltaFF(signal_smooth, control_fit)
 
@@ -182,7 +182,6 @@ def deltaFF(signal: np.ndarray, control: np.ndarray) -> np.ndarray:
 
     res = np.subtract(signal, control)
     normData = np.divide(res, control)
-    # deltaFF = normData
     normData = normData * 100
 
     return normData

--- a/src/guppy/extractors/tdt_recording_extractor.py
+++ b/src/guppy/extractors/tdt_recording_extractor.py
@@ -137,8 +137,6 @@ class TdtRecordingExtractor(BaseRecordingExtractor):
 
         eventNew = np.array(list(event))
 
-        # logger.info(allnames)
-        # logger.info(eventNew)
         row = self._ismember(data["name"], event)
 
         if sum(row) == 0:

--- a/src/guppy/frontend/npm_gui_prompts.py
+++ b/src/guppy/frontend/npm_gui_prompts.py
@@ -104,7 +104,6 @@ def get_timestamp_configuration(
         timestamps_combo = ttk.Combobox(window, values=col_names_ts, textvariable=holdComboboxValues["timestamps"])
         timestamps_combo.grid(row=0, column=2, pady=25, padx=25)
         timestamps_combo.current(0)
-        # timestamps_combo.bind("<<ComboboxSelected>>", comboBoxSelected)
 
         time_unit_label = ttk.Label(window, text="Select timestamps unit : ").grid(row=1, column=1, pady=25, padx=25)
         holdComboboxValues["time_unit"] = StringVar()
@@ -115,7 +114,6 @@ def get_timestamp_configuration(
         )
         time_unit_combo.grid(row=1, column=2, pady=25, padx=25)
         time_unit_combo.current(0)
-        # time_unit_combo.bind("<<ComboboxSelected>>", comboBoxSelected)
         window.lift()
         window.after(500, lambda: window.lift())
         window.mainloop()

--- a/src/guppy/frontend/parameterized_plotter.py
+++ b/src/guppy/frontend/parameterized_plotter.py
@@ -712,7 +712,6 @@ class ParameterizedPlotter(param.Parameterized):
             op_filename = os.path.join(op, self.event_selector + "_" + self.y)
             self.results_psth["plot"] = img
             self.results_psth["op"] = op_filename
-            # self.save_plots(img, save_opts, op_filename)
 
             return img
 
@@ -748,10 +747,8 @@ class ParameterizedPlotter(param.Parameterized):
                 line_width=0,
             )
 
-            plot_curve = hv.Curve((xpoints[index], ypoints[index]))  # .opts(**ropts_curve)
-            plot_spread = hv.Spread(
-                (xpoints[index], ypoints[index], err[index], err[index])
-            )  # .opts(**ropts_spread) #vdims=['y', 'yerrpos', 'yerrneg']
+            plot_curve = hv.Curve((xpoints[index], ypoints[index]))
+            plot_spread = hv.Spread((xpoints[index], ypoints[index], err[index], err[index]))
             plot = (plot_curve * plot_spread).opts({"Curve": ropts_curve, "Spread": ropts_spread})
             plot = plot.opts(
                 hooks=[

--- a/src/guppy/frontend/storenames_instructions.py
+++ b/src/guppy/frontend/storenames_instructions.py
@@ -5,7 +5,6 @@ import holoviews as hv
 import numpy as np
 import panel as pn
 
-# hv.extension()
 pn.extension()
 
 logger = logging.getLogger(__name__)

--- a/src/guppy/frontend/storenames_selector.py
+++ b/src/guppy/frontend/storenames_selector.py
@@ -40,13 +40,11 @@ class StorenamesSelector:
         self.literal_input_1 = pn.widgets.LiteralInput(
             name="Number of times you want the above storename (list)", value=[], type=list
         )
-        # self.literal_input_2 = pn.widgets.LiteralInput(name='Names for Storenames (list)', type=list)
 
         self.repeat_storenames = pn.widgets.Checkbox(name="Storenames to repeat", value=False)
         self.repeat_storename_wd = pn.WidgetBox("", width=600)
 
         self.repeat_storenames.link(self.repeat_storename_wd, callbacks={"value": self.callback})
-        # self.repeat_storename_wd = pn.WidgetBox('Storenames to repeat (leave blank if not needed)', multi_choice, literal_input_1, background="white", width=600)
 
         self.update_options = pn.widgets.Button(name="Select Storenames", width=600)
         self.save = pn.widgets.Button(name="Save", width=600)

--- a/src/guppy/orchestration/preprocess.py
+++ b/src/guppy/orchestration/preprocess.py
@@ -95,9 +95,9 @@ def visualizeControlAndSignal(filepath: str, removeArtifacts: bool) -> list:
     widgets : list of ArtifactRemovalWidget
         One widget per channel pair.
     """
-    path_1 = find_files(filepath, "control_*", ignore_case=True)  # glob.glob(os.path.join(filepath, 'control*'))
+    path_1 = find_files(filepath, "control_*", ignore_case=True)
 
-    path_2 = find_files(filepath, "signal_*", ignore_case=True)  # glob.glob(os.path.join(filepath, 'signal*'))
+    path_2 = find_files(filepath, "signal_*", ignore_case=True)
 
     path = sorted(path_1 + path_2, key=str.casefold)
 
@@ -246,8 +246,8 @@ def execute_zscore(folderNames: list[str], inputParameters: dict[str, object]) -
     for j in range(len(storesListPath)):
         filepath = storesListPath[j]
         logger.debug(f"Computing z-score for each of the data in {filepath}")
-        path_1 = find_files(filepath, "control_*", ignore_case=True)  # glob.glob(os.path.join(filepath, 'control*'))
-        path_2 = find_files(filepath, "signal_*", ignore_case=True)  # glob.glob(os.path.join(filepath, 'signal*'))
+        path_1 = find_files(filepath, "control_*", ignore_case=True)
+        path_2 = find_files(filepath, "signal_*", ignore_case=True)
         path = sorted(path_1 + path_2, key=str.casefold)
         if len(path) % 2 != 0:
             controls = sorted(p for p in path if "control_" in os.path.basename(p).lower())
@@ -539,8 +539,6 @@ def extractTsAndSignal(inputParameters: dict[str, object]) -> None:
     # on-disk GuPPyParamtersUsed.json always reflects the last-run configuration.
     save_parameters(inputParameters=inputParameters)
 
-    # storesList = np.genfromtxt(inputParameters['storesListPath'], dtype='str', delimiter=',')
-
     folderNames = inputParameters["folderNames"]
     timeForLightsTurnOn = inputParameters["timeForLightsTurnOn"]
     isosbestic_control = inputParameters["isosbestic_control"]
@@ -556,8 +554,6 @@ def extractTsAndSignal(inputParameters: dict[str, object]) -> None:
     for i in range(len(folderNames)):
         storesListPath.append(select_output_dirs(folderNames[i], selected_outputs.get(folderNames[i])))
     storesListPath = np.concatenate(storesListPath)
-    # pbMaxValue = storesListPath.shape[0] + len(folderNames)
-    # writeToFile(str((pbMaxValue+1)*10)+'\n'+str(10)+'\n')
     if combine_data == False:
         pbMaxValue = storesListPath.shape[0] + len(folderNames)
         writeToFile(str((pbMaxValue + 1) * 10) + "\n" + str(10) + "\n", file_path=PB_STEPS_FILE)

--- a/src/guppy/orchestration/psth.py
+++ b/src/guppy/orchestration/psth.py
@@ -120,7 +120,7 @@ def execute_compute_psth(filepath: str, event: str, inputParameters: dict[str, o
             basename,
             psth_baselineUncorrected,
             columns=cols,
-        )  # extra
+        )
         create_Df_for_psth(filepath, event + "_" + name_1, basename, psth, columns=cols)
         logger.info(f"PSTH for event {event} computed.")
 
@@ -142,7 +142,6 @@ def execute_compute_psth_peak_and_area(filepath: str, event: str, inputParameter
     if "control" in event.lower() or "signal" in event.lower():
         return 0
 
-    # sampling_rate = read_hdf5(storesList[0,0], filepath, 'sampling_rate')
     peak_startPoint = inputParameters["peak_startPoint"]
     peak_endPoint = inputParameters["peak_endPoint"]
     selectForComputePsth = inputParameters["selectForComputePsth"]
@@ -167,16 +166,13 @@ def execute_compute_psth_peak_and_area(filepath: str, event: str, inputParameter
         trials_names = [cols[i] for i in range(len(cols)) if regex_trials.match(cols[i])]
         psth_mean_bin_names = trials_names + bin_names + ["mean"]
         psth_mean_bin_mean = np.asarray(psth[psth_mean_bin_names])
-        timestamps = np.asarray(psth["timestamps"]).ravel()  # np.asarray(read_Df(filepath, 'ts_psth', '')).ravel()
+        timestamps = np.asarray(psth["timestamps"]).ravel()
         peak_area = compute_psth_peak_and_area(
             psth_mean_bin_mean, timestamps, sampling_rate, peak_startPoint, peak_endPoint
-        )  # peak, area =
-        # arr = np.array([[peak, area]])
+        )
         fileName = [os.path.basename(os.path.dirname(filepath))]
         index = [fileName[0] + "_" + s for s in psth_mean_bin_names]
-        write_peak_and_area_to_hdf5(
-            filepath, peak_area, event + "_" + name_1 + "_" + basename, index=index
-        )  # columns=['peak', 'area']
+        write_peak_and_area_to_hdf5(filepath, peak_area, event + "_" + name_1 + "_" + basename, index=index)
         write_peak_and_area_to_csv(filepath, peak_area, event + "_" + name_1 + "_" + basename, index=index)
         logger.info(f"Peak and Area for PSTH mean signal for event {event} computed.")
 
@@ -286,10 +282,6 @@ def orchestrate_psth(inputParameters: dict[str, object]) -> None:
                 cr.starmap(
                     execute_compute_cross_correlation, zip(repeat(filepath), storesList[1, :], repeat(inputParameters))
                 )
-
-                # for k in range(storesList.shape[1]):
-                # 	storenamePsth(filepath, storesList[1,k], inputParameters)
-                # 	findPSTHPeakAndArea(filepath, storesList[1,k], inputParameters)
 
             writeToFile(str(10 + ((inputParameters["step"] + 1) * 10)) + "\n", file_path=PB_STEPS_FILE)
             inputParameters["step"] += 1
@@ -497,8 +489,6 @@ def psthForEachStorename(inputParameters: dict[str, object]) -> dict[str, object
 
     _validate_psth_window_parameters(inputParameters)
 
-    # storesList = np.genfromtxt(inputParameters['storesListPath'], dtype='str', delimiter=',')
-
     average = inputParameters["averageForGroup"]
     combine_data = inputParameters["combine_data"]
     numProcesses = inputParameters["numberOfCores"]
@@ -521,11 +511,11 @@ def psthForEachStorename(inputParameters: dict[str, object]) -> dict[str, object
 
     logger.info(f"Average for group : {average}")
 
-    # for average following if statement will be executed
+    # Group-average analysis aggregates PSTHs across all sessions in the group.
     if average == True:
         execute_average_for_group(inputParameters)
 
-    # for individual analysis following else statement will be executed
+    # Otherwise each session is analyzed individually.
     else:
         if combine_data == True:
             execute_psth_combined(inputParameters)

--- a/src/guppy/orchestration/visualize.py
+++ b/src/guppy/orchestration/visualize.py
@@ -75,7 +75,6 @@ def helper_plots(filepath: str, event: list[str], name: list[str] | str, inputPa
                 cols = list(temp_df.columns)
                 regex = re.compile("bin_[(]")
                 bins[new_event[-1]] = [cols[i] for i in range(len(cols)) if regex.match(cols[i])]
-                # bins.append(keep_cols)
                 frames.append(temp_df)
 
         df = pd.concat(frames, keys=new_event, axis=1)
@@ -111,7 +110,6 @@ def helper_plots(filepath: str, event: list[str], name: list[str] | str, inputPa
         for i in range(len(bins_keys)):
             arr = bins[bins_keys[i]]
             if len(arr) > 0:
-                # heatmap_options.append('{}_bin'.format(bins_keys[i]))
                 for j in arr:
                     multiple_plots_options.append("{}_{}".format(bins_keys[i], j))
 
@@ -372,9 +370,7 @@ def visualizeResults(inputParameters: dict[str, object]) -> None:
     combine_data = inputParameters["combine_data"]
 
     if average == True and len(folderNamesForAvg) > 0:
-        # folderNames = folderNamesForAvg
         filepath_avg = os.path.join(inputParameters["abspath"], "average")
-        # filepath = os.path.join(inputParameters['abspath'], folderNames[0])
         group_selected_outputs = inputParameters.get("groupSelectedOutputs") or {}
         storesListPath = []
         for i in range(len(folderNamesForAvg)):
@@ -432,7 +428,3 @@ def visualizeResults(inputParameters: dict[str, object]) -> None:
                     ).reshape(2, -1)
 
                     createPlots(filepath, storesList[1, :], inputParameters)
-
-
-# logger.info(sys.argv[1:])
-# visualizeResults(sys.argv[1:][0])


### PR DESCRIPTION
Sweeps `src/guppy/` for commented-out dead code and removes it: disabled statements, old widget definitions, superseded assignments, stale `folderNames`/`storesList` plumbing, and inline old implementations left as trailing comments. Also rewords a few WHAT-restatement comments and drops some vague scratch notes (`# extra`, `# changes done`). `TODO`/`FIXME` markers are left intact.

Verified with `pre-commit` and the full `tests/consistency` suite (20 passed) — since this only touches comments, the consistency regression tests confirm no output changed.

Resolves #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)