### PR TITLE
Use informative variable names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - The Heat Map's first and last trial rows no longer render at half height: the Trials (Y) axis now always spans the full cell edges on every render, and its manual axis-limit boxes (which could clip the edge rows) were removed since the axis only encodes trial number. [PR #374](https://github.com/LernerLab/GuPPy/pull/374)
 
 ## Improvements
-- Renamed vague variable names (`arr`, `d`, `ts`, `op`, `cols`, suffixed `*_arr`, etc.) throughout `src/guppy/` to descriptive, context-appropriate names; behavior-preserving (consistency suite unchanged). [PR #XXX](https://github.com/LernerLab/GuPPy/pull/XXX)
+- Renamed vague variable names (`arr`, `d`, `ts`, `op`, `cols`, suffixed `*_arr`, etc.) throughout `src/guppy/` to descriptive, context-appropriate names; behavior-preserving (consistency suite unchanged). [PR #378](https://github.com/LernerLab/GuPPy/pull/378)
 - Deduplicated copy-pasted code: shared timestamp-realignment kernels for artifact-removal and multi-session combining, a shared group-averaging preamble, a single pipeline-step launch helper in the homepage, and shared ndx-fiber-photometry boilerplate across the mock-NWB generators. [PR #377](https://github.com/LernerLab/GuPPy/pull/377)
 - Removed commented-out dead code throughout `src/guppy/` and clarified the remaining comments. [PR #376](https://github.com/LernerLab/GuPPy/pull/376)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - The Heat Map's first and last trial rows no longer render at half height: the Trials (Y) axis now always spans the full cell edges on every render, and its manual axis-limit boxes (which could clip the edge rows) were removed since the axis only encodes trial number. [PR #374](https://github.com/LernerLab/GuPPy/pull/374)
 
 ## Improvements
+- Renamed vague variable names (`arr`, `d`, `ts`, `op`, `cols`, suffixed `*_arr`, etc.) throughout `src/guppy/` to descriptive, context-appropriate names; behavior-preserving (consistency suite unchanged). [PR #XXX](https://github.com/LernerLab/GuPPy/pull/XXX)
 - Deduplicated copy-pasted code: shared timestamp-realignment kernels for artifact-removal and multi-session combining, a shared group-averaging preamble, a single pipeline-step launch helper in the homepage, and shared ndx-fiber-photometry boilerplate across the mock-NWB generators. [PR #377](https://github.com/LernerLab/GuPPy/pull/377)
 - Removed commented-out dead code throughout `src/guppy/` and clarified the remaining comments. [PR #376](https://github.com/LernerLab/GuPPy/pull/376)
 

--- a/src/guppy/analysis/artifact_removal.py
+++ b/src/guppy/analysis/artifact_removal.py
@@ -124,16 +124,16 @@ def addingNaNtoChunksWithArtifacts(
                 or "signal_" + pair_name.lower() in names_for_storenames[i].lower()
             ):
                 data = name_to_data[names_for_storenames[i]].reshape(-1)
-                data = addingNaNValues(data=data, ts=tsNew, coords=coords)
+                data = addingNaNValues(data=data, timestamps=tsNew, coords=coords)
                 name_to_corrected_data[names_for_storenames[i]] = data
             else:
                 if "control" in names_for_storenames[i].lower() or "signal" in names_for_storenames[i].lower():
                     continue
                 ttl_name = names_for_storenames[i]
                 compound_name = ttl_name + "_" + pair_name
-                ts = compound_name_to_ttl_timestamps[compound_name].reshape(-1)
-                ts = removeTTLs(ts=ts, coords=coords)
-                compound_name_to_corrected_ttl_timestamps[compound_name] = ts
+                ttl_timestamps = compound_name_to_ttl_timestamps[compound_name].reshape(-1)
+                ttl_timestamps = removeTTLs(ttl_timestamps=ttl_timestamps, coords=coords)
+                compound_name_to_corrected_ttl_timestamps[compound_name] = ttl_timestamps
     logger.info("Chunks with artifacts are replaced by NaN values.")
 
     return name_to_corrected_data, compound_name_to_corrected_ttl_timestamps
@@ -197,7 +197,7 @@ def processTimestampsForArtifacts(
                 data = name_to_data[names_for_storenames[i]]
                 data, timestampNew = eliminateData(
                     data=data,
-                    ts=tsNew,
+                    timestamps=tsNew,
                     coords=coords,
                     timeForLightsTurnOn=timeForLightsTurnOn,
                     sampling_rate=sampling_rate,
@@ -208,15 +208,15 @@ def processTimestampsForArtifacts(
                 if "control" in names_for_storenames[i].lower() or "signal" in names_for_storenames[i].lower():
                     continue
                 compound_name = names_for_storenames[i] + "_" + pair_name
-                ts = compound_name_to_ttl_timestamps[compound_name]
-                ts = eliminateTs(
-                    ts=ts,
+                ttl_timestamps = compound_name_to_ttl_timestamps[compound_name]
+                ttl_timestamps = eliminateTs(
+                    ttl_timestamps=ttl_timestamps,
                     tsNew=tsNew,
                     coords=coords,
                     timeForLightsTurnOn=timeForLightsTurnOn,
                     sampling_rate=sampling_rate,
                 )
-                compound_name_to_corrected_ttl_timestamps[compound_name] = ts
+                compound_name_to_corrected_ttl_timestamps[compound_name] = ttl_timestamps
 
     logger.info("Timestamps processed, artifacts are removed and good chunks are concatenated.")
 
@@ -228,7 +228,7 @@ def processTimestampsForArtifacts(
 
 
 def eliminateData(
-    *, data: np.ndarray, ts: np.ndarray, coords: np.ndarray, timeForLightsTurnOn: float, sampling_rate: float
+    *, data: np.ndarray, timestamps: np.ndarray, coords: np.ndarray, timeForLightsTurnOn: float, sampling_rate: float
 ) -> tuple[np.ndarray, np.ndarray]:
     """
     Concatenate non-artifact data chunks and realign their timestamps.
@@ -236,8 +236,8 @@ def eliminateData(
     Parameters
     ----------
     data : np.ndarray
-        1-D data array aligned with ``ts``.
-    ts : np.ndarray
+        1-D data array aligned with ``timestamps``.
+    timestamps : np.ndarray
         1-D timestamp array.
     coords : np.ndarray
         Shape ``(N, 2)`` array of ``[start, end]`` bounds for good chunks.
@@ -248,32 +248,37 @@ def eliminateData(
 
     Returns
     -------
-    arr : np.ndarray
+    concatenated_data : np.ndarray
         Concatenated data from all good chunks.
-    ts_arr : np.ndarray
-        Realigned timestamps corresponding to ``arr``.
+    realigned_timestamps : np.ndarray
+        Realigned timestamps corresponding to ``concatenated_data``.
     """
 
     if (data == 0).all() == True:
-        data = np.zeros(ts.shape[0])
+        data = np.zeros(timestamps.shape[0])
 
     segments = []
     for i in range(coords.shape[0]):
-        index = np.where((ts > coords[i, 0]) & (ts < coords[i, 1]))[0]
-        segments.append((data[index], ts[index]))
+        in_window_indices = np.where((timestamps > coords[i, 0]) & (timestamps < coords[i, 1]))[0]
+        segments.append((data[in_window_indices], timestamps[in_window_indices]))
 
     return concatenate_and_realign_data(segments, timeForLightsTurnOn=timeForLightsTurnOn, sampling_rate=sampling_rate)
 
 
 def eliminateTs(
-    *, ts: np.ndarray, tsNew: np.ndarray, coords: np.ndarray, timeForLightsTurnOn: float, sampling_rate: float
+    *,
+    ttl_timestamps: np.ndarray,
+    tsNew: np.ndarray,
+    coords: np.ndarray,
+    timeForLightsTurnOn: float,
+    sampling_rate: float,
 ) -> np.ndarray:
     """
     Realign TTL timestamps to match concatenated non-artifact photometry chunks.
 
     Parameters
     ----------
-    ts : np.ndarray
+    ttl_timestamps : np.ndarray
         TTL timestamp array to realign.
     tsNew : np.ndarray
         Corrected photometry timestamp array used as the reference.
@@ -286,30 +291,30 @@ def eliminateTs(
 
     Returns
     -------
-    ts_arr : np.ndarray
+    realigned_ttl_timestamps : np.ndarray
         Realigned TTL timestamps.
     """
 
-    # tsNew (continuous) and ts (events) are both on the recording-start basis, matching the basis
-    # of the artifact-removal coords, so both windowing comparisons are consistent.
+    # tsNew (continuous) and ttl_timestamps (events) are both on the recording-start basis, matching
+    # the basis of the artifact-removal coords, so both windowing comparisons are consistent.
     pairs = []
     for i in range(coords.shape[0]):
-        tsNew_index = np.where((tsNew > coords[i, 0]) & (tsNew < coords[i, 1]))[0]
-        ts_index = np.where((ts > coords[i, 0]) & (ts < coords[i, 1]))[0]
-        pairs.append((tsNew[tsNew_index], ts[ts_index]))
+        reference_in_window_indices = np.where((tsNew > coords[i, 0]) & (tsNew < coords[i, 1]))[0]
+        ttl_in_window_indices = np.where((ttl_timestamps > coords[i, 0]) & (ttl_timestamps < coords[i, 1]))[0]
+        pairs.append((tsNew[reference_in_window_indices], ttl_timestamps[ttl_in_window_indices]))
 
     return realign_ttl_timestamps(pairs, timeForLightsTurnOn=timeForLightsTurnOn, sampling_rate=sampling_rate)
 
 
-def addingNaNValues(*, data: np.ndarray, ts: np.ndarray, coords: np.ndarray) -> np.ndarray:
+def addingNaNValues(*, data: np.ndarray, timestamps: np.ndarray, coords: np.ndarray) -> np.ndarray:
     """
     Set data samples outside the good-chunk windows to NaN.
 
     Parameters
     ----------
     data : np.ndarray
-        1-D data array aligned with ``ts``.
-    ts : np.ndarray
+        1-D data array aligned with ``timestamps``.
+    timestamps : np.ndarray
         1-D timestamp array.
     coords : np.ndarray
         Shape ``(N, 2)`` array of ``[start, end]`` bounds for good chunks.
@@ -321,40 +326,40 @@ def addingNaNValues(*, data: np.ndarray, ts: np.ndarray, coords: np.ndarray) -> 
     """
 
     if (data == 0).all() == True:
-        data = np.zeros(ts.shape[0])
+        data = np.zeros(timestamps.shape[0])
 
-    arr = np.array([])
-    ts_index = np.arange(ts.shape[0])
+    kept_indices = np.array([])
+    all_indices = np.arange(timestamps.shape[0])
     for i in range(coords.shape[0]):
 
-        index = np.where((ts > coords[i, 0]) & (ts < coords[i, 1]))[0]
-        arr = np.concatenate((arr, index))
+        chunk_indices = np.where((timestamps > coords[i, 0]) & (timestamps < coords[i, 1]))[0]
+        kept_indices = np.concatenate((kept_indices, chunk_indices))
 
-    nan_indices = list(set(ts_index).symmetric_difference(arr))
+    nan_indices = list(set(all_indices).symmetric_difference(kept_indices))
     data[nan_indices] = np.nan
 
     return data
 
 
-def removeTTLs(*, ts: np.ndarray, coords: np.ndarray) -> np.ndarray:
+def removeTTLs(*, ttl_timestamps: np.ndarray, coords: np.ndarray) -> np.ndarray:
     """
     Keep only TTL timestamps that fall within good-chunk windows.
 
     Parameters
     ----------
-    ts : np.ndarray
+    ttl_timestamps : np.ndarray
         TTL timestamp array to filter.
     coords : np.ndarray
         Shape ``(N, 2)`` array of ``[start, end]`` bounds for good chunks.
 
     Returns
     -------
-    ts_arr : np.ndarray
+    kept_ttl_timestamps : np.ndarray
         TTL timestamps that fall within the good-chunk windows.
     """
-    ts_arr = np.array([])
+    kept_ttl_timestamps = np.array([])
     for i in range(coords.shape[0]):
-        ts_index = np.where((ts > coords[i, 0]) & (ts < coords[i, 1]))[0]
-        ts_arr = np.concatenate((ts_arr, ts[ts_index]))
+        in_window_indices = np.where((ttl_timestamps > coords[i, 0]) & (ttl_timestamps < coords[i, 1]))[0]
+        kept_ttl_timestamps = np.concatenate((kept_ttl_timestamps, ttl_timestamps[in_window_indices]))
 
-    return ts_arr
+    return kept_ttl_timestamps

--- a/src/guppy/analysis/combine_data.py
+++ b/src/guppy/analysis/combine_data.py
@@ -33,10 +33,10 @@ def eliminateData(
 
     Returns
     -------
-    arr : np.ndarray
+    concatenated_data : np.ndarray
         Concatenated data across all sessions.
-    ts_arr : np.ndarray
-        Realigned timestamps corresponding to ``arr``.
+    realigned_timestamps : np.ndarray
+        Realigned timestamps corresponding to ``concatenated_data``.
     """
 
     segments = [(filepath_to_data[filepath], filepath_to_timestamps[filepath]) for filepath in filepath_to_timestamps]
@@ -65,7 +65,7 @@ def eliminateTs(
 
     Returns
     -------
-    ts_arr : np.ndarray
+    realigned_ttl_timestamps : np.ndarray
         Realigned TTL timestamps concatenated across all sessions.
     """
 
@@ -128,13 +128,13 @@ def combine_data(
         name_1 = ((os.path.basename(path[0, j])).split(".")[0]).split("_")[-1]
         name_2 = ((os.path.basename(path[1, j])).split(".")[0]).split("_")[-1]
         if name_1 != name_2:
-            msg = (
+            message = (
                 f"Pair name mismatch in '{filepaths_to_combine[0]}': control file suffix '{name_1}' does not match "
                 f"signal file suffix '{name_2}'. Check the naming convention of your files and the "
                 f"storesList file, then re-run step 1."
             )
-            logger.error(msg)
-            raise ValueError(msg)
+            logger.error(message)
+            raise ValueError(message)
         pair_name = name_1
 
         for i in range(len(names_for_storenames)):
@@ -160,12 +160,12 @@ def combine_data(
                 filepath_to_timestamps = pair_name_to_filepath_to_timestamps[pair_name]
                 filepath_to_ttl_timestamps = compound_name_to_filepath_to_ttl_timestamps[compound_name]
 
-                ts = eliminateTs(
+                ttl_timestamps = eliminateTs(
                     filepath_to_timestamps,
                     filepath_to_ttl_timestamps,
                     timeForLightsTurnOn,
                     sampling_rate,
                 )
-                compound_name_to_ttl_timestamps[compound_name] = ts
+                compound_name_to_ttl_timestamps[compound_name] = ttl_timestamps
 
     return pair_name_to_tsNew, display_name_to_data, compound_name_to_ttl_timestamps

--- a/src/guppy/analysis/compute_psth.py
+++ b/src/guppy/analysis/compute_psth.py
@@ -20,7 +20,7 @@ def compute_psth(
     naming: str,
     just_use_signal: bool,
     sampling_rate: float,
-    ts: np.ndarray,
+    event_timestamps: np.ndarray,
     corrected_timestamps: np.ndarray,
     timeForLightsTurnOn: float,
 ) -> tuple[np.ndarray, np.ndarray, list[object], np.ndarray]:
@@ -55,7 +55,7 @@ def compute_psth(
         When True, z-score each trial independently rather than using the pre-computed z-score.
     sampling_rate : float
         Sampling rate in Hz.
-    ts : np.ndarray
+    event_timestamps : np.ndarray
         Event timestamp array (s).
     corrected_timestamps : np.ndarray
         Full corrected photometry timestamp array (recording-start basis), used for
@@ -73,7 +73,7 @@ def compute_psth(
         Same shape as ``psth`` but without baseline correction.
     columns : list
         Column labels corresponding to ``psth``; last entry is ``'timestamps'``.
-    ts : np.ndarray
+    event_timestamps : np.ndarray
         Filtered event timestamps actually used to build the PSTH.
     """
 
@@ -92,34 +92,34 @@ def compute_psth(
     # reject timestamps for which baseline cannot be calculated because of nan values.
     # Events are on the recording-start basis; z_score[0] is the lights-on instant, so the
     # time available before an event is measured relative to timeForLightsTurnOn.
-    new_ts = []
-    for i in range(ts.shape[0]):
-        thisTime = ts[i]
+    kept_timestamps = []
+    for i in range(event_timestamps.shape[0]):
+        thisTime = event_timestamps[i]
         if (thisTime - timeForLightsTurnOn) < abs(baselineStart):
             continue
         else:
-            new_ts.append(ts[i])
+            kept_timestamps.append(event_timestamps[i])
 
     # reject burst of timestamps
-    ts = np.asarray(new_ts)
+    event_timestamps = np.asarray(kept_timestamps)
     # skip the event if there are no TTLs
-    if len(ts) == 0:
-        new_ts = np.array([])
+    if len(event_timestamps) == 0:
+        kept_timestamps = np.array([])
         logger.info(f"Warning : No TTLs present for {event}. This will cause an error in Visualization step")
     else:
-        new_ts = [ts[0]]
-        for i in range(1, ts.shape[0]):
-            thisTime = ts[i]
-            prevTime = new_ts[-1]
+        kept_timestamps = [event_timestamps[0]]
+        for i in range(1, event_timestamps.shape[0]):
+            thisTime = event_timestamps[i]
+            prevTime = kept_timestamps[-1]
             diff = thisTime - prevTime
             if diff < timeInterval:
                 continue
             else:
-                new_ts.append(ts[i])
+                kept_timestamps.append(event_timestamps[i])
 
     # final timestamps
-    ts = np.asarray(new_ts)
-    nTs = ts.shape[0]
+    event_timestamps = np.asarray(kept_timestamps)
+    nTs = event_timestamps.shape[0]
 
     # initialize PSTH vector
     psth = np.full((nTs, totalTs + 1), np.nan)
@@ -127,30 +127,30 @@ def compute_psth(
 
     # for each timestamp, create trial which will be saved in a PSTH vector
     for i in range(nTs):
-        thisTime = ts[i]
+        thisTime = event_timestamps[i]
         # Events are on the recording-start basis; z_score[0] corresponds to the lights-on
         # instant, so subtract timeForLightsTurnOn to get the positional index into z_score.
         thisIndex = int(round((thisTime - timeForLightsTurnOn) * sampling_rate))
         # nSecPrev (and therefore nTsPrev) is negative by convention; flip to a positive
         # sample count for rowFormation, which expects nTsPrev as a positive lookback length.
-        arr = rowFormation(z_score, thisIndex, -1 * nTsPrev, nTsPost)
+        trial = rowFormation(z_score, thisIndex, -1 * nTsPrev, nTsPost)
         if just_use_signal == True:
-            res = np.subtract(arr, np.nanmean(arr))
-            z_score_arr = np.divide(res, np.nanstd(arr))
-            arr = z_score_arr
+            centered_trial = np.subtract(trial, np.nanmean(trial))
+            trial_z_score = np.divide(centered_trial, np.nanstd(trial))
+            trial = trial_z_score
         else:
-            arr = arr
+            trial = trial
 
-        psth_baselineUncorrected[i, :] = arr
-        psth[i, :] = baselineCorrection(arr, timeAxis, baselineStart, baselineEnd)
+        psth_baselineUncorrected[i, :] = trial
+        psth[i, :] = baselineCorrection(trial, timeAxis, baselineStart, baselineEnd)
 
-    columns = list(ts)
+    columns = list(event_timestamps)
 
     if use_time_or_trials == "Time (min)" and bin_psth_trials > 0:
         corrected_timestamps = np.divide(corrected_timestamps, 60)
         # Bins are built from the continuous timestamps (recording-start basis); shift events
         # by timeForLightsTurnOn so both sit on the lights-on origin the bin edges assume.
-        ts_min = np.divide(ts - timeForLightsTurnOn, 60)
+        ts_min = np.divide(event_timestamps - timeForLightsTurnOn, 60)
         bin_steps = np.arange(corrected_timestamps[0], corrected_timestamps[-1] + bin_psth_trials, bin_psth_trials)
         indices_each_step = dict()
         for i in range(1, bin_steps.shape[0]):
@@ -158,9 +158,9 @@ def compute_psth(
                 (ts_min >= bin_steps[i - 1]) & (ts_min <= bin_steps[i])
             )[0]
     elif use_time_or_trials == "# of trials" and bin_psth_trials > 0:
-        bin_steps = np.arange(0, ts.shape[0], bin_psth_trials)
-        if bin_steps[-1] < ts.shape[0]:
-            bin_steps = np.concatenate((bin_steps, [ts.shape[0]]), axis=0)
+        bin_steps = np.arange(0, event_timestamps.shape[0], bin_psth_trials)
+        if bin_steps[-1] < event_timestamps.shape[0]:
+            bin_steps = np.concatenate((bin_steps, [event_timestamps.shape[0]]), axis=0)
         indices_each_step = dict()
         for i in range(1, bin_steps.shape[0]):
             indices_each_step[f"{bin_steps[i-1]}-{bin_steps[i]}"] = np.arange(bin_steps[i - 1], bin_steps[i])
@@ -169,30 +169,30 @@ def compute_psth(
 
     psth_bin, psth_bin_baselineUncorrected = [], []
     if indices_each_step:
-        keys = list(indices_each_step.keys())
-        for k in keys:
+        bin_labels = list(indices_each_step.keys())
+        for bin_label in bin_labels:
             # no trials in a given bin window, just put all the nan values
-            if indices_each_step[k].shape[0] == 0:
+            if indices_each_step[bin_label].shape[0] == 0:
                 psth_bin.append(np.full(psth.shape[1], np.nan))
                 psth_bin_baselineUncorrected.append(np.full(psth_baselineUncorrected.shape[1], np.nan))
                 psth_bin.append(np.full(psth.shape[1], np.nan))
                 psth_bin_baselineUncorrected.append(np.full(psth_baselineUncorrected.shape[1], np.nan))
             else:
-                index = indices_each_step[k]
-                arr = psth[index, :]
+                trial_indices = indices_each_step[bin_label]
+                binned_trials = psth[trial_indices, :]
                 #  mean of bins
-                psth_bin.append(np.nanmean(psth[index, :], axis=0))
-                psth_bin_baselineUncorrected.append(np.nanmean(psth_baselineUncorrected[index, :], axis=0))
-                psth_bin.append(np.nanstd(psth[index, :], axis=0) / math.sqrt(psth[index, :].shape[0]))
+                psth_bin.append(np.nanmean(psth[trial_indices, :], axis=0))
+                psth_bin_baselineUncorrected.append(np.nanmean(psth_baselineUncorrected[trial_indices, :], axis=0))
+                psth_bin.append(np.nanstd(psth[trial_indices, :], axis=0) / math.sqrt(psth[trial_indices, :].shape[0]))
                 # error of bins
                 psth_bin_baselineUncorrected.append(
-                    np.nanstd(psth_baselineUncorrected[index, :], axis=0)
-                    / math.sqrt(psth_baselineUncorrected[index, :].shape[0])
+                    np.nanstd(psth_baselineUncorrected[trial_indices, :], axis=0)
+                    / math.sqrt(psth_baselineUncorrected[trial_indices, :].shape[0])
                 )
 
             # adding column names
-            columns.append(f"bin_({k})")
-            columns.append(f"bin_err_({k})")
+            columns.append(f"bin_({bin_label})")
+            columns.append(f"bin_err_({bin_label})")
 
         psth = np.concatenate((psth, psth_bin), axis=0)
         psth_baselineUncorrected = np.concatenate((psth_baselineUncorrected, psth_bin_baselineUncorrected), axis=0)
@@ -202,7 +202,7 @@ def compute_psth(
     psth_baselineUncorrected = np.concatenate((psth_baselineUncorrected, timeAxis), axis=0)
     columns.append("timestamps")
 
-    return psth, psth_baselineUncorrected, columns, ts
+    return psth, psth_baselineUncorrected, columns, event_timestamps
 
 
 def rowFormation(z_score: np.ndarray, thisIndex: int, nTsPrev: int, nTsPost: int) -> np.ndarray:
@@ -222,42 +222,42 @@ def rowFormation(z_score: np.ndarray, thisIndex: int, nTsPrev: int, nTsPost: int
 
     Returns
     -------
-    res : np.ndarray
+    trial : np.ndarray
         1-D trial array of length ``nTsPrev + nTsPost + 1``, NaN-padded where the
         signal does not exist.
     """
 
     if nTsPrev < thisIndex and z_score.shape[0] > (thisIndex + nTsPost):
-        res = z_score[thisIndex - nTsPrev - 1 : thisIndex + nTsPost]
+        trial = z_score[thisIndex - nTsPrev - 1 : thisIndex + nTsPost]
     elif nTsPrev >= thisIndex and z_score.shape[0] > (thisIndex + nTsPost):
         mismatch = nTsPrev - thisIndex + 1
-        res = np.zeros(nTsPrev + nTsPost + 1)
-        res[:mismatch] = np.nan
-        res[mismatch:] = z_score[: thisIndex + nTsPost]
+        trial = np.zeros(nTsPrev + nTsPost + 1)
+        trial[:mismatch] = np.nan
+        trial[mismatch:] = z_score[: thisIndex + nTsPost]
     elif nTsPrev >= thisIndex and z_score.shape[0] < (thisIndex + nTsPost):
         mismatch1 = nTsPrev - thisIndex + 1
         mismatch2 = (thisIndex + nTsPost) - z_score.shape[0]
-        res1 = np.full(mismatch1, np.nan)
-        res2 = z_score
-        res3 = np.full(mismatch2, np.nan)
-        res = np.concatenate((res1, np.concatenate((res2, res3))))
+        nan_prefix = np.full(mismatch1, np.nan)
+        existing_signal = z_score
+        nan_suffix = np.full(mismatch2, np.nan)
+        trial = np.concatenate((nan_prefix, np.concatenate((existing_signal, nan_suffix))))
     else:
         mismatch = (thisIndex + nTsPost) - z_score.shape[0]
-        res1 = np.zeros(mismatch)
-        res1[:] = np.nan
-        res2 = z_score[thisIndex - nTsPrev - 1 : z_score.shape[0]]
-        res = np.concatenate((res2, res1))
+        nan_suffix = np.zeros(mismatch)
+        nan_suffix[:] = np.nan
+        existing_signal = z_score[thisIndex - nTsPrev - 1 : z_score.shape[0]]
+        trial = np.concatenate((existing_signal, nan_suffix))
 
-    return res
+    return trial
 
 
-def baselineCorrection(arr: np.ndarray, timeAxis: np.ndarray, baselineStart: float, baselineEnd: float) -> np.ndarray:
+def baselineCorrection(trial: np.ndarray, timeAxis: np.ndarray, baselineStart: float, baselineEnd: float) -> np.ndarray:
     """
     Subtract the mean baseline from a single PSTH trial.
 
     Parameters
     ----------
-    arr : np.ndarray
+    trial : np.ndarray
         1-D trial array aligned with ``timeAxis``.
     timeAxis : np.ndarray
         1-D time axis (s) for the trial window.
@@ -269,16 +269,16 @@ def baselineCorrection(arr: np.ndarray, timeAxis: np.ndarray, baselineStart: flo
     Returns
     -------
     baselineSub : np.ndarray
-        Trial array with the mean baseline subtracted; ``arr`` unchanged when
+        Trial array with the mean baseline subtracted; ``trial`` unchanged when
         both ``baselineStart`` and ``baselineEnd`` are zero.
     """
     baselineStrtPt = np.where(timeAxis >= baselineStart)[0]
     baselineEndPt = np.where(timeAxis >= baselineEnd)[0]
 
     if baselineStart == 0 and baselineEnd == 0:
-        return arr
+        return trial
 
-    baseline = np.nanmean(arr[baselineStrtPt[0] : baselineEndPt[0]])
-    baselineSub = np.subtract(arr, baseline)
+    baseline = np.nanmean(trial[baselineStrtPt[0] : baselineEndPt[0]])
+    baselineSub = np.subtract(trial, baseline)
 
     return baselineSub

--- a/src/guppy/analysis/control_channel.py
+++ b/src/guppy/analysis/control_channel.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 # This function just creates placeholder Control-HDF5 files that are then immediately overwritten later on in the pipeline.
 # TODO: Refactor this function to avoid unnecessary file creation.
-def add_control_channel(filepath: str, arr: np.ndarray) -> np.ndarray:
+def add_control_channel(filepath: str, stores_list_array: np.ndarray) -> np.ndarray:
     """
     Add synthetic control-channel entries to the storesList when no isosbestic control exists.
 
@@ -25,28 +25,28 @@ def add_control_channel(filepath: str, arr: np.ndarray) -> np.ndarray:
     ----------
     filepath : str
         Path to the session output directory containing the storesList CSV.
-    arr : np.ndarray
+    stores_list_array : np.ndarray
         2-D storesList array with rows [storenames, display_names].
 
     Returns
     -------
-    arr : np.ndarray
+    stores_list_array : np.ndarray
         Updated storesList array with synthetic control entries appended.
     """
 
-    storenames = arr[0, :]
-    storesList = np.char.lower(arr[1, :])
+    storenames = stores_list_array[0, :]
+    storesList = np.char.lower(stores_list_array[1, :])
 
     keep_control = np.array([])
     # check a case if there is isosbestic control channel present
     for i in range(storesList.shape[0]):
         if "control" in storesList[i].lower():
             name = storesList[i].split("_")[-1]
-            new_str = "signal_" + str(name).lower()
-            find_signal = [True for i in storesList if i == new_str]
+            expected_signal_name = "signal_" + str(name).lower()
+            find_signal = [True for i in storesList if i == expected_signal_name]
             if len(find_signal) > 1:
                 message = (
-                    f"Multiple signal channels named '{new_str}' found in storesList for control "
+                    f"Multiple signal channels named '{expected_signal_name}' found in storesList for control "
                     f"channel '{storesList[i]}' in '{filepath}'. Each signal name must be unique; "
                     "check the storesList file and re-run step 1."
                 )
@@ -56,7 +56,7 @@ def add_control_channel(filepath: str, arr: np.ndarray) -> np.ndarray:
                 message = (
                     "Isosbestic control channel parameter is set to False, but the storesList file "
                     f"in '{filepath}' contains a control channel '{storesList[i]}' with no matching "
-                    f"signal channel '{new_str}'. Either enable isosbestic control or re-run step 1 "
+                    f"signal channel '{expected_signal_name}'. Either enable isosbestic control or re-run step 1 "
                     "to remove the unmatched control entry."
                 )
                 logger.error(message)
@@ -67,21 +67,27 @@ def add_control_channel(filepath: str, arr: np.ndarray) -> np.ndarray:
     for i in range(storesList.shape[0]):
         if "signal" in storesList[i].lower():
             name = storesList[i].split("_")[-1]
-            new_str = "control_" + str(name).lower()
-            find_signal = [True for i in storesList if i == new_str]
+            expected_control_name = "control_" + str(name).lower()
+            find_signal = [True for i in storesList if i == expected_control_name]
             if len(find_signal) == 0:
-                src, dst = os.path.join(filepath, arr[0, i] + ".hdf5"), os.path.join(
+                source_path, destination_path = os.path.join(filepath, stores_list_array[0, i] + ".hdf5"), os.path.join(
                     filepath, "cntrl" + str(i) + ".hdf5"
                 )
-                shutil.copyfile(src, dst)
-                arr = np.concatenate((arr, [["cntrl" + str(i)], ["control_" + str(arr[1, i].split("_")[-1])]]), axis=1)
+                shutil.copyfile(source_path, destination_path)
+                stores_list_array = np.concatenate(
+                    (
+                        stores_list_array,
+                        [["cntrl" + str(i)], ["control_" + str(stores_list_array[1, i].split("_")[-1])]],
+                    ),
+                    axis=1,
+                )
 
-    np.savetxt(os.path.join(filepath, "storesList.csv"), arr, delimiter=",", fmt="%s")
+    np.savetxt(os.path.join(filepath, "storesList.csv"), stores_list_array, delimiter=",", fmt="%s")
 
-    return arr
+    return stores_list_array
 
 
-def create_control_channel(filepath: str, arr: np.ndarray, window: int = 5001) -> None:
+def create_control_channel(filepath: str, stores_list_array: np.ndarray, window: int = 5001) -> None:
     """
     Fit a synthetic control channel from the signal channel and save it.
 
@@ -89,14 +95,14 @@ def create_control_channel(filepath: str, arr: np.ndarray, window: int = 5001) -
     ----------
     filepath : str
         Path to the session output directory where HDF5 and CSV files are written.
-    arr : np.ndarray
+    stores_list_array : np.ndarray
         2-D storesList array with rows [storenames, display_names].
     window : int, optional
         Savitzky-Golay filter window length used for initial smoothing. Default is 5001.
     """
 
-    storenames = arr[0, :]
-    storesList = arr[1, :]
+    storenames = stores_list_array[0, :]
+    storesList = stores_list_array[1, :]
 
     for i in range(storesList.shape[0]):
         event_name, event = storesList[i], storenames[i]
@@ -111,8 +117,8 @@ def create_control_channel(filepath: str, arr: np.ndarray, window: int = 5001) -
             control = helper_create_control_channel(signal, timestampNew, window)
 
             write_hdf5(control, event_name, filepath, "data")
-            d = {"timestamps": timestampNew, "data": control, "sampling_rate": sampling_rate}
-            df = pd.DataFrame(d)
+            data_dict = {"timestamps": timestampNew, "data": control, "sampling_rate": sampling_rate}
+            df = pd.DataFrame(data_dict)
             df.to_csv(os.path.join(os.path.dirname(filepath), event.lower() + ".csv"), index=False)
             logger.info("Control channel from signal channel created using curve-fitting")
 
@@ -150,8 +156,8 @@ def helper_create_control_channel(signal: np.ndarray, timestamps: np.ndarray, wi
 
     try:
         popt, pcov = curve_fit(curveFitFn, timestamps, filtered_signal, p0)
-    except Exception as e:
-        logger.error(str(e))
+    except Exception as error:
+        logger.error(str(error))
 
     control = curveFitFn(timestamps, *popt)
 

--- a/src/guppy/analysis/cross_correlation.py
+++ b/src/guppy/analysis/cross_correlation.py
@@ -6,37 +6,39 @@ from scipy import signal
 logger = logging.getLogger(__name__)
 
 
-def compute_cross_correlation(arr_A: list[np.ndarray], arr_B: list[np.ndarray], sample_rate: float) -> np.ndarray:
+def compute_cross_correlation(
+    signal_a_trials: list[np.ndarray], signal_b_trials: list[np.ndarray], sample_rate: float
+) -> np.ndarray:
     """
     Compute normalized cross-correlations between paired trial arrays.
 
     Parameters
     ----------
-    arr_A : array-like of np.ndarray
+    signal_a_trials : array-like of np.ndarray
         Sequence of 1-D arrays for the first signal (one per trial).
-    arr_B : array-like of np.ndarray
+    signal_b_trials : array-like of np.ndarray
         Sequence of 1-D arrays for the second signal (one per trial).
     sample_rate : float
         Sampling rate in Hz; used to convert lag indices to milliseconds.
 
     Returns
     -------
-    cross_corr_arr : np.ndarray
+    cross_correlations : np.ndarray
         Shape ``(n_trials + 1, n_lags)`` array where the last row contains
         lag values in milliseconds.
     """
     cross_corr = list()
-    for a, b in zip(arr_A, arr_B):
-        if np.isnan(a).any() or np.isnan(b).any():
-            corr = signal.correlate(a, b, method="direct")
+    for trial_a, trial_b in zip(signal_a_trials, signal_b_trials):
+        if np.isnan(trial_a).any() or np.isnan(trial_b).any():
+            corr = signal.correlate(trial_a, trial_b, method="direct")
         else:
-            corr = signal.correlate(a, b)
+            corr = signal.correlate(trial_a, trial_b)
         corr_norm = corr / np.max(np.abs(corr))
         cross_corr.append(corr_norm)
-        lag = signal.correlation_lags(len(a), len(b))
+        lag = signal.correlation_lags(len(trial_a), len(trial_b))
         lag_msec = np.array(lag / sample_rate, dtype="float32")
 
-    cross_corr_arr = np.array(cross_corr, dtype="float32")
+    cross_correlations = np.array(cross_corr, dtype="float32")
     lag_msec = lag_msec.reshape(1, -1)
-    cross_corr_arr = np.concatenate((cross_corr_arr, lag_msec), axis=0)
-    return cross_corr_arr
+    cross_correlations = np.concatenate((cross_correlations, lag_msec), axis=0)
+    return cross_correlations

--- a/src/guppy/analysis/io_utils.py
+++ b/src/guppy/analysis/io_utils.py
@@ -37,15 +37,15 @@ def find_files(path: str, glob_path: str, ignore_case: bool = False) -> list[str
     )
 
     no_bytes_path = os.listdir(os.path.expanduser(path))
-    str_path = []
+    decoded_names = []
 
     # converting byte object to string
-    for x in no_bytes_path:
+    for raw_name in no_bytes_path:
         try:
-            str_path.append(x.decode("utf-8"))
+            decoded_names.append(raw_name.decode("utf-8"))
         except:
-            str_path.append(x)
-    return [os.path.join(path, n) for n in str_path if rule.match(n)]
+            decoded_names.append(raw_name)
+    return [os.path.join(path, name) for name in decoded_names if rule.match(name)]
 
 
 def check_TDT(filepath: str) -> bool:
@@ -207,19 +207,19 @@ def check_storeslistfile(folderNames: list[str]) -> np.ndarray:
     return storesList
 
 
-def write_combined_stores_list(op: list[object], storesList: np.ndarray) -> None:
+def write_combined_stores_list(output_dirs: list[object], storesList: np.ndarray) -> None:
     """
     Write a combined storesList CSV to each output directory.
 
     Parameters
     ----------
-    op : list
+    output_dirs : list
         Sequence of ``[filepath, ...]`` entries; ``filepath`` is the output directory.
     storesList : np.ndarray
         2-D storesList array with rows [storenames, display_names].
     """
-    for k in range(len(op)):
-        filepath = op[k][0]
+    for k in range(len(output_dirs)):
+        filepath = output_dirs[k][0]
         np.savetxt(os.path.join(filepath, "combine_storesList.csv"), storesList, fmt="%s", delimiter=",")
 
 
@@ -234,22 +234,22 @@ def get_control_and_signal_channel_names(storesList: np.ndarray) -> np.ndarray:
 
     Returns
     -------
-    channels_arr : np.ndarray
+    control_signal_names : np.ndarray
         Shape ``(2, N)`` array where row 0 is control display names and
         row 1 is the matching signal display names.
     """
     storenames = storesList[0, :]
     names_for_storenames = storesList[1, :]
 
-    channels_arr = []
+    control_signal_names = []
     for i in range(names_for_storenames.shape[0]):
         if "control" in names_for_storenames[i].lower() or "signal" in names_for_storenames[i].lower():
-            channels_arr.append(names_for_storenames[i])
+            control_signal_names.append(names_for_storenames[i])
 
-    channels_arr = sorted(channels_arr, key=str.casefold)
+    control_signal_names = sorted(control_signal_names, key=str.casefold)
 
-    signal_regions = {name[len("signal_") :] for name in channels_arr if name.lower().startswith("signal_")}
-    control_regions = {name[len("control_") :] for name in channels_arr if name.lower().startswith("control_")}
+    signal_regions = {name[len("signal_") :] for name in control_signal_names if name.lower().startswith("signal_")}
+    control_regions = {name[len("control_") :] for name in control_signal_names if name.lower().startswith("control_")}
     # Only enforce region pairing when both signal and control channels are present
     # (signal-only / control-only configurations are valid when isosbestic control is disabled).
     if signal_regions and control_regions:
@@ -271,7 +271,7 @@ def get_control_and_signal_channel_names(storesList: np.ndarray) -> np.ndarray:
             raise ValueError(message)
 
     try:
-        channels_arr = np.asarray(channels_arr).reshape(2, -1)
+        control_signal_names = np.asarray(control_signal_names).reshape(2, -1)
     except ValueError:
         message = (
             f"Cannot pair control and signal channels: found {len(control_regions)} control and "
@@ -281,7 +281,7 @@ def get_control_and_signal_channel_names(storesList: np.ndarray) -> np.ndarray:
         logger.error(message)
         raise ValueError(message)
 
-    return channels_arr
+    return control_signal_names
 
 
 def make_dir_for_cross_correlation(filepath: str) -> str:
@@ -295,13 +295,13 @@ def make_dir_for_cross_correlation(filepath: str) -> str:
 
     Returns
     -------
-    op : str
+    output_dir : str
         Path to the cross-correlation output directory.
     """
-    op = os.path.join(filepath, "cross_correlation_output")
-    if not os.path.exists(op):
-        os.mkdir(op)
-    return op
+    output_dir = os.path.join(filepath, "cross_correlation_output")
+    if not os.path.exists(output_dir):
+        os.mkdir(output_dir)
+    return output_dir
 
 
 def makeAverageDir(filepath: str) -> str:
@@ -315,12 +315,12 @@ def makeAverageDir(filepath: str) -> str:
 
     Returns
     -------
-    op : str
+    output_dir : str
         Path to the average output directory.
     """
 
-    op = os.path.join(filepath, "average")
-    if not os.path.exists(op):
-        os.mkdir(op)
+    output_dir = os.path.join(filepath, "average")
+    if not os.path.exists(output_dir):
+        os.mkdir(output_dir)
 
-    return op
+    return output_dir

--- a/src/guppy/analysis/psth_average.py
+++ b/src/guppy/analysis/psth_average.py
@@ -40,25 +40,25 @@ def averageForGroup(folderNames: list[str], event: str, inputParameters: dict[st
     path = []
     abspath = inputParameters["abspath"]
     selectForComputePsth = inputParameters["selectForComputePsth"]
-    op = makeAverageDir(abspath)
+    output_dir = makeAverageDir(abspath)
 
     # combining paths to all the selected folders for doing average
     for i in range(len(folderNames)):
         if selectForComputePsth == "z_score":
-            path_temp = glob.glob(os.path.join(folderNames[i], "z_score_*"))
+            matched_paths = glob.glob(os.path.join(folderNames[i], "z_score_*"))
         elif selectForComputePsth == "dff":
-            path_temp = glob.glob(os.path.join(folderNames[i], "dff_*"))
+            matched_paths = glob.glob(os.path.join(folderNames[i], "dff_*"))
         else:
-            path_temp = glob.glob(os.path.join(folderNames[i], "z_score_*")) + glob.glob(
+            matched_paths = glob.glob(os.path.join(folderNames[i], "z_score_*")) + glob.glob(
                 os.path.join(folderNames[i], "dff_*")
             )
 
-        for j in range(len(path_temp)):
-            basename = (os.path.basename(path_temp[j])).split(".")[0]
-            write_hdf5(np.array([]), basename, op, "data")
+        for j in range(len(matched_paths)):
+            basename = (os.path.basename(matched_paths[j])).split(".")[0]
+            write_hdf5(np.array([]), basename, output_dir, "data")
             name_1 = basename.split("_")[-1]
-            temp = [folderNames[i], event + "_" + name_1, basename]
-            path.append(temp)
+            entry = [folderNames[i], event + "_" + name_1, basename]
+            path.append(entry)
 
     # processing of all the paths
     naming = []
@@ -70,46 +70,49 @@ def averageForGroup(folderNames: list[str], event: str, inputParameters: dict[st
     # or non-overlapping storenames across sessions do not cause an IndexError.
     new_path = [[] for _ in range(len(naming))]
     for i in range(len(path)):
-        idx = np.where(naming == path[i][2])[0][0]
-        new_path[idx].append(path[i])
+        index = np.where(naming == path[i][2])[0][0]
+        new_path[index].append(path[i])
 
     # read PSTH for each event and make the average of it. Save the final output to an average folder.
     for i in range(len(new_path)):
         psth, psth_bins = [], []
         columns = []
-        bins_cols = []
-        temp_path = new_path[i]
-        for j in range(len(temp_path)):
-            if not os.path.exists(os.path.join(temp_path[j][0], temp_path[j][1] + "_{}.h5".format(temp_path[j][2]))):
+        bin_columns = []
+        session_entries = new_path[i]
+        for j in range(len(session_entries)):
+            if not os.path.exists(
+                os.path.join(session_entries[j][0], session_entries[j][1] + "_{}.h5".format(session_entries[j][2]))
+            ):
                 continue
             else:
-                df = read_Df(temp_path[j][0], temp_path[j][1], temp_path[j][2])  # filepath, event, name
-                cols = list(df.columns)
+                # read_Df arguments are filepath, event, name
+                df = read_Df(session_entries[j][0], session_entries[j][1], session_entries[j][2])
+                column_names = list(df.columns)
                 regex = re.compile("bin_[(]")
-                bins_cols = [cols[i] for i in range(len(cols)) if regex.match(cols[i])]
+                bin_columns = [column_names[i] for i in range(len(column_names)) if regex.match(column_names[i])]
                 psth.append(np.asarray(df["mean"]))
-                columns.append(os.path.basename(temp_path[j][0]))
-                if len(bins_cols) > 0:
-                    psth_bins.append(df[bins_cols])
+                columns.append(os.path.basename(session_entries[j][0]))
+                if len(bin_columns) > 0:
+                    psth_bins.append(df[bin_columns])
 
         if len(psth) == 0:
             logger.warning(
-                f"No PSTH files found for event {event!r} (basename {temp_path[0][2]!r}, "
+                f"No PSTH files found for event {event!r} (basename {session_entries[0][2]!r}, "
                 f"selectForComputePsth={selectForComputePsth!r}) across the selected folders; "
                 "skipping average for this event."
             )
             continue
 
-        if len(bins_cols) > 0:
+        if len(bin_columns) > 0:
             df_bins = pd.concat(psth_bins, axis=1)
             df_bins_mean = df_bins.T.groupby(df_bins.columns).mean().T
             df_bins_err = df_bins.T.groupby(df_bins.columns).std().T / math.sqrt(df_bins.shape[1])
-            cols_err = list(df_bins_err.columns)
-            dict_err = {}
-            for i in cols_err:
-                split = i.split("_")
-                dict_err[i] = "{}_err_{}".format(split[0], split[1])
-            df_bins_err = df_bins_err.rename(columns=dict_err)
+            error_column_names = list(df_bins_err.columns)
+            error_rename_map = {}
+            for column_name in error_column_names:
+                name_parts = column_name.split("_")
+                error_rename_map[column_name] = "{}_err_{}".format(name_parts[0], name_parts[1])
+            df_bins_err = df_bins_err.rename(columns=error_rename_map)
             columns = columns + list(df_bins_mean.columns) + list(df_bins_err.columns)
             df_bins_mean_err = pd.concat([df_bins_mean, df_bins_err], axis=1).T
             psth, df_bins_mean_err = np.asarray(psth), np.asarray(df_bins_mean_err)
@@ -121,44 +124,49 @@ def averageForGroup(folderNames: list[str], event: str, inputParameters: dict[st
         timestamps = np.asarray(df["timestamps"]).reshape(1, -1)
         psth = np.concatenate((psth, timestamps), axis=0)
         columns = columns + ["timestamps"]
-        create_Df_for_psth(op, temp_path[j][1], temp_path[j][2], psth, columns=columns)
+        create_Df_for_psth(output_dir, session_entries[j][1], session_entries[j][2], psth, columns=columns)
 
     # read PSTH peak and area for each event and combine them. Save the final output to an average folder
     for i in range(len(new_path)):
-        arr = []
-        index = []
-        temp_path = new_path[i]
-        for j in range(len(temp_path)):
+        peak_area_frames = []
+        row_indices = []
+        session_entries = new_path[i]
+        for j in range(len(session_entries)):
             if not os.path.exists(
-                os.path.join(temp_path[j][0], "peak_AUC_" + temp_path[j][1] + "_" + temp_path[j][2] + ".h5")
+                os.path.join(
+                    session_entries[j][0], "peak_AUC_" + session_entries[j][1] + "_" + session_entries[j][2] + ".h5"
+                )
             ):
                 continue
             else:
-                df = read_Df_area_peak(temp_path[j][0], temp_path[j][1] + "_" + temp_path[j][2])
-                arr.append(df)
-                index.append(list(df.index))
+                df = read_Df_area_peak(session_entries[j][0], session_entries[j][1] + "_" + session_entries[j][2])
+                peak_area_frames.append(df)
+                row_indices.append(list(df.index))
 
-        if len(arr) == 0:
+        if len(peak_area_frames) == 0:
             logger.warning(
-                f"No peak/AUC files found for event {event!r} (basename {temp_path[0][2]!r}) "
+                f"No peak/AUC files found for event {event!r} (basename {session_entries[0][2]!r}) "
                 "across the selected folders; skipping peak/AUC average for this event."
             )
             continue
-        index = list(np.concatenate(index))
-        new_df = pd.concat(arr, axis=0)
-        new_df.to_csv(os.path.join(op, "peak_AUC_{}_{}.csv".format(temp_path[j][1], temp_path[j][2])), index=index)
+        row_indices = list(np.concatenate(row_indices))
+        new_df = pd.concat(peak_area_frames, axis=0)
+        new_df.to_csv(
+            os.path.join(output_dir, "peak_AUC_{}_{}.csv".format(session_entries[j][1], session_entries[j][2])),
+            index=row_indices,
+        )
         new_df.to_hdf(
-            os.path.join(op, "peak_AUC_{}_{}.h5".format(temp_path[j][1], temp_path[j][2])),
+            os.path.join(output_dir, "peak_AUC_{}_{}.h5".format(session_entries[j][1], session_entries[j][2])),
             key="df",
             mode="w",
-            index=index,
+            index=row_indices,
         )
 
     # read cross-correlation files and combine them. Save the final output to an average folder
     type = []
     for i in range(len(folderNames)):
-        _, temp_type = getCorrCombinations(folderNames[i], inputParameters)
-        type.append(temp_type)
+        _, session_types = getCorrCombinations(folderNames[i], inputParameters)
+        type.append(session_types)
 
     type = np.unique(np.array(type))
     for i in range(len(type)):
@@ -192,7 +200,7 @@ def averageForGroup(folderNames: list[str], event: str, inputParameters: dict[st
         corr = np.concatenate((corr, timestamps), axis=0)
         columns.append("timestamps")
         create_Df_for_psth(
-            make_dir_for_cross_correlation(op),
+            make_dir_for_cross_correlation(output_dir),
             "corr_" + event,
             type[i] + "_" + corr_info[k - 1] + "_" + corr_info[k],
             corr,
@@ -251,7 +259,7 @@ def read_Df_area_peak(filepath: str, name: str) -> pd.DataFrame:
     df : pd.DataFrame
         DataFrame of peak and area-under-curve metrics.
     """
-    op = os.path.join(filepath, "peak_AUC_" + name + ".h5")
-    df = pd.read_hdf(op, key="df", mode="r")
+    output_path = os.path.join(filepath, "peak_AUC_" + name + ".h5")
+    df = pd.read_hdf(output_path, key="df", mode="r")
 
     return df

--- a/src/guppy/analysis/psth_utils.py
+++ b/src/guppy/analysis/psth_utils.py
@@ -30,9 +30,9 @@ def create_Df_for_psth(filepath: str, event: str, name: str, psth: np.ndarray, c
     event = event.replace("\\", "_")
     event = event.replace("/", "_")
     if name:
-        op = os.path.join(filepath, event + "_{}.h5".format(name))
+        output_path = os.path.join(filepath, event + "_{}.h5".format(name))
     else:
-        op = os.path.join(filepath, event + ".h5")
+        output_path = os.path.join(filepath, event + ".h5")
 
     # removing psth binned trials
     columns = np.array(columns, dtype="str")
@@ -43,16 +43,18 @@ def create_Df_for_psth(filepath: str, event: str, name: str, psth: np.ndarray, c
     psth = psth.T
     if psth.ndim > 1:
         mean = np.nanmean(psth[:, single_trials_index], axis=1).reshape(-1, 1)
-        err = np.nanstd(psth[:, single_trials_index], axis=1) / math.sqrt(psth[:, single_trials_index].shape[1])
-        err = err.reshape(-1, 1)
+        standard_error = np.nanstd(psth[:, single_trials_index], axis=1) / math.sqrt(
+            psth[:, single_trials_index].shape[1]
+        )
+        standard_error = standard_error.reshape(-1, 1)
         psth = np.hstack((psth, mean))
-        psth = np.hstack((psth, err))
+        psth = np.hstack((psth, standard_error))
 
     columns = np.asarray(columns)
     columns = np.append(columns, ["mean", "err"])
     df = pd.DataFrame(psth, index=None, columns=list(columns), dtype="float32")
 
-    df.to_hdf(op, key="df", mode="w")
+    df.to_hdf(output_path, key="df", mode="w")
 
 
 def create_Df_for_cross_correlation(
@@ -75,9 +77,9 @@ def create_Df_for_cross_correlation(
         Column labels for the trials axis. Default is an empty list.
     """
     if name:
-        op = os.path.join(filepath, event + "_{}.h5".format(name))
+        output_path = os.path.join(filepath, event + "_{}.h5".format(name))
     else:
-        op = os.path.join(filepath, event + ".h5")
+        output_path = os.path.join(filepath, event + ".h5")
 
     # removing psth binned trials
     columns = list(np.array(columns, dtype="str"))
@@ -88,16 +90,18 @@ def create_Df_for_cross_correlation(
     psth = psth.T
     if psth.ndim > 1:
         mean = np.nanmean(psth[:, single_trials_index], axis=1).reshape(-1, 1)
-        err = np.nanstd(psth[:, single_trials_index], axis=1) / math.sqrt(psth[:, single_trials_index].shape[1])
-        err = err.reshape(-1, 1)
+        standard_error = np.nanstd(psth[:, single_trials_index], axis=1) / math.sqrt(
+            psth[:, single_trials_index].shape[1]
+        )
+        standard_error = standard_error.reshape(-1, 1)
         psth = np.hstack((psth, mean))
-        psth = np.hstack((psth, err))
+        psth = np.hstack((psth, standard_error))
 
     columns = np.asarray(columns)
     columns = np.append(columns, ["mean", "err"])
     df = pd.DataFrame(psth, index=None, columns=columns, dtype="float32")
 
-    df.to_hdf(op, key="df", mode="w")
+    df.to_hdf(output_path, key="df", mode="w")
 
 
 def getCorrCombinations(filepath: str, inputParameters: dict[str, object]) -> tuple[list[str], list[str]]:

--- a/src/guppy/analysis/realignment.py
+++ b/src/guppy/analysis/realignment.py
@@ -20,25 +20,25 @@ def concatenate_and_realign_data(
 
     Returns
     -------
-    arr : np.ndarray
+    concatenated_data : np.ndarray
         Concatenated data across all segments.
-    ts_arr : np.ndarray
-        Realigned timestamps corresponding to ``arr``.
+    realigned_timestamps : np.ndarray
+        Realigned timestamps corresponding to ``concatenated_data``.
     """
-    arr = np.array([])
-    ts_arr = np.array([])
+    concatenated_data = np.array([])
+    realigned_timestamps = np.array([])
     for data_segment, ts_segment in segments:
-        if len(arr) == 0:
-            arr = np.concatenate((arr, data_segment))
-            sub = ts_segment[0] - timeForLightsTurnOn
-            new_ts = ts_segment - sub
-            ts_arr = np.concatenate((ts_arr, new_ts))
+        if len(concatenated_data) == 0:
+            concatenated_data = np.concatenate((concatenated_data, data_segment))
+            offset = ts_segment[0] - timeForLightsTurnOn
+            shifted_timestamps = ts_segment - offset
+            realigned_timestamps = np.concatenate((realigned_timestamps, shifted_timestamps))
         else:
-            new_ts = ts_segment - (ts_segment[0] - ts_arr[-1])
-            arr = np.concatenate((arr, data_segment))
-            ts_arr = np.concatenate((ts_arr, new_ts + (1 / sampling_rate)))
+            shifted_timestamps = ts_segment - (ts_segment[0] - realigned_timestamps[-1])
+            concatenated_data = np.concatenate((concatenated_data, data_segment))
+            realigned_timestamps = np.concatenate((realigned_timestamps, shifted_timestamps + (1 / sampling_rate)))
 
-    return arr, ts_arr
+    return concatenated_data, realigned_timestamps
 
 
 def realign_ttl_timestamps(
@@ -63,20 +63,24 @@ def realign_ttl_timestamps(
 
     Returns
     -------
-    ts_arr : np.ndarray
+    realigned_ttl_timestamps : np.ndarray
         Realigned TTL timestamps concatenated across all segments.
     """
-    ts_arr = np.array([])
-    tsNew_arr = np.array([])
+    realigned_ttl_timestamps = np.array([])
+    realigned_reference_timestamps = np.array([])
     for tsNew_segment, ts_segment in pairs:
-        if len(tsNew_arr) == 0:
-            sub = tsNew_segment[0] - timeForLightsTurnOn
-            tsNew_arr = np.concatenate((tsNew_arr, tsNew_segment - sub))
-            ts_arr = np.concatenate((ts_arr, ts_segment - sub))
+        if len(realigned_reference_timestamps) == 0:
+            offset = tsNew_segment[0] - timeForLightsTurnOn
+            realigned_reference_timestamps = np.concatenate((realigned_reference_timestamps, tsNew_segment - offset))
+            realigned_ttl_timestamps = np.concatenate((realigned_ttl_timestamps, ts_segment - offset))
         else:
-            new_ts = ts_segment - (tsNew_segment[0] - tsNew_arr[-1])
-            new_tsNew = tsNew_segment - (tsNew_segment[0] - tsNew_arr[-1])
-            tsNew_arr = np.concatenate((tsNew_arr, new_tsNew + (1 / sampling_rate)))
-            ts_arr = np.concatenate((ts_arr, new_ts + (1 / sampling_rate)))
+            shifted_ttl_timestamps = ts_segment - (tsNew_segment[0] - realigned_reference_timestamps[-1])
+            shifted_reference_timestamps = tsNew_segment - (tsNew_segment[0] - realigned_reference_timestamps[-1])
+            realigned_reference_timestamps = np.concatenate(
+                (realigned_reference_timestamps, shifted_reference_timestamps + (1 / sampling_rate))
+            )
+            realigned_ttl_timestamps = np.concatenate(
+                (realigned_ttl_timestamps, shifted_ttl_timestamps + (1 / sampling_rate))
+            )
 
-    return ts_arr
+    return realigned_ttl_timestamps

--- a/src/guppy/analysis/standard_io.py
+++ b/src/guppy/analysis/standard_io.py
@@ -39,7 +39,7 @@ def read_control_and_signal(
     name_to_npoints : dict
         Display name → npoints array (or None for CSV datasets).
     """
-    channels_arr = get_control_and_signal_channel_names(storesList)
+    control_signal_names = get_control_and_signal_channel_names(storesList)
     storenames = storesList[0, :]
     names_for_storenames = storesList[1, :]
 
@@ -48,13 +48,13 @@ def read_control_and_signal(
     name_to_sampling_rate = {}
     name_to_npoints = {}
 
-    for i in range(channels_arr.shape[1]):
-        control_name = channels_arr[0, i]
-        signal_name = channels_arr[1, i]
-        idx_c = np.where(names_for_storenames == control_name)[0]
-        idx_s = np.where(names_for_storenames == signal_name)[0]
-        control_storename = storenames[idx_c[0]]
-        signal_storename = storenames[idx_s[0]]
+    for i in range(control_signal_names.shape[1]):
+        control_name = control_signal_names[0, i]
+        signal_name = control_signal_names[1, i]
+        control_index = np.where(names_for_storenames == control_name)[0]
+        signal_index = np.where(names_for_storenames == signal_name)[0]
+        control_storename = storenames[control_index[0]]
+        signal_storename = storenames[signal_index[0]]
 
         control_data = read_hdf5(control_storename, filepath, "data")
         signal_data = read_hdf5(signal_storename, filepath, "data")
@@ -97,13 +97,13 @@ def read_ttl(filepath: str, storesList: np.ndarray) -> dict[str, np.ndarray]:
     name_to_timestamps : dict
         Display name → TTL timestamp array for each non-channel store.
     """
-    channels_arr = get_control_and_signal_channel_names(storesList)
+    control_signal_names = get_control_and_signal_channel_names(storesList)
     storenames = storesList[0, :]
     names_for_storenames = storesList[1, :]
 
     name_to_timestamps = {}
     for storename, name in zip(storenames, names_for_storenames):
-        if name in channels_arr:
+        if name in control_signal_names:
             continue
         timestamps = read_hdf5(storename, filepath, "timestamps")
         name_to_timestamps[name] = timestamps
@@ -221,7 +221,7 @@ def write_zscore(
     z_score: np.ndarray,
     dff: np.ndarray,
     control_fit: np.ndarray,
-    temp_control_arr: np.ndarray | None,
+    synthetic_control: np.ndarray | None,
 ) -> None:
     """
     Write z-score, dF/F, and fitted-control arrays to HDF5 files.
@@ -238,14 +238,14 @@ def write_zscore(
         Delta-F/F signal array.
     control_fit : np.ndarray
         Fitted control channel array.
-    temp_control_arr : np.ndarray or None
+    synthetic_control : np.ndarray or None
         Synthetic control array when no isosbestic control is present; None otherwise.
     """
     write_hdf5(z_score, "z_score_" + name, filepath, "data")
     write_hdf5(dff, "dff_" + name, filepath, "data")
     write_hdf5(control_fit, "cntrl_sig_fit_" + name, filepath, "data")
-    if temp_control_arr is not None:
-        write_hdf5(temp_control_arr, "control_" + name, filepath, "data")
+    if synthetic_control is not None:
+        write_hdf5(synthetic_control, "control_" + name, filepath, "data")
 
 
 def read_corrected_timestamps_pairwise(
@@ -273,13 +273,13 @@ def read_corrected_timestamps_pairwise(
         name_1 = ((os.path.basename(path[0, j])).split(".")[0]).split("_")
         name_2 = ((os.path.basename(path[1, j])).split(".")[0]).split("_")
         if name_1[-1] != name_2[-1]:
-            msg = (
+            message = (
                 f"Pair name mismatch in '{filepath}': control file suffix '{name_1[-1]}' does not match "
                 f"signal file suffix '{name_2[-1]}'. Check the naming convention of your files and the "
                 f"storesList file, then re-run step 1."
             )
-            logger.error(msg)
-            raise ValueError(msg)
+            logger.error(message)
+            raise ValueError(message)
         name = name_1[-1]
 
         tsNew = read_hdf5("timeCorrection_" + name, filepath, "timestampNew")
@@ -311,13 +311,13 @@ def read_coords_pairwise(filepath: str, pair_name_to_tsNew: dict[str, np.ndarray
         name_1 = ((os.path.basename(path[0, j])).split(".")[0]).split("_")
         name_2 = ((os.path.basename(path[1, j])).split(".")[0]).split("_")
         if name_1[-1] != name_2[-1]:
-            msg = (
+            message = (
                 f"Pair name mismatch in '{filepath}': control file suffix '{name_1[-1]}' does not match "
                 f"signal file suffix '{name_2[-1]}'. Check the naming convention of your files and the "
                 f"storesList file, then re-run step 1."
             )
-            logger.error(msg)
-            raise ValueError(msg)
+            logger.error(message)
+            raise ValueError(message)
         pair_name = name_1[-1]
 
         tsNew = pair_name_to_tsNew[pair_name]
@@ -377,26 +377,26 @@ def read_corrected_ttl_timestamps(filepath: str, storesList: np.ndarray) -> dict
     compound_name_to_ttl_timestamps = {}
     storenames = storesList[0, :]
     names_for_storenames = storesList[1, :]
-    arr = get_control_and_signal_channel_names(storesList)
+    control_signal_names = get_control_and_signal_channel_names(storesList)
 
     for storename, name in zip(storenames, names_for_storenames):
-        if name in arr:
+        if name in control_signal_names:
             continue
         ttl_name = name
-        for i in range(arr.shape[1]):
-            name_1 = arr[0, i].split("_")[-1]
-            name_2 = arr[1, i].split("_")[-1]
+        for i in range(control_signal_names.shape[1]):
+            name_1 = control_signal_names[0, i].split("_")[-1]
+            name_2 = control_signal_names[1, i].split("_")[-1]
             if name_1 != name_2:
                 message = (
-                    f"Pair name mismatch in storesList: control channel '{arr[0, i]}' has suffix "
-                    f"'{name_1}' but signal channel '{arr[1, i]}' has suffix '{name_2}'. Check the "
+                    f"Pair name mismatch in storesList: control channel '{control_signal_names[0, i]}' has suffix "
+                    f"'{name_1}' but signal channel '{control_signal_names[1, i]}' has suffix '{name_2}'. Check the "
                     "naming convention of your files and the storesList file, then re-run step 1."
                 )
                 logger.error(message)
                 raise ValueError(message)
             compound_name = ttl_name + "_" + name_1
-            ts = read_hdf5(compound_name, filepath, "ts")
-            compound_name_to_ttl_timestamps[compound_name] = ts
+            ttl_timestamps = read_hdf5(compound_name, filepath, "ts")
+            compound_name_to_ttl_timestamps[compound_name] = ttl_timestamps
 
     return compound_name_to_ttl_timestamps
 
@@ -466,13 +466,13 @@ def read_timestamps_for_combining_data(
         name_1 = ((os.path.basename(path[0, j])).split(".")[0]).split("_")[-1]
         name_2 = ((os.path.basename(path[1, j])).split(".")[0]).split("_")[-1]
         if name_1 != name_2:
-            msg = (
+            message = (
                 f"Pair name mismatch in '{filepaths_to_combine[0]}': control file suffix '{name_1}' does not match "
                 f"signal file suffix '{name_2}'. Check the naming convention of your files and the "
                 f"storesList file, then re-run step 1."
             )
-            logger.error(msg)
-            raise ValueError(msg)
+            logger.error(message)
+            raise ValueError(message)
         pair_name = name_1
         pair_name_to_filepath_to_timestamps[pair_name] = {}
         for filepath in filepaths_to_combine:
@@ -507,13 +507,13 @@ def read_data_for_combining_data(
         name_1 = ((os.path.basename(path[0, j])).split(".")[0]).split("_")[-1]
         name_2 = ((os.path.basename(path[1, j])).split(".")[0]).split("_")[-1]
         if name_1 != name_2:
-            msg = (
+            message = (
                 f"Pair name mismatch in '{filepaths_to_combine[0]}': control file suffix '{name_1}' does not match "
                 f"signal file suffix '{name_2}'. Check the naming convention of your files and the "
                 f"storesList file, then re-run step 1."
             )
-            logger.error(msg)
-            raise ValueError(msg)
+            logger.error(message)
+            raise ValueError(message)
         pair_name = name_1
         for i in range(len(names_for_storenames)):
             if not (
@@ -573,10 +573,10 @@ def read_ttl_timestamps_for_combining_data(
             compound_name_to_filepath_to_ttl_timestamps[compound_name] = {}
             for filepath in filepaths_to_combine:
                 if os.path.exists(os.path.join(filepath, names_for_storenames[i] + "_" + pair_name + ".hdf5")):
-                    ts = read_hdf5(names_for_storenames[i] + "_" + pair_name, filepath, "ts").reshape(-1)
+                    ttl_timestamps = read_hdf5(names_for_storenames[i] + "_" + pair_name, filepath, "ts").reshape(-1)
                 else:
-                    ts = np.array([])
-                compound_name_to_filepath_to_ttl_timestamps[compound_name][filepath] = ts
+                    ttl_timestamps = np.array([])
+                compound_name_to_filepath_to_ttl_timestamps[compound_name][filepath] = ttl_timestamps
 
     return compound_name_to_filepath_to_ttl_timestamps
 
@@ -605,11 +605,11 @@ def write_combined_data(
         write_hdf5(tsNew, "timeCorrection_" + pair_name, output_filepath, "timestampNew")
     for display_name, data in display_name_to_data.items():
         write_hdf5(data, display_name, output_filepath, "data")
-    for compound_name, ts in compound_name_to_ttl_timestamps.items():
-        write_hdf5(ts, compound_name, output_filepath, "ts")
+    for compound_name, ttl_timestamps in compound_name_to_ttl_timestamps.items():
+        write_hdf5(ttl_timestamps, compound_name, output_filepath, "ts")
 
 
-def write_peak_and_area_to_hdf5(filepath: str, arr: object, name: str, index: list[object] = []) -> None:
+def write_peak_and_area_to_hdf5(filepath: str, peak_and_area_data: object, name: str, index: list[object] = []) -> None:
     """
     Save peak and area-under-curve metrics to an HDF5 file.
 
@@ -617,7 +617,7 @@ def write_peak_and_area_to_hdf5(filepath: str, arr: object, name: str, index: li
     ----------
     filepath : str
         Output directory.
-    arr : array-like
+    peak_and_area_data : array-like
         Metrics data to store in the DataFrame.
     name : str
         Filename stem; the file is written as ``peak_AUC_<name>.h5``.
@@ -625,15 +625,15 @@ def write_peak_and_area_to_hdf5(filepath: str, arr: object, name: str, index: li
         Row index labels. Default is an empty list.
     """
 
-    op = os.path.join(filepath, "peak_AUC_" + name + ".h5")
+    output_path = os.path.join(filepath, "peak_AUC_" + name + ".h5")
     dirname = os.path.dirname(filepath)
 
-    df = pd.DataFrame(arr, index=index)
+    df = pd.DataFrame(peak_and_area_data, index=index)
 
-    df.to_hdf(op, key="df", mode="w")
+    df.to_hdf(output_path, key="df", mode="w")
 
 
-def write_peak_and_area_to_csv(filepath: str, arr: object, name: str, index: list[object] = []) -> None:
+def write_peak_and_area_to_csv(filepath: str, peak_and_area_data: object, name: str, index: list[object] = []) -> None:
     """
     Save peak and area-under-curve metrics to a CSV file.
 
@@ -641,21 +641,21 @@ def write_peak_and_area_to_csv(filepath: str, arr: object, name: str, index: lis
     ----------
     filepath : str
         Output directory.
-    arr : array-like
+    peak_and_area_data : array-like
         Metrics data to store in the DataFrame.
     name : str
         Filename stem; the file is written as ``peak_AUC_<name>.csv``.
     index : list, optional
         Row index labels. Default is an empty list.
     """
-    op = os.path.join(filepath, "peak_AUC_" + name + ".csv")
-    df = pd.DataFrame(arr, index=index)
+    output_path = os.path.join(filepath, "peak_AUC_" + name + ".csv")
+    df = pd.DataFrame(peak_and_area_data, index=index)
 
-    df.to_csv(op)
+    df.to_csv(output_path)
 
 
 def write_freq_and_amp_to_hdf5(
-    filepath: str, arr: object, name: str, index: list[object] = [], columns: list[object] = []
+    filepath: str, freq_and_amp_data: object, name: str, index: list[object] = [], columns: list[object] = []
 ) -> None:
     """
     Save transient frequency and amplitude metrics to an HDF5 file.
@@ -664,7 +664,7 @@ def write_freq_and_amp_to_hdf5(
     ----------
     filepath : str
         Output directory.
-    arr : array-like
+    freq_and_amp_data : array-like
         Metrics data to store in the DataFrame.
     name : str
         Filename stem; the file is written as ``freqAndAmp_<name>.h5``.
@@ -674,16 +674,16 @@ def write_freq_and_amp_to_hdf5(
         Column labels. Default is an empty list.
     """
 
-    op = os.path.join(filepath, "freqAndAmp_" + name + ".h5")
+    output_path = os.path.join(filepath, "freqAndAmp_" + name + ".h5")
     dirname = os.path.dirname(filepath)
 
-    df = pd.DataFrame(arr, index=index, columns=columns)
+    df = pd.DataFrame(freq_and_amp_data, index=index, columns=columns)
 
-    df.to_hdf(op, key="df", mode="w")
+    df.to_hdf(output_path, key="df", mode="w")
 
 
 def write_freq_and_amp_to_csv(
-    filepath: str, arr: object, name: str, index: list[object] = [], columns: list[object] = []
+    filepath: str, freq_and_amp_data: object, name: str, index: list[object] = [], columns: list[object] = []
 ) -> None:
     """
     Save transient frequency and amplitude metrics to a CSV file.
@@ -692,7 +692,7 @@ def write_freq_and_amp_to_csv(
     ----------
     filepath : str
         Output directory.
-    arr : array-like
+    freq_and_amp_data : array-like
         Metrics data to store in the DataFrame.
     name : str
         Output filename (written directly inside ``filepath``).
@@ -701,9 +701,9 @@ def write_freq_and_amp_to_csv(
     columns : list, optional
         Column labels. Default is an empty list.
     """
-    op = os.path.join(filepath, name)
-    df = pd.DataFrame(arr, index=index, columns=columns)
-    df.to_csv(op)
+    output_path = os.path.join(filepath, name)
+    df = pd.DataFrame(freq_and_amp_data, index=index, columns=columns)
+    df.to_csv(output_path)
 
 
 def read_freq_and_amp_from_hdf5(filepath: str, name: str) -> pd.DataFrame:
@@ -722,14 +722,14 @@ def read_freq_and_amp_from_hdf5(filepath: str, name: str) -> pd.DataFrame:
     df : pd.DataFrame
         DataFrame of frequency and amplitude metrics.
     """
-    op = os.path.join(filepath, "freqAndAmp_" + name + ".h5")
-    df = pd.read_hdf(op, key="df", mode="r")
+    output_path = os.path.join(filepath, "freqAndAmp_" + name + ".h5")
+    df = pd.read_hdf(output_path, key="df", mode="r")
 
     return df
 
 
 def write_transients_to_hdf5(
-    filepath: str, name: str, z_score: np.ndarray, ts: np.ndarray, peaksInd: np.ndarray
+    filepath: str, name: str, z_score: np.ndarray, timestamps: np.ndarray, peaksInd: np.ndarray
 ) -> None:
     """
     Write transient detection outputs (z-score, timestamps, peak indices) to HDF5.
@@ -742,14 +742,14 @@ def write_transients_to_hdf5(
         Channel suffix used to build the HDF5 event key.
     z_score : np.ndarray
         Z-scored signal array (NaN-free).
-    ts : np.ndarray
+    timestamps : np.ndarray
         Timestamp array corresponding to ``z_score``.
     peaksInd : np.ndarray
         Integer indices of detected transient peaks in ``z_score``.
     """
     event = f"transient_outputs_{name}"
     write_hdf5(z_score, event, filepath, "z_score")
-    write_hdf5(ts, event, filepath, "timestamps")
+    write_hdf5(timestamps, event, filepath, "timestamps")
     write_hdf5(peaksInd, event, filepath, "peaksInd")
 
 
@@ -768,13 +768,13 @@ def read_transients_from_hdf5(filepath: str, name: str) -> tuple[np.ndarray, np.
     -------
     z_score : np.ndarray
         Z-scored signal array.
-    ts : np.ndarray
+    timestamps : np.ndarray
         Timestamp array.
     peaksInd : np.ndarray
         Integer indices of detected transient peaks.
     """
     event = f"transient_outputs_{name}"
     z_score = read_hdf5(event, filepath, "z_score")
-    ts = read_hdf5(event, filepath, "timestamps")
+    timestamps = read_hdf5(event, filepath, "timestamps")
     peaksInd = read_hdf5(event, filepath, "peaksInd")
-    return z_score, ts, peaksInd
+    return z_score, timestamps, peaksInd

--- a/src/guppy/analysis/timestamp_correction.py
+++ b/src/guppy/analysis/timestamp_correction.py
@@ -126,16 +126,16 @@ def timestampCorrection(
     name_to_corrected_data = {}
     storenames = storesList[0, :]
     names_for_storenames = storesList[1, :]
-    channels_arr = get_control_and_signal_channel_names(storesList)
+    control_signal_names = get_control_and_signal_channel_names(storesList)
 
-    indices = check_cntrl_sig_length(channels_arr, name_to_data)
+    indices = check_cntrl_sig_length(control_signal_names, name_to_data)
 
-    for i in range(channels_arr.shape[1]):
-        control_name = channels_arr[0, i]
-        signal_name = channels_arr[1, i]
-        idx = np.where(names_for_storenames == indices[i])[0]
+    for i in range(control_signal_names.shape[1]):
+        control_name = control_signal_names[0, i]
+        signal_name = control_signal_names[1, i]
+        match_index = np.where(names_for_storenames == indices[i])[0]
 
-        name = names_for_storenames[idx][0]
+        name = names_for_storenames[match_index][0]
         timestamp = name_to_timestamps[name]
         sampling_rate = name_to_sampling_rate[name]
         npoints = name_to_npoints[name]
@@ -202,17 +202,17 @@ def decide_naming_and_applyCorrection_ttl(
     logger.debug("Applying correction of timestamps to the data and event timestamps")
     storenames = storesList[0, :]
     names_for_storenames = storesList[1, :]
-    arr = get_control_and_signal_channel_names(storesList)
-    indices = check_cntrl_sig_length(arr, name_to_data)
+    control_signal_names = get_control_and_signal_channel_names(storesList)
+    indices = check_cntrl_sig_length(control_signal_names, name_to_data)
 
     compound_name_to_corrected_ttl_timestamps = {}
     for ttl_name, ttl_timestamps in name_to_timestamps_ttl.items():
-        for i in range(arr.shape[1]):
-            name_1 = arr[0, i].split("_")[-1]
+        for i in range(control_signal_names.shape[1]):
+            name_1 = control_signal_names[0, i].split("_")[-1]
 
-            idx = np.where(names_for_storenames == indices[i])[0]
+            match_index = np.where(names_for_storenames == indices[i])[0]
 
-            name = names_for_storenames[idx][0]
+            name = names_for_storenames[match_index][0]
             timestamps = name_to_timestamps[name]
             timeRecStart = timestamps[0]
             corrected_ttl_timestamps = applyCorrection_ttl(
@@ -263,21 +263,21 @@ def applyCorrection_ttl(
     """
     corrected_ttl_timestamps = ttl_timestamps
     if mode == "tdt":
-        res = (corrected_ttl_timestamps >= timeRecStart).all()
+        all_on_recording_clock = (corrected_ttl_timestamps >= timeRecStart).all()
         # When all TTLs are on the recording clock, rebase them to recording start.
         # Otherwise they are not on the recording clock; leave them as-is (rare path).
-        if res == True:
+        if all_on_recording_clock == True:
             corrected_ttl_timestamps = np.subtract(corrected_ttl_timestamps, timeRecStart)
     return corrected_ttl_timestamps
 
 
-def check_cntrl_sig_length(channels_arr: np.ndarray, name_to_data: dict[str, np.ndarray]) -> list[str]:
+def check_cntrl_sig_length(control_signal_names: np.ndarray, name_to_data: dict[str, np.ndarray]) -> list[str]:
     """
     Identify the shorter channel in each control/signal pair.
 
     Parameters
     ----------
-    channels_arr : np.ndarray
+    control_signal_names : np.ndarray
         Shape ``(2, N)`` array where row 0 is control names and row 1 is signal names.
     name_to_data : dict
         Display name → data array.
@@ -290,9 +290,9 @@ def check_cntrl_sig_length(channels_arr: np.ndarray, name_to_data: dict[str, np.
     """
 
     indices = []
-    for i in range(channels_arr.shape[1]):
-        control_name = channels_arr[0, i]
-        signal_name = channels_arr[1, i]
+    for i in range(control_signal_names.shape[1]):
+        control_name = control_signal_names[0, i]
+        signal_name = control_signal_names[1, i]
         control = name_to_data[control_name]
         signal = name_to_data[signal_name]
         if control.shape[0] < signal.shape[0]:

--- a/src/guppy/analysis/transients.py
+++ b/src/guppy/analysis/transients.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 def analyze_transients(
-    ts: np.ndarray,
+    timestamps: np.ndarray,
     window: float,
     numProcesses: int,
     highAmpFilt: float,
@@ -23,7 +23,7 @@ def analyze_transients(
 
     Parameters
     ----------
-    ts : np.ndarray
+    timestamps : np.ndarray
         Timestamp array corresponding to ``z_score``.
     window : float
         Chunk duration in seconds for parallel processing.
@@ -43,44 +43,44 @@ def analyze_transients(
     -------
     z_score : np.ndarray
         NaN-free z-score array used for analysis.
-    ts : np.ndarray
+    timestamps : np.ndarray
         NaN-free timestamp array aligned with the returned ``z_score``.
     peaksInd : np.ndarray
         Integer indices of detected transient peaks in ``z_score``.
     peaks_occurrences : np.ndarray
         Shape ``(n_peaks, 2)`` array of ``[timestamp, amplitude]`` for each peak.
-    arr : np.ndarray
+    freq_and_amplitude : np.ndarray
         Shape ``(1, 2)`` array of ``[frequency (events/min), mean amplitude]``.
     """
     not_nan_indices = ~np.isnan(z_score)
     z_score = z_score[not_nan_indices]
     z_score_chunks, z_score_chunks_index = createChunks(z_score, sampling_rate, window)
 
-    with mp.Pool(numProcesses) as p:
-        result = p.starmap(
+    with mp.Pool(numProcesses) as pool:
+        result = pool.starmap(
             processChunks, zip(z_score_chunks, z_score_chunks_index, repeat(highAmpFilt), repeat(transientsThresh))
         )
 
     result = np.asarray(result, dtype=object)
-    ts = ts[not_nan_indices]
-    freq, peaksAmp, peaksInd = calculate_freq_amp(result, z_score, z_score_chunks_index, ts)
-    peaks_occurrences = np.array([ts[peaksInd], peaksAmp]).T
-    arr = np.array([[freq, np.mean(peaksAmp)]])
-    return z_score, ts, peaksInd, peaks_occurrences, arr
+    timestamps = timestamps[not_nan_indices]
+    freq, peaksAmp, peaksInd = calculate_freq_amp(result, z_score, z_score_chunks_index, timestamps)
+    peaks_occurrences = np.array([timestamps[peaksInd], peaksAmp]).T
+    freq_and_amplitude = np.array([[freq, np.mean(peaksAmp)]])
+    return z_score, timestamps, peaksInd, peaks_occurrences, freq_and_amplitude
 
 
 def processChunks(
-    arrValues: np.ndarray, arrIndexes: np.ndarray, highAmpFilt: float, transientsThresh: float
+    chunk_values: np.ndarray, chunk_indices: np.ndarray, highAmpFilt: float, transientsThresh: float
 ) -> tuple[np.ndarray, float, float, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """
     Apply the two-threshold MAD transient-detection algorithm to one chunk.
 
     Parameters
     ----------
-    arrValues : np.ndarray
+    chunk_values : np.ndarray
         Z-score values for this chunk (may contain NaN padding).
-    arrIndexes : np.ndarray
-        Global sample indices corresponding to ``arrValues``.
+    chunk_indices : np.ndarray
+        Global sample indices corresponding to ``chunk_values``.
     highAmpFilt : float
         MAD multiplier for the first (high-amplitude exclusion) threshold.
     transientsThresh : float
@@ -91,40 +91,40 @@ def processChunks(
     tuple
         ``(peaks, mad, filteredOutMad, medianY, filteredOutMedianY,
         firstThresholdY, secondThresholdY)`` — detected peak indices and
-        diagnostic arrays aligned with ``arrValues``.
+        diagnostic arrays aligned with ``chunk_values``.
     """
 
-    arrValues = arrValues[~np.isnan(arrValues)]
-    median = np.median(arrValues)
+    chunk_values = chunk_values[~np.isnan(chunk_values)]
+    median = np.median(chunk_values)
 
-    mad = np.median(np.abs(arrValues - median))
+    mad = np.median(np.abs(chunk_values - median))
 
     firstThreshold = median + (highAmpFilt * mad)
 
-    greaterThanMad = np.where(arrValues > firstThreshold)[0]
+    greaterThanMad = np.where(chunk_values > firstThreshold)[0]
 
-    arr = np.arange(arrValues.shape[0])
-    lowerThanMad = np.isin(arr, greaterThanMad, invert=True)
-    filteredOut = arrValues[np.where(lowerThanMad == True)[0]]
+    sample_indices = np.arange(chunk_values.shape[0])
+    lowerThanMad = np.isin(sample_indices, greaterThanMad, invert=True)
+    filteredOut = chunk_values[np.where(lowerThanMad == True)[0]]
 
     filteredOutMedian = np.median(filteredOut)
     filteredOutMad = np.median(np.abs(filteredOut - np.median(filteredOut)))
     secondThreshold = filteredOutMedian + (transientsThresh * filteredOutMad)
 
-    greaterThanThreshIndex = np.where(arrValues > secondThreshold)[0]
-    greaterThanThreshValues = arrValues[greaterThanThreshIndex]
-    temp = np.zeros(arrValues.shape[0])
-    temp[greaterThanThreshIndex] = greaterThanThreshValues
-    peaks = argrelextrema(temp, np.greater)[0]
+    greaterThanThreshIndex = np.where(chunk_values > secondThreshold)[0]
+    greaterThanThreshValues = chunk_values[greaterThanThreshIndex]
+    thresholded_values = np.zeros(chunk_values.shape[0])
+    thresholded_values[greaterThanThreshIndex] = greaterThanThreshValues
+    peaks = argrelextrema(thresholded_values, np.greater)[0]
 
-    firstThresholdY = np.full(arrValues.shape[0], firstThreshold)
-    secondThresholdY = np.full(arrValues.shape[0], secondThreshold)
+    firstThresholdY = np.full(chunk_values.shape[0], firstThreshold)
+    secondThresholdY = np.full(chunk_values.shape[0], secondThreshold)
 
-    newPeaks = np.full(arrValues.shape[0], np.nan)
-    newPeaks[peaks] = peaks + arrIndexes[0]
+    newPeaks = np.full(chunk_values.shape[0], np.nan)
+    newPeaks[peaks] = peaks + chunk_indices[0]
 
-    medianY = np.full(arrValues.shape[0], median)
-    filteredOutMedianY = np.full(arrValues.shape[0], filteredOutMedian)
+    medianY = np.full(chunk_values.shape[0], median)
+    filteredOutMedianY = np.full(chunk_values.shape[0], filteredOutMedian)
 
     return peaks, mad, filteredOutMad, medianY, filteredOutMedianY, firstThresholdY, secondThresholdY
 
@@ -180,14 +180,14 @@ def createChunks(z_score: np.ndarray, sampling_rate: float, window: float) -> tu
 
 
 def calculate_freq_amp(
-    arr: np.ndarray, z_score: np.ndarray, z_score_chunks_index: np.ndarray, timestamps: np.ndarray
+    chunk_results: np.ndarray, z_score: np.ndarray, z_score_chunks_index: np.ndarray, timestamps: np.ndarray
 ) -> tuple[float, np.ndarray, np.ndarray]:
     """
     Aggregate per-chunk transient results into global frequency and amplitude statistics.
 
     Parameters
     ----------
-    arr : np.ndarray
+    chunk_results : np.ndarray
         Object array returned by ``processChunks``; each row is a chunk result tuple.
     z_score : np.ndarray
         Full 1-D z-score array.
@@ -205,8 +205,8 @@ def calculate_freq_amp(
     peaksInd : np.ndarray
         Global integer indices of detected peaks in ``z_score``.
     """
-    peaks = arr[:, 0]
-    filteredOutMedian = arr[:, 4]
+    peaks = chunk_results[:, 0]
+    filteredOutMedian = chunk_results[:, 4]
     count = 0
     peaksAmp = np.array([])
     peaksInd = np.array([])

--- a/src/guppy/analysis/transients_average.py
+++ b/src/guppy/analysis/transients_average.py
@@ -37,18 +37,18 @@ def averageForGroup(folderNames: list[str], inputParameters: dict[str, object]) 
 
     for i in range(len(folderNames)):
         if selectForTransientsComputation == "z_score":
-            path_temp = glob.glob(os.path.join(folderNames[i], "z_score_*"))
+            matched_paths = glob.glob(os.path.join(folderNames[i], "z_score_*"))
         elif selectForTransientsComputation == "dff":
-            path_temp = glob.glob(os.path.join(folderNames[i], "dff_*"))
+            matched_paths = glob.glob(os.path.join(folderNames[i], "dff_*"))
         else:
-            path_temp = glob.glob(os.path.join(folderNames[i], "z_score_*")) + glob.glob(
+            matched_paths = glob.glob(os.path.join(folderNames[i], "z_score_*")) + glob.glob(
                 os.path.join(folderNames[i], "dff_*")
             )
 
-        for j in range(len(path_temp)):
-            basename = (os.path.basename(path_temp[j])).split(".")[0]
-            temp = [folderNames[i], basename]
-            path.append(temp)
+        for j in range(len(matched_paths)):
+            basename = (os.path.basename(matched_paths[j])).split(".")[0]
+            entry = [folderNames[i], basename]
+            path.append(entry)
 
     naming = []
     for i in range(len(path)):
@@ -59,29 +59,35 @@ def averageForGroup(folderNames: list[str], inputParameters: dict[str, object]) 
     # or non-overlapping storenames across sessions do not cause an IndexError.
     new_path = [[] for _ in range(len(naming))]
     for i in range(len(path)):
-        idx = np.where(naming == path[i][1])[0][0]
-        new_path[idx].append(path[i])
+        index = np.where(naming == path[i][1])[0][0]
+        new_path[index].append(path[i])
 
-    op = makeAverageDir(abspath)
+    output_dir = makeAverageDir(abspath)
 
     for i in range(len(new_path)):
-        arr = []
+        freq_and_amp_values = []
         fileName = []
-        temp_path = new_path[i]
-        for j in range(len(temp_path)):
-            if not os.path.exists(os.path.join(temp_path[j][0], "freqAndAmp_" + temp_path[j][1] + ".h5")):
+        session_entries = new_path[i]
+        for j in range(len(session_entries)):
+            if not os.path.exists(os.path.join(session_entries[j][0], "freqAndAmp_" + session_entries[j][1] + ".h5")):
                 continue
             else:
-                df = read_freq_and_amp_from_hdf5(temp_path[j][0], temp_path[j][1])
-                arr.append(np.array([df["freq (events/min)"].iloc[0], df["amplitude"].iloc[0]]))
-                fileName.append(os.path.basename(temp_path[j][0]))
+                df = read_freq_and_amp_from_hdf5(session_entries[j][0], session_entries[j][1])
+                freq_and_amp_values.append(np.array([df["freq (events/min)"].iloc[0], df["amplitude"].iloc[0]]))
+                fileName.append(os.path.basename(session_entries[j][0]))
 
-        arr = np.asarray(arr)
-        write_freq_and_amp_to_hdf5(op, arr, temp_path[j][1], index=fileName, columns=["freq (events/min)", "amplitude"])
+        freq_and_amp_values = np.asarray(freq_and_amp_values)
+        write_freq_and_amp_to_hdf5(
+            output_dir,
+            freq_and_amp_values,
+            session_entries[j][1],
+            index=fileName,
+            columns=["freq (events/min)", "amplitude"],
+        )
         write_freq_and_amp_to_csv(
-            op,
-            arr,
-            "freqAndAmp_" + temp_path[j][1] + ".csv",
+            output_dir,
+            freq_and_amp_values,
+            "freqAndAmp_" + session_entries[j][1] + ".csv",
             index=fileName,
             columns=["freq (events/min)", "amplitude"],
         )

--- a/src/guppy/analysis/z_score.py
+++ b/src/guppy/analysis/z_score.py
@@ -56,65 +56,65 @@ def compute_z_score(
 
     Returns
     -------
-    z_score_arr : np.ndarray
+    z_scores : np.ndarray
         Computed z-score array.
-    norm_data_arr : np.ndarray
+    normalized_data : np.ndarray
         Normalized dF/F array (NaN-filled where artifacts were removed).
-    control_fit_arr : np.ndarray
+    fitted_control : np.ndarray
         Fitted control channel array (NaN-filled where artifacts were removed).
-    temp_control_arr : np.ndarray or None
+    synthetic_control : np.ndarray or None
         Synthetic control array (when ``isosbestic_control=False``); None otherwise.
     """
     if (control == 0).all() == True:
         control = np.zeros(tsNew.shape[0])
 
-    z_score_arr = np.array([])
-    norm_data_arr = np.full(tsNew.shape[0], np.nan)
-    control_fit_arr = np.full(tsNew.shape[0], np.nan)
-    temp_control_arr = np.full(tsNew.shape[0], np.nan)
+    z_scores = np.array([])
+    normalized_data = np.full(tsNew.shape[0], np.nan)
+    fitted_control = np.full(tsNew.shape[0], np.nan)
+    synthetic_control = np.full(tsNew.shape[0], np.nan)
 
     # for artifacts removal, each chunk which was selected by user is being processed individually and then
     # z-score is calculated
     for i in range(coords.shape[0]):
-        tsNew_index = np.where((tsNew > coords[i, 0]) & (tsNew < coords[i, 1]))[0]
+        chunk_indices = np.where((tsNew > coords[i, 0]) & (tsNew < coords[i, 1]))[0]
         if isosbestic_control == False:
-            control_arr = helper_create_control_channel(signal[tsNew_index], tsNew[tsNew_index], window=101)
-            signal_arr = signal[tsNew_index]
+            control_segment = helper_create_control_channel(signal[chunk_indices], tsNew[chunk_indices], window=101)
+            signal_segment = signal[chunk_indices]
             norm_data, control_fit = execute_controlFit_dff(
-                control_arr, signal_arr, isosbestic_control, filter_window, control_fit_method
+                control_segment, signal_segment, isosbestic_control, filter_window, control_fit_method
             )
-            temp_control_arr[tsNew_index] = control_arr
+            synthetic_control[chunk_indices] = control_segment
             if i < coords.shape[0] - 1:
-                blank_index = np.where((tsNew > coords[i, 1]) & (tsNew < coords[i + 1, 0]))[0]
-                temp_control_arr[blank_index] = np.full(blank_index.shape[0], np.nan)
+                gap_indices = np.where((tsNew > coords[i, 1]) & (tsNew < coords[i + 1, 0]))[0]
+                synthetic_control[gap_indices] = np.full(gap_indices.shape[0], np.nan)
         else:
-            control_arr = control[tsNew_index]
-            signal_arr = signal[tsNew_index]
+            control_segment = control[chunk_indices]
+            signal_segment = signal[chunk_indices]
             norm_data, control_fit = execute_controlFit_dff(
-                control_arr, signal_arr, isosbestic_control, filter_window, control_fit_method
+                control_segment, signal_segment, isosbestic_control, filter_window, control_fit_method
             )
-        norm_data_arr[tsNew_index] = norm_data
-        control_fit_arr[tsNew_index] = control_fit
+        normalized_data[chunk_indices] = norm_data
+        fitted_control[chunk_indices] = control_fit
 
     if artifactsRemovalMethod == "concatenate":
-        norm_data_arr = norm_data_arr[~np.isnan(norm_data_arr)]
-        control_fit_arr = control_fit_arr[~np.isnan(control_fit_arr)]
-    z_score = z_score_computation(norm_data_arr, tsNew, zscore_method, baseline_start, baseline_end)
-    z_score_arr = np.concatenate((z_score_arr, z_score))
+        normalized_data = normalized_data[~np.isnan(normalized_data)]
+        fitted_control = fitted_control[~np.isnan(fitted_control)]
+    z_score = z_score_computation(normalized_data, tsNew, zscore_method, baseline_start, baseline_end)
+    z_scores = np.concatenate((z_scores, z_score))
 
     # handle the case if there are chunks being cut in the front and the end
     if isosbestic_control == False:
         coords = coords.flatten()
         # front chunk
-        idx = np.where((tsNew >= tsNew[0]) & (tsNew < coords[0]))[0]
-        temp_control_arr[idx] = np.full(idx.shape[0], np.nan)
+        front_chunk_indices = np.where((tsNew >= tsNew[0]) & (tsNew < coords[0]))[0]
+        synthetic_control[front_chunk_indices] = np.full(front_chunk_indices.shape[0], np.nan)
         # end chunk
-        idx = np.where((tsNew > coords[-1]) & (tsNew <= tsNew[-1]))[0]
-        temp_control_arr[idx] = np.full(idx.shape[0], np.nan)
+        end_chunk_indices = np.where((tsNew > coords[-1]) & (tsNew <= tsNew[-1]))[0]
+        synthetic_control[end_chunk_indices] = np.full(end_chunk_indices.shape[0], np.nan)
     else:
-        temp_control_arr = None
+        synthetic_control = None
 
-    return z_score_arr, norm_data_arr, control_fit_arr, temp_control_arr
+    return z_scores, normalized_data, fitted_control, synthetic_control
 
 
 def execute_controlFit_dff(
@@ -180,8 +180,8 @@ def deltaFF(signal: np.ndarray, control: np.ndarray) -> np.ndarray:
         Percent dF/F array.
     """
 
-    res = np.subtract(signal, control)
-    normData = np.divide(res, control)
+    difference = np.subtract(signal, control)
+    normData = np.divide(difference, control)
     normData = normData * 100
 
     return normData
@@ -205,14 +205,14 @@ def controlFit(control: np.ndarray, signal: np.ndarray, *, method: Literal["IRWL
 
     Returns
     -------
-    arr : np.ndarray
+    fitted_values : np.ndarray
         Fitted control values (linear projection onto the signal scale).
     """
 
     if method == "OLS":
-        p = np.polyfit(control, signal, 1)
-        arr = (p[0] * control) + p[1]
-        return arr
+        coefficients = np.polyfit(control, signal, 1)
+        fitted_values = (coefficients[0] * control) + coefficients[1]
+        return fitted_values
     elif method == "IRWLS":
         design_matrix = sm.add_constant(control)
         results = sm.RLM(signal, design_matrix, M=sm.robust.norms.TukeyBiweight()).fit()
@@ -295,19 +295,19 @@ def z_score_computation(
             range_label="signal timespan",
         )
 
-        idx = np.where((timestamps > baseline_start) & (timestamps < baseline_end))[0]
-        if idx.shape[0] == 0:
-            msg = (
+        baseline_indices = np.where((timestamps > baseline_start) & (timestamps < baseline_end))[0]
+        if baseline_indices.shape[0] == 0:
+            message = (
                 f"No signal samples found in the baseline window "
                 f"({baseline_start}, {baseline_end})s; "
                 f"signal timespan is [{ts_min:.4g}, {ts_max:.4g}]s — "
                 f"choose baselineWindowStart and baselineWindowEnd within this range."
             )
-            logger.error(msg)
-            raise ValueError(msg)
+            logger.error(message)
+            raise ValueError(message)
         else:
-            baseline_mean = np.nanmean(dff[idx])
-            baseline_std = np.nanstd(dff[idx])
+            baseline_mean = np.nanmean(dff[baseline_indices])
+            baseline_std = np.nanstd(dff[baseline_indices])
             numerator = np.subtract(dff, baseline_mean)
             zscore = np.divide(numerator, baseline_std)
     else:

--- a/src/guppy/extractors/csv_recording_extractor.py
+++ b/src/guppy/extractors/csv_recording_extractor.py
@@ -55,90 +55,90 @@ class CsvRecordingExtractor(BaseRecordingExtractor):
         path = sorted(list(set(path)))
         flag = "None"
         event_from_filename = []
-        flag_arr = []
+        flags = []
         for i in range(len(path)):
-            ext = os.path.basename(path[i]).split(".")[-1]
-            if ext != "csv":
+            extension = os.path.basename(path[i]).split(".")[-1]
+            if extension != "csv":
                 raise ValueError(f"Only .csv files are supported by CsvRecordingExtractor; got '{path[i]}'.")
             df = pd.read_csv(path[i], header=None, nrows=2, index_col=False, dtype=str)
             df = df.dropna(axis=1, how="all")
-            df_arr = np.array(df).flatten()
+            header_values = np.array(df).flatten()
             check_all_str = []
-            for element in df_arr:
+            for element in header_values:
                 try:
                     float(element)
                 except:
                     check_all_str.append(i)
-            if len(check_all_str) == len(df_arr):
+            if len(check_all_str) == len(header_values):
                 raise ValueError(
                     f"CSV file '{path[i]}' appears to be a Doric .csv (all-string header rows). "
                     "CsvRecordingExtractor only supports standard .csv files; use the Doric extractor instead."
                 )
             df = pd.read_csv(path[i], index_col=False)
 
-            _, value = cls._check_header(df)
+            _, numeric_headers = cls._check_header(df)
 
             # check dataframe structure and read data accordingly
-            if len(value) > 0:
+            if len(numeric_headers) > 0:
                 columns_isstr = False
                 df = pd.read_csv(path[i], header=None)
-                cols = np.array(list(df.columns), dtype=str)
+                columns = np.array(list(df.columns), dtype=str)
             else:
                 df = df
                 columns_isstr = True
-                cols = np.array(list(df.columns), dtype=str)
+                columns = np.array(list(df.columns), dtype=str)
             # check the structure of dataframe and assign flag to the type of file
-            if len(cols) == 1:
-                if cols[0].lower() != "timestamps":
+            if len(columns) == 1:
+                if columns[0].lower() != "timestamps":
                     message = (
-                        f"CSV file '{path[i]}' has 1 column named '{cols[0]}', but the only-supported "
+                        f"CSV file '{path[i]}' has 1 column named '{columns[0]}', but the only-supported "
                         "single-column CSV format requires the column to be named 'timestamps' (lower case)."
                     )
                     logger.error(message)
                     raise ValueError(message)
                 else:
                     flag = "event_csv"
-            elif len(cols) == 3:
-                arr1 = np.array(["timestamps", "data", "sampling_rate"])
-                arr2 = np.char.lower(np.array(cols))
-                if (np.sort(arr1) == np.sort(arr2)).all() == False:
+            elif len(columns) == 3:
+                required_columns = np.array(["timestamps", "data", "sampling_rate"])
+                lowercase_columns = np.char.lower(np.array(columns))
+                if (np.sort(required_columns) == np.sort(lowercase_columns)).all() == False:
                     message = (
-                        f"CSV file '{path[i]}' has columns {list(cols)}, but the 3-column CSV format "
+                        f"CSV file '{path[i]}' has columns {list(columns)}, but the 3-column CSV format "
                         "requires column names 'timestamps', 'data', 'sampling_rate' (all lower case)."
                     )
                     logger.error(message)
                     raise ValueError(message)
                 else:
                     flag = "data_csv"
-            elif len(cols) >= 2:
+            elif len(columns) >= 2:
                 raise ValueError(
-                    f"CSV file '{path[i]}' has {len(cols)} columns {list(cols)}, which matches the "
+                    f"CSV file '{path[i]}' has {len(columns)} columns {list(columns)}, which matches the "
                     "Neurophotometrics (NPM) layout. Set 'Acquisition System' to 'NPM' in the "
                     "Input Parameters GUI before re-running the pipeline."
                 )
 
-            flag_arr.append(flag)
+            flags.append(flag)
             logger.info(flag)
             name = os.path.basename(path[i]).split(".")[0]
             event_from_filename.append(name)
 
         logger.info("Importing of csv file is done.")
-        return event_from_filename, flag_arr
+        return event_from_filename, flags
 
     def __init__(self, folder_path: str) -> None:
         self.folder_path = folder_path
 
     @staticmethod
     def _check_header(df: pd.DataFrame) -> tuple[list[str], list[float]]:
-        arr = list(df.columns)
+        columns = list(df.columns)
         check_float = []
-        for i in arr:
+        for column in columns:
             try:
-                check_float.append(float(i))
+                check_float.append(float(column))
             except:
                 pass
 
-        return arr, check_float
+        return columns, check_float
 
     def count_samples(self, *, event: str) -> int:
         """Return the number of data rows in ``<event>.csv`` (excludes header)."""
@@ -183,7 +183,7 @@ class CsvRecordingExtractor(BaseRecordingExtractor):
         output_dicts = []
         for event in events:
             dataframe = self._read_csv(event=event)
-            columns_lowercase = [col.lower() for col in dataframe.columns]
+            columns_lowercase = [column.lower() for column in dataframe.columns]
             if "data" in columns_lowercase:
                 output_dicts.append(
                     {

--- a/src/guppy/extractors/detect_acquisition_formats.py
+++ b/src/guppy/extractors/detect_acquisition_formats.py
@@ -24,50 +24,50 @@ def _classify_csv_file(path: str) -> str:
     """
     df = pd.read_csv(path, header=None, nrows=2, index_col=False, dtype=str)
     df = df.dropna(axis=1, how="all")
-    df_arr = np.array(df).flatten()
-    non_numeric = [el for el in df_arr if not _is_float(el)]
+    header_values = np.array(df).flatten()
+    non_numeric = [value for value in header_values if not _is_float(value)]
 
     # Doric CSV files have a 2-line all-string header (metadata + units rows) with no
     # numeric values in the first two rows at all.
-    if len(non_numeric) == len(df_arr):
+    if len(non_numeric) == len(header_values):
         return "doric"
 
     # File has string headers (or numeric-only headers) — inspect column names to distinguish npm from csv.
     df = pd.read_csv(path, index_col=False)
-    colnames = list(df.columns)
+    column_names = list(df.columns)
 
     # Doric v2 files store numeric values as column headers; treat them as headerless.
-    if all(_is_float(c) for c in colnames):
+    if all(_is_float(name) for name in column_names):
         df = pd.read_csv(path, header=None)
-        cols = np.array(list(df.columns), dtype=str)
+        columns = np.array(list(df.columns), dtype=str)
     else:
-        cols = np.array(colnames, dtype=str)
+        columns = np.array(column_names, dtype=str)
 
-    if len(cols) == 1:
-        if cols[0].lower() != "timestamps":
+    if len(columns) == 1:
+        if columns[0].lower() != "timestamps":
             message = (
-                f"CSV file '{path}' has 1 column named '{cols[0]}', but the only-supported "
+                f"CSV file '{path}' has 1 column named '{columns[0]}', but the only-supported "
                 "single-column CSV format requires the column to be named 'timestamps' (lower case)."
             )
             logger.error(message)
             raise ValueError(message)
         return "csv"
-    elif len(cols) == 3:
-        arr1 = np.array(["timestamps", "data", "sampling_rate"])
-        arr2 = np.char.lower(cols)
-        if (np.sort(arr1) == np.sort(arr2)).all():
+    elif len(columns) == 3:
+        required_columns = np.array(["timestamps", "data", "sampling_rate"])
+        lowercase_columns = np.char.lower(columns)
+        if (np.sort(required_columns) == np.sort(lowercase_columns)).all():
             return "csv"
         message = (
-            f"CSV file '{path}' has columns {list(cols)}, but the 3-column CSV format "
+            f"CSV file '{path}' has columns {list(columns)}, but the 3-column CSV format "
             "requires column names 'timestamps', 'data', 'sampling_rate' (all lower case)."
         )
         logger.error(message)
         raise ValueError(message)
-    elif len(cols) >= 2:
+    elif len(columns) >= 2:
         return "npm"
     else:
         message = (
-            f"CSV file '{path}' has {len(cols)} columns, which is not a recognized layout. "
+            f"CSV file '{path}' has {len(columns)} columns, which is not a recognized layout. "
             "Expected 1 column ('timestamps'), 2 columns (NPM event/data), or 3 columns "
             "('timestamps', 'data', 'sampling_rate')."
         )
@@ -98,8 +98,8 @@ def _is_event_csv(path: str) -> bool:
     bool
     """
     df = pd.read_csv(path, nrows=0, index_col=False)
-    cols = list(df.columns)
-    return len(cols) == 1 and cols[0].lower() == "timestamps"
+    columns = list(df.columns)
+    return len(columns) == 1 and columns[0].lower() == "timestamps"
 
 
 def detect_acquisition_formats(folder_path: str) -> set[str]:
@@ -139,9 +139,9 @@ def detect_acquisition_formats(folder_path: str) -> set[str]:
     # Multi-column CSV files can be NPM, Doric CSV exports, or 3-column data_csv files.
     # NPM demultiplexes its raw files in memory and never writes intermediates to the
     # folder, so each modality is detected independently of the others here.
-    non_event_csv_paths = [p for p in csv_paths if not _is_event_csv(p)]
+    non_event_csv_paths = [csv_path for csv_path in csv_paths if not _is_event_csv(csv_path)]
     if non_event_csv_paths:
-        labels = {_classify_csv_file(p) for p in non_event_csv_paths}
+        labels = {_classify_csv_file(csv_path) for csv_path in non_event_csv_paths}
         if "npm" in labels:
             formats.add("npm")
         if "doric" in labels:
@@ -152,7 +152,7 @@ def detect_acquisition_formats(folder_path: str) -> set[str]:
     # Single-column timestamp CSVs are genuine external TTL files read by
     # CsvRecordingExtractor. NpmRecordingExtractor owns its own event streams in
     # memory, so single-column files no longer originate from NPM processing.
-    if any(_is_event_csv(p) for p in csv_paths):
+    if any(_is_event_csv(csv_path) for csv_path in csv_paths):
         formats.add("csv")
 
     return formats

--- a/src/guppy/extractors/doric_recording_extractor.py
+++ b/src/guppy/extractors/doric_recording_extractor.py
@@ -60,29 +60,29 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
             glob.glob(os.path.join(folder_path, "*.doric"))
         )
         # Exclude event CSV files (single 'timestamps' column) — those belong to CsvRecordingExtractor
-        path = [p for p in path if not (p.endswith(".csv") and _is_event_csv(p))]
+        path = [data_path for data_path in path if not (data_path.endswith(".csv") and _is_event_csv(data_path))]
         path = sorted(list(set(path)))
         flag = "None"
         event_from_filename = []
-        flag_arr = []
+        flags = []
 
         for i in range(len(path)):
-            ext = os.path.basename(path[i]).split(".")[-1]
-            if ext == "doric":
+            extension = os.path.basename(path[i]).split(".")[-1]
+            if extension == "doric":
                 key_names = cls._read_doric_file(path[i])
                 event_from_filename.extend(key_names)
                 flag = "doric_doric"
             else:
                 df = pd.read_csv(path[i], header=None, nrows=2, index_col=False, dtype=str)
                 df = df.dropna(axis=1, how="all")
-                df_arr = np.array(df).flatten()
+                header_values = np.array(df).flatten()
                 check_all_str = []
-                for element in df_arr:
+                for element in header_values:
                     try:
                         float(element)
                     except:
                         check_all_str.append(i)
-                if len(check_all_str) != len(df_arr):
+                if len(check_all_str) != len(header_values):
                     raise ValueError(
                         f"CSV file '{path[i]}' appears to be a standard .csv (numeric values in header rows). "
                         "DoricRecordingExtractor only supports Doric .csv files; use the standard CSV extractor instead."
@@ -98,7 +98,7 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
                 logger.info(flag)
 
         logger.info("Doric event discovery complete.")
-        return event_from_filename, flag_arr
+        return event_from_filename, flags
 
     def __init__(self, folder_path: str, event_name_to_event_type: dict[str, str]) -> None:
         self.folder_path = folder_path
@@ -107,31 +107,31 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
     @staticmethod
     def _read_doric_file(filepath: str) -> list[str]:
         """Static helper to read Doric file headers for event discovery."""
-        with h5py.File(filepath, "r") as f:
-            if "Traces" in list(f.keys()):
-                keys = DoricRecordingExtractor._access_keys_doricV1(f)
-            elif list(f.keys()) == ["Configurations", "DataAcquisition"]:
-                keys = DoricRecordingExtractor._access_keys_doricV6(f)
+        with h5py.File(filepath, "r") as doric_file:
+            if "Traces" in list(doric_file.keys()):
+                keys = DoricRecordingExtractor._access_keys_doricV1(doric_file)
+            elif list(doric_file.keys()) == ["Configurations", "DataAcquisition"]:
+                keys = DoricRecordingExtractor._access_keys_doricV6(doric_file)
 
         return keys
 
     @staticmethod
     def _access_keys_doricV6(doric_file: h5py.File) -> list[str]:
-        data = [doric_file["DataAcquisition"]]
-        res = []
-        while len(data) != 0:
-            members = len(data)
+        stack = [doric_file["DataAcquisition"]]
+        dataset_names = []
+        while len(stack) != 0:
+            members = len(stack)
             while members != 0:
                 members -= 1
-                data, last_element = DoricRecordingExtractor._separate_last_element(data)
+                stack, last_element = DoricRecordingExtractor._separate_last_element(stack)
                 if isinstance(last_element, h5py.Dataset) and not last_element.name.endswith("/Time"):
-                    res.append(last_element.name)
+                    dataset_names.append(last_element.name)
                 elif isinstance(last_element, h5py.Group):
-                    data.extend(reversed([last_element[k] for k in last_element.keys()]))
+                    stack.extend(reversed([last_element[key] for key in last_element.keys()]))
 
         keys = []
-        for element in res:
-            sep_values = element.split("/")
+        for dataset_name in dataset_names:
+            sep_values = dataset_name.split("/")
             if sep_values[-1] == "Values":
                 keys.append(f"{sep_values[-3]}/{sep_values[-2]}")
             else:
@@ -147,9 +147,9 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
         return keys
 
     @staticmethod
-    def _separate_last_element(arr: list) -> tuple[list, object]:
-        l = arr[-1]
-        return arr[:-1], l
+    def _separate_last_element(elements: list) -> tuple[list, object]:
+        last_element = elements[-1]
+        return elements[:-1], last_element
 
     @staticmethod
     def _validate_signal_control_data(event: str, data: np.ndarray, event_type: str) -> None:
@@ -197,32 +197,32 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
             doric_paths = glob.glob(os.path.join(self.folder_path, "*.doric"))
             if not doric_paths:
                 return 0
-            with h5py.File(doric_paths[0], "r") as f:
-                if "Traces" in list(f.keys()):
-                    console = f["Traces"]["Console"]
+            with h5py.File(doric_paths[0], "r") as doric_file:
+                if "Traces" in list(doric_file.keys()):
+                    console = doric_file["Traces"]["Console"]
                     if event in console:
                         return int(console[event][event].shape[0])
                     return 0
-                if list(f.keys()) == ["Configurations", "DataAcquisition"]:
-                    data = [f["DataAcquisition"]]
-                    res = []
-                    while len(data) != 0:
-                        members = len(data)
+                if list(doric_file.keys()) == ["Configurations", "DataAcquisition"]:
+                    stack = [doric_file["DataAcquisition"]]
+                    dataset_names = []
+                    while len(stack) != 0:
+                        members = len(stack)
                         while members != 0:
                             members -= 1
-                            data, last_element = self._separate_last_element(data)
+                            stack, last_element = self._separate_last_element(stack)
                             if isinstance(last_element, h5py.Dataset) and not last_element.name.endswith("/Time"):
-                                res.append(last_element.name)
+                                dataset_names.append(last_element.name)
                             elif isinstance(last_element, h5py.Group):
-                                data.extend(reversed([last_element[k] for k in last_element.keys()]))
-                    for element in res:
-                        sep_values = element.split("/")
+                                stack.extend(reversed([last_element[key] for key in last_element.keys()]))
+                    for dataset_name in dataset_names:
+                        sep_values = dataset_name.split("/")
                         if sep_values[-1] == "Values":
                             label = f"{sep_values[-3]}/{sep_values[-2]}"
                         else:
                             label = f"{sep_values[-2]}/{sep_values[-1]}"
                         if label == event:
-                            return int(f[element].shape[0])
+                            return int(doric_file[dataset_name].shape[0])
                     return 0
         return 0
 
@@ -230,10 +230,10 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
         logger.debug("Checking if doric file exists")
         path = glob.glob(os.path.join(self.folder_path, "*.csv")) + glob.glob(os.path.join(self.folder_path, "*.doric"))
 
-        flag_arr = []
+        flags = []
         for i in range(len(path)):
-            ext = os.path.basename(path[i]).split(".")[-1]
-            if ext == "csv":
+            extension = os.path.basename(path[i]).split(".")[-1]
+            if extension == "csv":
                 with warnings.catch_warnings():
                     warnings.simplefilter("error")
                     try:
@@ -241,14 +241,14 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
                     except:  # TODO: fix this bare try-except
                         df = pd.read_csv(path[i], header=1, index_col=False, nrows=10)
                         flag = "doric_csv"
-                        flag_arr.append(flag)
-            elif ext == "doric":
+                        flags.append(flag)
+            elif extension == "doric":
                 flag = "doric_doric"
-                flag_arr.append(flag)
+                flags.append(flag)
             else:
                 pass
 
-        if len(flag_arr) > 1:
+        if len(flags) > 1:
             doric_paths = sorted(
                 glob.glob(os.path.join(self.folder_path, "*.csv"))
                 + glob.glob(os.path.join(self.folder_path, "*.doric"))
@@ -259,11 +259,11 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
             )
             logger.error(message)
             raise ValueError(message)
-        if len(flag_arr) == 0:
+        if len(flags) == 0:
             logger.error("Doric file not found.")
             return 0
         logger.info("Doric file found.")
-        return flag_arr[0]
+        return flags[0]
 
     def _read_doric_csv(self, events: list[str]) -> list[dict[str, object]]:
         path = glob.glob(os.path.join(self.folder_path, "*.csv"))
@@ -283,7 +283,7 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
         output_dicts = []
         for event in events:
             if event not in df.columns:
-                available = sorted(c for c in df.columns if c != "Time(s)")
+                available = sorted(column for column in df.columns if column != "Time(s)")
                 raise ValueError(
                     f"Doric channel {event!r} not found in Doric CSV file. "
                     f"Available channels: {available}. Empty columns (trailing commas, "
@@ -323,63 +323,63 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
             )
             logger.error(message)
             raise ValueError(message)
-        with h5py.File(path[0], "r") as f:
-            if "Traces" in list(f.keys()):
-                output_dicts = self._access_data_doricV1(f, events)
-            elif list(f.keys()) == ["Configurations", "DataAcquisition"]:
-                output_dicts = self._access_data_doricV6(f, events)
+        with h5py.File(path[0], "r") as doric_file:
+            if "Traces" in list(doric_file.keys()):
+                output_dicts = self._access_data_doricV1(doric_file, events)
+            elif list(doric_file.keys()) == ["Configurations", "DataAcquisition"]:
+                output_dicts = self._access_data_doricV6(doric_file, events)
         return output_dicts
 
     def _access_data_doricV6(self, doric_file: h5py.File, events: list[str]) -> list[dict[str, object]]:
-        data = [doric_file["DataAcquisition"]]
-        res = []
-        while len(data) != 0:
-            members = len(data)
+        stack = [doric_file["DataAcquisition"]]
+        dataset_names = []
+        while len(stack) != 0:
+            members = len(stack)
             while members != 0:
                 members -= 1
-                data, last_element = self._separate_last_element(data)
+                stack, last_element = self._separate_last_element(stack)
                 if isinstance(last_element, h5py.Dataset) and not last_element.name.endswith("/Time"):
-                    res.append(last_element.name)
+                    dataset_names.append(last_element.name)
                 elif isinstance(last_element, h5py.Group):
-                    data.extend(reversed([last_element[k] for k in last_element.keys()]))
+                    stack.extend(reversed([last_element[key] for key in last_element.keys()]))
 
         decide_path = []
-        for element in res:
-            sep_values = element.split("/")
+        for dataset_name in dataset_names:
+            sep_values = dataset_name.split("/")
             if sep_values[-1] == "Values":
                 if f"{sep_values[-3]}/{sep_values[-2]}" in events:
-                    decide_path.append(element)
+                    decide_path.append(dataset_name)
             else:
                 if f"{sep_values[-2]}/{sep_values[-1]}" in events:
-                    decide_path.append(element)
+                    decide_path.append(dataset_name)
 
         output_dicts = []
         for event in events:
             event_type = self._event_name_to_event_type[event]
             if "control" in event_type or "signal" in event_type:
                 regex = re.compile("(.*?)" + str(event) + "(.*?)")
-                idx = [i for i in range(len(decide_path)) if regex.match(decide_path[i])]
-                if len(idx) > 1:
-                    matched_paths = [decide_path[i] for i in idx]
+                matching_indices = [i for i in range(len(decide_path)) if regex.match(decide_path[i])]
+                if len(matching_indices) > 1:
+                    matched_paths = [decide_path[i] for i in matching_indices]
                     message = (
                         f"Doric channel {event!r} matches multiple internal HDF5 paths "
                         f"({matched_paths}); expected exactly one. The Doric file may have a malformed structure."
                     )
                     logger.error(message)
                     raise ValueError(message)
-                if len(idx) == 0:
+                if len(matching_indices) == 0:
                     available = sorted(
                         {
-                            p.rsplit("/", 1)[-1] if p.rsplit("/", 1)[-1] != "Values" else p.rsplit("/", 2)[-2]
-                            for p in res
+                            name.rsplit("/", 1)[-1] if name.rsplit("/", 1)[-1] != "Values" else name.rsplit("/", 2)[-2]
+                            for name in dataset_names
                         }
                     )
                     raise ValueError(
                         f"Doric channel {event!r} not found in Doric V6 file. " f"Available channels: {available}."
                     )
-                idx = idx[0]
-                data = np.array(doric_file[decide_path[idx]])
-                timestamps = np.array(doric_file[decide_path[idx].rsplit("/", 1)[0] + "/Time"])
+                match_index = matching_indices[0]
+                data = np.array(doric_file[decide_path[match_index]])
+                timestamps = np.array(doric_file[decide_path[match_index].rsplit("/", 1)[0] + "/Time"])
                 self._validate_signal_control_data(event, data, event_type)
                 sampling_rate = np.array([1 / (timestamps[-1] - timestamps[-2])])
                 storename = event
@@ -392,28 +392,28 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
                 output_dicts.append(event_dict)
             else:
                 regex = re.compile("(.*?)" + event + "$")
-                idx = [i for i in range(len(decide_path)) if regex.match(decide_path[i])]
-                if len(idx) > 1:
-                    matched_paths = [decide_path[i] for i in idx]
+                matching_indices = [i for i in range(len(decide_path)) if regex.match(decide_path[i])]
+                if len(matching_indices) > 1:
+                    matched_paths = [decide_path[i] for i in matching_indices]
                     message = (
                         f"Doric channel {event!r} matches multiple internal HDF5 paths "
                         f"({matched_paths}); expected exactly one. The Doric file may have a malformed structure."
                     )
                     logger.error(message)
                     raise ValueError(message)
-                if len(idx) == 0:
+                if len(matching_indices) == 0:
                     available = sorted(
                         {
-                            p.rsplit("/", 1)[-1] if p.rsplit("/", 1)[-1] != "Values" else p.rsplit("/", 2)[-2]
-                            for p in res
+                            name.rsplit("/", 1)[-1] if name.rsplit("/", 1)[-1] != "Values" else name.rsplit("/", 2)[-2]
+                            for name in dataset_names
                         }
                     )
                     raise ValueError(
                         f"Doric TTL channel {event!r} not found in Doric V6 file. " f"Available channels: {available}."
                     )
-                idx = idx[0]
-                ttl = np.array(doric_file[decide_path[idx]])
-                timestamps = np.array(doric_file[decide_path[idx].rsplit("/", 1)[0] + "/Time"])
+                match_index = matching_indices[0]
+                ttl = np.array(doric_file[decide_path[match_index]])
+                timestamps = np.array(doric_file[decide_path[match_index].rsplit("/", 1)[0] + "/Time"])
                 indices = np.where(ttl <= 0)[0]
                 diff_indices = np.where(np.diff(indices) > 1)[0]
                 timestamps = timestamps[indices[diff_indices] + 1]

--- a/src/guppy/extractors/npm_recording_extractor.py
+++ b/src/guppy/extractors/npm_recording_extractor.py
@@ -99,14 +99,14 @@ class NpmRecordingExtractor(CsvRecordingExtractor):
             # TODO: come up with a better name for npm_split_events that can be appropriately pluralized for a list
             npm_split_events = inputParameters.get("npm_split_events")
 
-        streams, flag_arr = cls._decompose_streams(
+        streams, flags = cls._decompose_streams(
             folder_path=folder_path,
             num_ch=num_ch,
             npm_timestamp_column_names=npm_timestamp_column_names,
             npm_time_units=npm_time_units,
             npm_split_events=npm_split_events,
         )
-        return list(streams.keys()), flag_arr
+        return list(streams.keys()), flags
 
     @classmethod
     def _decompose_streams(
@@ -159,7 +159,7 @@ class NpmRecordingExtractor(CsvRecordingExtractor):
 
         path = sorted(list(set(path) - set(path_chev_chod_event)))
         # Exclude single-column timestamp CSVs — those are handled by CsvRecordingExtractor.
-        path = [p for p in path if not (p.endswith(".csv") and _is_event_csv(p))]
+        path = [csv_path for csv_path in path if not (csv_path.endswith(".csv") and _is_event_csv(csv_path))]
 
         streams: dict[str, dict[str, np.ndarray]] = {}
         # Track derived stream names in creation order so the cross-file channel
@@ -168,7 +168,7 @@ class NpmRecordingExtractor(CsvRecordingExtractor):
         chod_names: list[str] = []
         chpr_names: list[str] = []
         event_names: list[str] = []
-        flag_arr: list[str] = []
+        flags: list[str] = []
         ts_unit = "seconds"
         for i in range(len(path)):
             # TODO: validate npm_timestamp_column_names, npm_time_units, npm_split_events lengths
@@ -185,53 +185,53 @@ class NpmRecordingExtractor(CsvRecordingExtractor):
             else:
                 split_events = npm_split_events[i]
 
-            ext = os.path.basename(path[i]).split(".")[-1]
-            if ext == "doric":
+            extension = os.path.basename(path[i]).split(".")[-1]
+            if extension == "doric":
                 raise ValueError(f"Doric files are not supported by NpmRecordingExtractor; got '{path[i]}'.")
             df = pd.read_csv(path[i], header=None, nrows=2, index_col=False, dtype=str)
             df = df.dropna(axis=1, how="all")
-            df_arr = np.array(df).flatten()
+            header_values = np.array(df).flatten()
             check_all_str = []
-            for element in df_arr:
+            for element in header_values:
                 try:
                     float(element)
                 except:
                     check_all_str.append(i)
-            if len(check_all_str) == len(df_arr):
+            if len(check_all_str) == len(header_values):
                 raise ValueError(
                     f"CSV file '{path[i]}' appears to be a Doric .csv (all-string header rows). "
                     "NpmRecordingExtractor only supports NPM .csv files; use the Doric extractor instead."
                 )
             df = pd.read_csv(path[i], index_col=False)
-            _, value = cls._check_header(df)
+            _, numeric_headers = cls._check_header(df)
 
             # check dataframe structure and read data accordingly
-            if len(value) > 0:
+            if len(numeric_headers) > 0:
                 columns_isstr = False
                 df = pd.read_csv(path[i], header=None)
-                cols = np.array(list(df.columns), dtype=str)
+                columns = np.array(list(df.columns), dtype=str)
             else:
                 df = df
                 columns_isstr = True
-                cols = np.array(list(df.columns), dtype=str)
+                columns = np.array(list(df.columns), dtype=str)
             # check the structure of dataframe and assign flag to the type of file
-            if len(cols) == 1:
+            if len(columns) == 1:
                 raise ValueError(
                     f"CSV file '{path[i]}' has 1 column (event .csv layout). "
                     "NpmRecordingExtractor only supports NPM .csv files; use the standard CSV extractor for event timestamp files."
                 )
-            if len(cols) == 3:
+            if len(columns) == 3:
                 raise ValueError(
-                    f"CSV file '{path[i]}' has 3 columns {list(cols)} (data .csv layout). "
+                    f"CSV file '{path[i]}' has 3 columns {list(columns)} (data .csv layout). "
                     "NpmRecordingExtractor only supports NPM .csv files; use the standard CSV extractor for 3-column data files."
                 )
-            if len(cols) == 2:
+            if len(columns) == 2:
                 flag = "event_or_data_np"
-            elif len(cols) > 2:
+            elif len(columns) > 2:
                 flag = "data_np"
 
             if columns_isstr == True and (
-                "flags" in np.char.lower(np.array(cols)) or "ledstate" in np.char.lower(np.array(cols))
+                "flags" in np.char.lower(np.array(columns)) or "ledstate" in np.char.lower(np.array(columns))
             ):
                 flag = flag + "_v2"
             else:
@@ -239,20 +239,20 @@ class NpmRecordingExtractor(CsvRecordingExtractor):
 
             # used assigned flags to process the files and read the data
             if flag == "event_or_data_np":
-                arr = list(df.iloc[:, 1])
-                check_float = [True for i in arr if isinstance(i, float)]
-                if len(arr) == len(check_float) and columns_isstr == False:
+                second_column_values = list(df.iloc[:, 1])
+                check_float = [True for value in second_column_values if isinstance(value, float)]
+                if len(second_column_values) == len(check_float) and columns_isstr == False:
                     flag = "data_np"
-                elif columns_isstr == True and ("value" in np.char.lower(np.array(cols))):
+                elif columns_isstr == True and ("value" in np.char.lower(np.array(columns))):
                     flag = "event_np"
                 else:
                     flag = "event_np"
 
-            flag_arr.append(flag)
+            flags.append(flag)
             logger.info(flag)
             if flag == "data_np":
-                file = f"file{str(i)}_"
-                df, indices_dict, _ = cls.decide_indices(file, df, flag, num_ch)
+                file_prefix = f"file{str(i)}_"
+                df, indices_dict, _ = cls.decide_indices(file_prefix, df, flag, num_ch)
                 keys = list(indices_dict.keys())
                 for k in range(len(keys)):
                     for j in range(df.shape[1]):
@@ -272,9 +272,9 @@ class NpmRecordingExtractor(CsvRecordingExtractor):
                 if split_events:
                     timestamps = np.array(df.iloc[:, 0])
                     for j in range(len(type_val_unique)):
-                        idx = np.where(type_val == type_val_unique[j])
+                        matching_indices = np.where(type_val == type_val_unique[j])
                         name = "event" + str(type_val_unique[j])
-                        streams[name] = {"timestamps": np.asarray(timestamps[idx], dtype=float)}
+                        streams[name] = {"timestamps": np.asarray(timestamps[matching_indices], dtype=float)}
                         event_names.append(name)
                 else:
                     timestamps = np.array(df.iloc[:, 0])
@@ -282,10 +282,10 @@ class NpmRecordingExtractor(CsvRecordingExtractor):
                     streams[name] = {"timestamps": np.asarray(timestamps, dtype=float)}
                     event_names.append(name)
             else:
-                file = f"file{str(i)}_"
+                file_prefix = f"file{str(i)}_"
                 ts_unit = npm_time_unit
                 df = cls._update_df_with_timestamp_columns(df, timestamp_column_name=npm_timestamp_column_name)
-                df, indices_dict, _ = cls.decide_indices(file, df, flag)
+                df, indices_dict, _ = cls.decide_indices(file_prefix, df, flag)
                 keys = list(indices_dict.keys())
                 for k in range(len(keys)):
                     for j in range(df.shape[1]):
@@ -301,8 +301,8 @@ class NpmRecordingExtractor(CsvRecordingExtractor):
 
         # Normalize timestamps relative to the chev reference and compute sampling
         # rates. Only runs when at least one data channel is present.
-        if "data_np_v2" in flag_arr or "data_np" in flag_arr:
-            if "data_np_v2" in flag_arr:
+        if "data_np_v2" in flags or "data_np" in flags:
+            if "data_np_v2" in flags:
                 if ts_unit == "seconds":
                     divisor = 1
                 elif ts_unit == "milliseconds":
@@ -352,7 +352,7 @@ class NpmRecordingExtractor(CsvRecordingExtractor):
                     chpr_stream["sampling_rate"] = np.array([sampling_rate])
 
         logger.info("Importing of NPM file is done.")
-        return streams, flag_arr
+        return streams, flags
 
     @staticmethod
     def _register_channel_name(
@@ -460,7 +460,7 @@ class NpmRecordingExtractor(CsvRecordingExtractor):
             else:
                 dataframe = df_probe
                 timestamp_column = next(
-                    (col for col in dataframe.columns if "timestamp" in col.lower()),
+                    (column for column in dataframe.columns if "timestamp" in column.lower()),
                     dataframe.columns[0],
                 )
                 has_text_header = True
@@ -495,27 +495,29 @@ class NpmRecordingExtractor(CsvRecordingExtractor):
         path_chev_chod_event = path_chev + path_chod + path_event + path_chpr
 
         path = sorted(list(set(path) - set(path_chev_chod_event)))
-        path = [p for p in path if not _is_event_csv(p)]  # Skip event CSVs, which are handled by CsvRecordingExtractor
+        path = [
+            csv_path for csv_path in path if not _is_event_csv(csv_path)
+        ]  # Skip event CSVs, which are handled by CsvRecordingExtractor
         multiple_event_ttls = []
         for i in range(len(path)):
             df = pd.read_csv(path[i], index_col=False)
-            _, value = cls._check_header(df)
+            _, numeric_headers = cls._check_header(df)
 
             # check dataframe structure and read data accordingly
-            if len(value) > 0:
+            if len(numeric_headers) > 0:
                 columns_isstr = False
                 df = pd.read_csv(path[i], header=None)
-                cols = np.array(list(df.columns), dtype=str)
+                columns = np.array(list(df.columns), dtype=str)
             else:
                 columns_isstr = True
-                cols = np.array(list(df.columns), dtype=str)
-            if len(cols) == 2:
+                columns = np.array(list(df.columns), dtype=str)
+            if len(columns) == 2:
                 flag = "event_or_data_np"
-            elif len(cols) > 2:
+            elif len(columns) > 2:
                 flag = "data_np"
             else:
                 message = (
-                    f"CSV file '{path[i]}' has {len(cols)} columns, which is not a recognized NPM layout. "
+                    f"CSV file '{path[i]}' has {len(columns)} columns, which is not a recognized NPM layout. "
                     "Expected 2+ columns."
                 )
                 logger.error(message)
@@ -523,11 +525,11 @@ class NpmRecordingExtractor(CsvRecordingExtractor):
 
             # used assigned flags to process the files and read the data
             if flag == "event_or_data_np":
-                arr = list(df.iloc[:, 1])
-                check_float = [True for i in arr if isinstance(i, float)]
-                if len(arr) == len(check_float) and columns_isstr == False:
+                second_column_values = list(df.iloc[:, 1])
+                check_float = [True for value in second_column_values if isinstance(value, float)]
+                if len(second_column_values) == len(check_float) and columns_isstr == False:
                     flag = "data_np"
-                elif columns_isstr == True and ("value" in np.char.lower(np.array(cols))):
+                elif columns_isstr == True and ("value" in np.char.lower(np.array(columns))):
                     flag = "event_np"
                 else:
                     flag = "event_np"
@@ -548,7 +550,7 @@ class NpmRecordingExtractor(CsvRecordingExtractor):
     # in neurophotometrics data
     @classmethod
     def decide_indices(
-        cls, file: str, df: pd.DataFrame, flag: str, num_ch: int = 2
+        cls, file_prefix: str, df: pd.DataFrame, flag: str, num_ch: int = 2
     ) -> tuple[pd.DataFrame, dict[str, np.ndarray], int]:
         """
         Determine the row indices belonging to each interleaved channel in NPM data.
@@ -559,7 +561,7 @@ class NpmRecordingExtractor(CsvRecordingExtractor):
 
         Parameters
         ----------
-        file : str
+        file_prefix : str
             Filename prefix used to build per-channel keys (e.g. ``"file0_"``).
         df : pd.DataFrame
             NPM data DataFrame, with or without a text header.
@@ -579,8 +581,8 @@ class NpmRecordingExtractor(CsvRecordingExtractor):
         num_ch : int
             Actual number of channels detected.
         """
-        ch_name = [file + "chev", file + "chod", file + "chpr"]
-        if len(ch_name) < num_ch:
+        channel_keys = [file_prefix + "chev", file_prefix + "chod", file_prefix + "chpr"]
+        if len(channel_keys) < num_ch:
             message = (
                 f"Number of channels in the Input Parameters GUI is set to {num_ch}, which exceeds the "
                 "maximum of 3 channels supported for NPM files. Set 'Number of channels' to 3 or fewer "
@@ -591,31 +593,31 @@ class NpmRecordingExtractor(CsvRecordingExtractor):
         if flag == "data_np":
             indices_dict = dict()
             for i in range(num_ch):
-                indices_dict[ch_name[i]] = np.arange(i, df.shape[0], num_ch)
+                indices_dict[channel_keys[i]] = np.arange(i, df.shape[0], num_ch)
 
         else:
-            cols = np.array(list(df.columns))
-            if "flags" in np.char.lower(np.array(cols)):
-                arr = ["FrameCounter", "Flags"]
+            columns = np.array(list(df.columns))
+            if "flags" in np.char.lower(np.array(columns)):
+                columns_to_drop = ["FrameCounter", "Flags"]
                 state = np.array(df["Flags"])
-            elif "ledstate" in np.char.lower(np.array(cols)):
-                arr = ["FrameCounter", "LedState"]
+            elif "ledstate" in np.char.lower(np.array(columns)):
+                columns_to_drop = ["FrameCounter", "LedState"]
                 state = np.array(df["LedState"])
             else:
                 message = (
                     "File type indicates Neurophotometrics newer version data but the columns do not "
-                    f"contain a 'Flags' or 'LedState' column. Found columns: {list(cols)}."
+                    f"contain a 'Flags' or 'LedState' column. Found columns: {list(columns)}."
                 )
                 logger.error(message)
                 raise ValueError(message)
 
-            num_ch, ch = cls.check_channels(state)
+            num_ch, unique_states = cls.check_channels(state)
             indices_dict = dict()
             for i in range(num_ch):
-                first_occurrence = np.where(state == ch[i])[0]
-                indices_dict[ch_name[i]] = np.arange(first_occurrence[0], df.shape[0], num_ch)
+                first_occurrence = np.where(state == unique_states[i])[0]
+                indices_dict[channel_keys[i]] = np.arange(first_occurrence[0], df.shape[0], num_ch)
 
-            df = df.drop(arr, axis=1)
+            df = df.drop(columns_to_drop, axis=1)
 
         return df, indices_dict, num_ch
 
@@ -673,7 +675,7 @@ class NpmRecordingExtractor(CsvRecordingExtractor):
         ts_unit_needs : list of bool
             One entry per NPM data file. ``True`` if the file has multiple
             timestamp columns and requires unit disambiguation.
-        col_names_ts : list of str
+        timestamp_column_names : list of str
             Names of all timestamp-like columns found across the files.
         """
         path = sorted(glob.glob(os.path.join(folder_path, "*.csv"))) + sorted(
@@ -687,85 +689,89 @@ class NpmRecordingExtractor(CsvRecordingExtractor):
         path_chev_chod_event = path_chev + path_chod + path_event + path_chpr
 
         path = sorted(list(set(path) - set(path_chev_chod_event)))
-        path = [p for p in path if not _is_event_csv(p)]  # Skip event CSVs, which are handled by CsvRecordingExtractor
+        path = [
+            csv_path for csv_path in path if not _is_event_csv(csv_path)
+        ]  # Skip event CSVs, which are handled by CsvRecordingExtractor
         ts_unit_needs = []
-        col_names_ts = [""]
+        timestamp_column_names = [""]
         for i in range(len(path)):
             df = pd.read_csv(path[i], index_col=False)
-            _, value = cls._check_header(df)
+            _, numeric_headers = cls._check_header(df)
 
             # check dataframe structure and read data accordingly
-            if len(value) > 0:
+            if len(numeric_headers) > 0:
                 df = pd.read_csv(path[i], header=None)
-                cols = np.array(list(df.columns), dtype=str)
+                columns = np.array(list(df.columns), dtype=str)
                 columns_isstr = False
             else:
                 columns_isstr = True
-                cols = np.array(list(df.columns), dtype=str)
+                columns = np.array(list(df.columns), dtype=str)
             # check the structure of dataframe and assign flag to the type of file
-            if len(cols) == 2:
+            if len(columns) == 2:
                 flag = "event_or_data_np"
-            elif len(cols) > 2:
+            elif len(columns) > 2:
                 flag = "data_np"
             else:
                 message = (
-                    f"CSV file '{path[i]}' has {len(cols)} columns, which is not a recognized NPM layout. "
+                    f"CSV file '{path[i]}' has {len(columns)} columns, which is not a recognized NPM layout. "
                     "Expected 2+ columns."
                 )
                 logger.error(message)
                 raise ValueError(message)
 
             if columns_isstr == True and (
-                "flags" in np.char.lower(np.array(cols)) or "ledstate" in np.char.lower(np.array(cols))
+                "flags" in np.char.lower(np.array(columns)) or "ledstate" in np.char.lower(np.array(columns))
             ):
                 flag = flag + "_v2"
 
             # used assigned flags to process the files and read the data
             if flag == "event_or_data_np":
-                arr = list(df.iloc[:, 1])
-                check_float = [True for i in arr if isinstance(i, float)]
-                if len(arr) == len(check_float) and columns_isstr == False:
+                second_column_values = list(df.iloc[:, 1])
+                check_float = [True for value in second_column_values if isinstance(value, float)]
+                if len(second_column_values) == len(check_float) and columns_isstr == False:
                     flag = "data_np"
-                elif columns_isstr == True and ("value" in np.char.lower(np.array(cols))):
+                elif columns_isstr == True and ("value" in np.char.lower(np.array(columns))):
                     flag = "event_np"
                 else:
                     flag = "event_np"
 
             if flag == "data_np":
-                file = f"file{str(i)}_"
-                df, _, _ = cls.decide_indices(file, df, flag, num_ch)
+                file_prefix = f"file{str(i)}_"
+                df, _, _ = cls.decide_indices(file_prefix, df, flag, num_ch)
 
             if flag == "event_np" or flag == "data_np":
                 ts_unit_needs.append(False)
                 continue
 
-            col_names = np.array(list(df.columns))
-            for name in col_names:
+            column_names = np.array(list(df.columns))
+            for name in column_names:
                 if "timestamp" in name.lower():
-                    col_names_ts.append(name)
+                    timestamp_column_names.append(name)
 
-            if len(col_names_ts) > 2:
+            if len(timestamp_column_names) > 2:
                 ts_unit_needs.append(True)
             else:
                 ts_unit_needs.append(False)
 
-        return ts_unit_needs, col_names_ts
+        return ts_unit_needs, timestamp_column_names
 
     @staticmethod
     def _update_df_with_timestamp_columns(df: pd.DataFrame, timestamp_column_name: str | None) -> pd.DataFrame:
-        col_names = np.array(list(df.columns))
-        col_names_ts = [""]
-        for name in col_names:
+        column_names = np.array(list(df.columns))
+        timestamp_column_names = [""]
+        for name in column_names:
             if "timestamp" in name.lower():
-                col_names_ts.append(name)
-        if len(col_names_ts) <= 2:
+                timestamp_column_names.append(name)
+        if len(timestamp_column_names) <= 2:
             return df
 
-        timestamp_column_name = timestamp_column_name if timestamp_column_name is not None else col_names_ts[1]
-        if timestamp_column_name not in col_names_ts:
+        timestamp_column_name = (
+            timestamp_column_name if timestamp_column_name is not None else timestamp_column_names[1]
+        )
+        if timestamp_column_name not in timestamp_column_names:
             raise ValueError(
-                f"Provided timestamp_column_name '{timestamp_column_name}' not found in columns {col_names_ts[1:]}."
+                f"Provided timestamp_column_name '{timestamp_column_name}' not found in columns {timestamp_column_names[1:]}."
             )
         df.insert(1, "Timestamp", df[timestamp_column_name])
-        df = df.drop(col_names_ts[1:], axis=1)
+        df = df.drop(timestamp_column_names[1:], axis=1)
         return df

--- a/src/guppy/extractors/nwb_recording_extractor.py
+++ b/src/guppy/extractors/nwb_recording_extractor.py
@@ -124,9 +124,9 @@ def _count_event_samples(*, nwbfile: NWBFile, io: NWBHDF5IO, event: str) -> int:
     negligibly to progress-bar weighting.
     """
     series_name_to_object = {
-        obj.name: obj
-        for obj in nwbfile.objects.values()
-        if getattr(obj, "neurodata_type", None) == "FiberPhotometryResponseSeries"
+        neurodata_object.name: neurodata_object
+        for neurodata_object in nwbfile.objects.values()
+        if getattr(neurodata_object, "neurodata_type", None) == "FiberPhotometryResponseSeries"
     }
     if event in series_name_to_object:
         return int(series_name_to_object[event].data.shape[0])
@@ -201,9 +201,9 @@ def _read_events_from_nwbfile(*, nwbfile: NWBFile, io: NWBHDF5IO, events: list[s
     ndx_events_version = _get_ndx_events_version(io)
 
     series_name_to_object = {
-        obj.name: obj
-        for obj in nwbfile.objects.values()
-        if getattr(obj, "neurodata_type", None) == "FiberPhotometryResponseSeries"
+        neurodata_object.name: neurodata_object
+        for neurodata_object in nwbfile.objects.values()
+        if getattr(neurodata_object, "neurodata_type", None) == "FiberPhotometryResponseSeries"
     }
 
     event_index = {}
@@ -331,16 +331,16 @@ def _build_event_index_v02(nwbfile: NWBFile) -> dict[str, tuple]:
         ``("events", object)``.
     """
     index = {}
-    for obj in nwbfile.objects.values():
-        neurodata_type = getattr(obj, "neurodata_type", None)
+    for neurodata_object in nwbfile.objects.values():
+        neurodata_type = getattr(neurodata_object, "neurodata_type", None)
         if neurodata_type == "AnnotatedEventsTable":
-            for row_index, label in enumerate(obj["label"].data):
-                index[f"{obj.name}_{label}"] = ("annotated", obj, row_index)
+            for row_index, label in enumerate(neurodata_object["label"].data):
+                index[f"{neurodata_object.name}_{label}"] = ("annotated", neurodata_object, row_index)
         elif neurodata_type == "LabeledEvents":
-            for label_index, label in enumerate(obj.data__labels):
-                index[f"{obj.name}_{label}"] = ("labeled", obj, label_index)
+            for label_index, label in enumerate(neurodata_object.data__labels):
+                index[f"{neurodata_object.name}_{label}"] = ("labeled", neurodata_object, label_index)
         elif neurodata_type == "Events":
-            index[obj.name] = ("events", obj)
+            index[neurodata_object.name] = ("events", neurodata_object)
     return index
 
 
@@ -382,18 +382,18 @@ def _read_ndx_event(*, event_name: str, source_info: tuple) -> dict[str, object]
     tag = source_info[0]
 
     if tag == "annotated":
-        _, obj, row_index = source_info
-        return {"storename": event_name, "timestamps": np.array(obj["event_times"][row_index])}
+        _, neurodata_object, row_index = source_info
+        return {"storename": event_name, "timestamps": np.array(neurodata_object["event_times"][row_index])}
 
     if tag == "labeled":
-        _, obj, label_index = source_info
-        all_timestamps = np.array(obj.timestamps[:])
-        all_data = np.array(obj.data[:])
+        _, neurodata_object, label_index = source_info
+        all_timestamps = np.array(neurodata_object.timestamps[:])
+        all_data = np.array(neurodata_object.data[:])
         return {"storename": event_name, "timestamps": all_timestamps[all_data == label_index]}
 
     if tag == "events":
-        _, obj = source_info
-        return {"storename": event_name, "timestamps": np.array(obj.timestamps[:])}
+        _, neurodata_object = source_info
+        return {"storename": event_name, "timestamps": np.array(neurodata_object.timestamps[:])}
 
     if tag == "core":
         _, table, split_column, split_value = source_info

--- a/src/guppy/extractors/tdt_recording_extractor.py
+++ b/src/guppy/extractors/tdt_recording_extractor.py
@@ -52,12 +52,12 @@ class TdtRecordingExtractor(BaseRecordingExtractor):
         if isinstance(header_df, pd.DataFrame):
             header_df["name"] = np.asarray(header_df["name"], dtype=str)
             allnames = np.unique(header_df["name"])
-            index = []
+            short_name_indices = []
             for i in range(len(allnames)):
                 length = len(str(allnames[i]))
                 if length < 4:
-                    index.append(i)
-            allnames = np.delete(allnames, index, 0)
+                    short_name_indices.append(i)
+            allnames = np.delete(allnames, short_name_indices, 0)
             # Epoc stores that encode multiple behaviours are split into one sub-event per
             # unique marker value here (at discover time) so storesList is fully settled
             # before step 2; read() then needs no storesList mutation.
@@ -110,36 +110,36 @@ class TdtRecordingExtractor(BaseRecordingExtractor):
         return df, flag
 
     def _readtev(self, event: str) -> dict[str, object]:
-        data = self._header_df.copy()
-        filepath = self.folder_path
+        header_df = self._header_df.copy()
+        folder_path = self.folder_path
 
         logger.debug("Reading data for event {} ...".format(event))
-        tevfilepath = glob.glob(os.path.join(filepath, "*.tev"))
+        tevfilepath = glob.glob(os.path.join(folder_path, "*.tev"))
         if len(tevfilepath) > 1:
             raise ValueError(
-                f"Multiple .tev files found in '{filepath}': {sorted(tevfilepath)}. "
+                f"Multiple .tev files found in '{folder_path}': {sorted(tevfilepath)}. "
                 "Each TDT tank folder must contain exactly one .tev file."
             )
         else:
             tevfilepath = tevfilepath[0]
 
-        data["name"] = np.asarray(data["name"], dtype=str)
+        header_df["name"] = np.asarray(header_df["name"], dtype=str)
 
-        allnames = np.unique(data["name"])
+        allnames = np.unique(header_df["name"])
 
-        index = []
+        short_name_indices = []
         for i in range(len(allnames)):
             length = len(str(allnames[i]))
             if length < 4:
-                index.append(i)
+                short_name_indices.append(i)
 
-        allnames = np.delete(allnames, index, 0)
+        allnames = np.delete(allnames, short_name_indices, 0)
 
         eventNew = np.array(list(event))
 
-        row = self._ismember(data["name"], event)
+        name_matches = self._ismember(header_df["name"], event)
 
-        if sum(row) == 0:
+        if sum(name_matches) == 0:
             available = sorted(str(name) for name in allnames)
             message = (
                 f"Requested TDT store name '{event}' not found in tank "
@@ -148,10 +148,10 @@ class TdtRecordingExtractor(BaseRecordingExtractor):
             logger.error(message)
             raise ValueError(message)
 
-        allIndexesWhereEventIsPresent = np.where(row == 1)
+        allIndexesWhereEventIsPresent = np.where(name_matches == 1)
         first_row = allIndexesWhereEventIsPresent[0][0]
 
-        formatNew = data["format"][first_row] + 1
+        formatNew = header_df["format"][first_row] + 1
 
         table = np.array(
             [
@@ -166,26 +166,26 @@ class TdtRecordingExtractor(BaseRecordingExtractor):
         event_dict = dict()
 
         event_dict["storename"] = str(event)
-        event_dict["sampling_rate"] = data["frequency"][first_row]
-        event_dict["timestamps"] = np.asarray(data["timestamp"][allIndexesWhereEventIsPresent[0]])
-        event_dict["channels"] = np.asarray(data["chan"][allIndexesWhereEventIsPresent[0]])
+        event_dict["sampling_rate"] = header_df["frequency"][first_row]
+        event_dict["timestamps"] = np.asarray(header_df["timestamp"][allIndexesWhereEventIsPresent[0]])
+        event_dict["channels"] = np.asarray(header_df["chan"][allIndexesWhereEventIsPresent[0]])
 
-        fp_loc = np.asarray(data["fp_loc"][allIndexesWhereEventIsPresent[0]])
-        data_size = np.asarray(data["size"])
+        fp_loc = np.asarray(header_df["fp_loc"][allIndexesWhereEventIsPresent[0]])
+        data_size = np.asarray(header_df["size"])
 
         if formatNew != 5:
             nsample = (data_size[first_row,] - 10) * int(table[formatNew, 2])
             event_dict["data"] = np.zeros((len(fp_loc), nsample))
             for i in range(0, len(fp_loc)):
-                with open(tevfilepath, "rb") as fp:
-                    fp.seek(fp_loc[i], os.SEEK_SET)
-                    event_dict["data"][i, :] = np.fromfile(fp, dtype=table[formatNew, 3], count=nsample).reshape(
+                with open(tevfilepath, "rb") as tev_file:
+                    tev_file.seek(fp_loc[i], os.SEEK_SET)
+                    event_dict["data"][i, :] = np.fromfile(tev_file, dtype=table[formatNew, 3], count=nsample).reshape(
                         1, nsample, order="F"
                     )
                     # event_dict['data'] = event_dict['data'].swapaxes()
             event_dict["npoints"] = nsample
         else:
-            event_dict["data"] = np.asarray(data["strobe"][allIndexesWhereEventIsPresent[0]])
+            event_dict["data"] = np.asarray(header_df["strobe"][allIndexesWhereEventIsPresent[0]])
             event_dict["npoints"] = 1
             event_dict["channels"] = np.tile(1, (event_dict["data"].shape[0],))
 
@@ -199,29 +199,29 @@ class TdtRecordingExtractor(BaseRecordingExtractor):
         Split sub-events are counted from the parent epoc store's header rows whose
         strobe value matches.
         """
-        data = self._header_df
-        names = np.asarray(data["name"], dtype=str)
+        header_df = self._header_df
+        names = np.asarray(header_df["name"], dtype=str)
 
         split_lookup = {
             split_name: (parent, value)
-            for parent, entries in self._compute_split_map(data).items()
+            for parent, entries in self._compute_split_map(header_df).items()
             for split_name, value in entries
         }
         if event in split_lookup:
             parent, value = split_lookup[event]
-            parent_strobes = np.asarray(data["strobe"])[np.where(names == parent)[0]]
+            parent_strobes = np.asarray(header_df["strobe"])[np.where(names == parent)[0]]
             return int(np.count_nonzero(parent_strobes == value))
 
-        row = self._ismember(names, event)
-        if sum(row) == 0:
+        name_matches = self._ismember(names, event)
+        if sum(name_matches) == 0:
             return 0
-        indexes = np.where(row == 1)[0]
+        indexes = np.where(name_matches == 1)[0]
         first_row = indexes[0]
-        format_new = data["format"][first_row] + 1
+        format_new = header_df["format"][first_row] + 1
         if format_new == 5:
             return int(len(indexes))
         bytes_per_sample_table = {1: 1, 2: 1, 3: 2, 4: 4}
-        nsample = int((data["size"][first_row] - 10) * bytes_per_sample_table[int(format_new)])
+        nsample = int((header_df["size"][first_row] - 10) * bytes_per_sample_table[int(format_new)])
         return int(nsample * len(indexes))
 
     def read(self, *, events: list[str], outputPath: str) -> list[dict[str, Any]]:
@@ -265,11 +265,11 @@ class TdtRecordingExtractor(BaseRecordingExtractor):
                 if parent not in parent_cache:
                     parent_cache[parent] = self._readtev(event=parent)
                 parent_dict = parent_cache[parent]
-                idx = np.where(parent_dict["data"] == value)[0]
+                matching_indices = np.where(parent_dict["data"] == value)[0]
                 output_dicts.append(
                     {
                         "storename": event,
-                        "timestamps": parent_dict["timestamps"][idx],
+                        "timestamps": parent_dict["timestamps"][matching_indices],
                         "sampling_rate": parent_dict["sampling_rate"],
                         "data": parent_dict["data"],
                         "npoints": parent_dict["npoints"],
@@ -281,9 +281,9 @@ class TdtRecordingExtractor(BaseRecordingExtractor):
         return output_dicts
 
     @staticmethod
-    def _ismember(arr: np.ndarray, element: str) -> np.ndarray:
-        res = [1 if i == element else 0 for i in arr]
-        return np.asarray(res)
+    def _ismember(values: np.ndarray, element: str) -> np.ndarray:
+        membership_flags = [1 if value == element else 0 for value in values]
+        return np.asarray(membership_flags)
 
     @staticmethod
     def _format_split_suffix(value: float) -> str:
@@ -342,13 +342,15 @@ class TdtRecordingExtractor(BaseRecordingExtractor):
             # meaningful strobe values (other stores reuse those bytes as a file pointer).
             if formats[first_row] + 1 != 5:
                 continue
-            data = strobes[indexes]
-            if not cls._event_needs_splitting(data=data, sampling_rate=frequencies[first_row]):
+            strobe_values = strobes[indexes]
+            if not cls._event_needs_splitting(data=strobe_values, sampling_rate=frequencies[first_row]):
                 continue
             # Mirror the historical sub-event naming: strip "/" from the store name
             # and append the formatted marker value (e.g. "PAB/" + 16 -> "PAB16").
             new_store = store.replace("/", "")
-            split_map[store] = [(new_store + cls._format_split_suffix(value), value) for value in np.unique(data)]
+            split_map[store] = [
+                (new_store + cls._format_split_suffix(value), value) for value in np.unique(strobe_values)
+            ]
         return split_map
 
     def _save_dict_to_hdf5(self, event_dict: dict[str, object], outputPath: str) -> None:

--- a/src/guppy/frontend/input_parameters.py
+++ b/src/guppy/frontend/input_parameters.py
@@ -17,12 +17,12 @@ from ..utils.validation import (
 logger = logging.getLogger(__name__)
 
 
-def checkSameLocation(arr: list[str], abspath: object) -> str:
-    """Check that all paths in ``arr`` share the same parent directory.
+def checkSameLocation(paths: list[str], abspath: object) -> str:
+    """Check that all ``paths`` share the same parent directory.
 
     Parameters
     ----------
-    arr : sequence of str
+    paths : sequence of str
         Paths to validate.
     abspath : object
         Ignored; retained for backwards-compatibility with existing callers.
@@ -30,12 +30,12 @@ def checkSameLocation(arr: list[str], abspath: object) -> str:
     Returns
     -------
     str
-        The common parent directory of all paths in ``arr``.
+        The common parent directory of all ``paths``.
     """
     # abspath retained as a positional arg for backwards compatibility with existing
-    # callers; only the contents of arr are inspected.
+    # callers; only the contents of paths are inspected.
     del abspath
-    return validate_same_parent_directory(paths=list(arr))
+    return validate_same_parent_directory(paths=list(paths))
 
 
 def getAbsPath(files_1: pn.widgets.FileSelector, files_2: pn.widgets.FileSelector) -> str:
@@ -451,7 +451,7 @@ class ParameterForm:
           starting directory set to the first session so the user lands on one session's
           outputs and can navigate up to switch between sessions.
         """
-        sessions = [s for s in (event.new or []) if os.path.isdir(s)]
+        sessions = [session for session in (event.new or []) if os.path.isdir(session)]
         if not sessions:
             root_target = default_root_path()
             directory_target = default_root_path()
@@ -767,8 +767,8 @@ class ParameterForm:
         for output_dir in event.new or []:
             json_path = os.path.join(output_dir, "GuPPyParamtersUsed.json")
             if os.path.exists(json_path):
-                with open(json_path) as f:
-                    saved.append(json.load(f))
+                with open(json_path) as parameters_file:
+                    saved.append(json.load(parameters_file))
         if not saved:
             return
 

--- a/src/guppy/frontend/parameterized_plotter.py
+++ b/src/guppy/frontend/parameterized_plotter.py
@@ -29,7 +29,7 @@ logging.getLogger("bokeh.io.export").setLevel(logging.ERROR)
 
 
 # remove unnecessary column names
-def remove_cols(cols: list[str]) -> list[str]:
+def remove_cols(columns: list[str]) -> list[str]:
     """Remove bookkeeping columns from a PSTH column list.
 
     Drops ``"err"``, ``"timestamps"``, and any column matching ``bin_err_*``
@@ -37,7 +37,7 @@ def remove_cols(cols: list[str]) -> list[str]:
 
     Parameters
     ----------
-    cols : list of str
+    columns : list of str
         Full list of column names from a PSTH DataFrame.
 
     Returns
@@ -46,14 +46,14 @@ def remove_cols(cols: list[str]) -> list[str]:
         Filtered column list with bookkeeping columns removed.
     """
     regex = re.compile("bin_err_*")
-    remove_cols = [cols[i] for i in range(len(cols)) if regex.match(cols[i])]
-    remove_cols = remove_cols + ["err", "timestamps"]
-    cols = [i for i in cols if i not in remove_cols]
+    columns_to_remove = [columns[i] for i in range(len(columns)) if regex.match(columns[i])]
+    columns_to_remove = columns_to_remove + ["err", "timestamps"]
+    columns = [column for column in columns if column not in columns_to_remove]
 
-    return cols
+    return columns
 
 
-def overview_y_options(cols: list[str]) -> list[str]:
+def overview_y_options(columns: list[str]) -> list[str]:
     """Whole-event y-selector options for the single-event overview plot.
 
     Filters :func:`remove_cols` output down to the whole-event views — ``"mean"``,
@@ -62,7 +62,7 @@ def overview_y_options(cols: list[str]) -> list[str]:
 
     Parameters
     ----------
-    cols : list of str
+    columns : list of str
         Full list of column names from a PSTH DataFrame (including ``"All"``).
 
     Returns
@@ -71,7 +71,7 @@ def overview_y_options(cols: list[str]) -> list[str]:
         Options containing only ``"mean"``, ``"All"``, and bin averages.
     """
     bin_pattern = re.compile("bin_")
-    return [col for col in remove_cols(cols) if col in ("mean", "All") or bin_pattern.match(col)]
+    return [column for column in remove_cols(columns) if column in ("mean", "All") or bin_pattern.match(column)]
 
 
 # make a new directory for saving plots
@@ -88,11 +88,11 @@ def make_dir(filepath: str) -> str:
     str
         Absolute path to the ``saved_plots`` directory.
     """
-    op = os.path.join(filepath, "saved_plots")
-    if not os.path.exists(op):
-        os.mkdir(op)
+    output_dir = os.path.join(filepath, "saved_plots")
+    if not os.path.exists(output_dir):
+        os.mkdir(output_dir)
 
-    return op
+    return output_dir
 
 
 def _headless_chrome_options() -> Options:  # pragma: no cover - configures a real browser subprocess
@@ -246,9 +246,9 @@ class ParameterizedPlotter(param.Parameterized):
     @staticmethod
     def _assign_range(axis_range: object, bounds: tuple) -> None:
         """Set a Bokeh range's ``start``/``end`` only when they actually differ."""
-        low, high = float(bounds[0]), float(bounds[1])
-        if (axis_range.start, axis_range.end) != (low, high):
-            axis_range.start, axis_range.end = low, high
+        range_start, range_end = float(bounds[0]), float(bounds[1])
+        if (axis_range.start, axis_range.end) != (range_start, range_end):
+            axis_range.start, axis_range.end = range_start, range_end
 
     def move_figure_to_range(self, name: str) -> None:
         """Move a plot's live Bokeh figure to match its current range params.
@@ -315,7 +315,7 @@ class ParameterizedPlotter(param.Parameterized):
             figure = plot.state
             self._figures[plot_key] = figure
 
-            def sync(attr: str, old: object, new: object) -> None:
+            def sync(attribute_name: str, old_value: object, new_value: object) -> None:
                 x_range = (figure.x_range.start, figure.x_range.end)
                 if None not in x_range and getattr(self, x_name) != x_range:
                     setattr(self, x_name, (float(x_range[0]), float(x_range[1])))
@@ -331,19 +331,19 @@ class ParameterizedPlotter(param.Parameterized):
 
         return hook
 
-    def _hide_minor_ticks_hook(self, attr: str) -> Callable[[object, object], None]:
+    def _hide_minor_ticks_hook(self, param_name: str) -> Callable[[object, object], None]:
         """Build a HoloViews ``hooks`` callback that hides the Bokeh axis minor ticks.
 
         Attached to a plot via ``.opts(hooks=[...])``, the returned hook removes the
         small tick marks between the axis numbers on both axes when the boolean param
-        named ``attr`` is set. When it is not set the freshly rendered figure keeps
+        named ``param_name`` is set. When it is not set the freshly rendered figure keeps
         Bokeh's default minor ticks, so no restore step is needed. The param name is a
         factory argument so the PSTH plots and the heatmap can each drive their own
         independent toggle (``hide_minor_ticks`` vs ``hide_minor_ticks_heatmap``).
         """
 
         def hook(plot: object, element: object) -> None:
-            if not getattr(self, attr):
+            if not getattr(self, param_name):
                 return
             figure = plot.state
             figure.xaxis.minor_tick_line_color = None
@@ -351,17 +351,17 @@ class ParameterizedPlotter(param.Parameterized):
 
         return hook
 
-    def _ticks_inside_hook(self, attr: str) -> Callable[[object, object], None]:
+    def _ticks_inside_hook(self, param_name: str) -> Callable[[object, object], None]:
         """Build a HoloViews ``hooks`` callback that points the axis ticks inward.
 
         Attached to a plot via ``.opts(hooks=[...])``, the returned hook flips both
         axes' major and minor ticks to point into the plot area when the boolean
-        param named ``attr`` is set. When it is not set the freshly rendered figure
+        param named ``param_name`` is set. When it is not set the freshly rendered figure
         keeps Bokeh's default outward ticks, so no restore step is needed.
         """
 
         def hook(plot: object, element: object) -> None:
-            if not getattr(self, attr):
+            if not getattr(self, param_name):
                 return
             figure = plot.state
             for axis in (figure.xaxis, figure.yaxis):
@@ -370,11 +370,11 @@ class ParameterizedPlotter(param.Parameterized):
 
         return hook
 
-    def _hide_outer_border_hook(self, attr: str) -> Callable[[object, object], None]:
+    def _hide_outer_border_hook(self, param_name: str) -> Callable[[object, object], None]:
         """Build a HoloViews ``hooks`` callback that removes the top/right frame lines.
 
         Attached to a plot via ``.opts(hooks=[...])``, the returned hook drops the
-        figure's four-sided outline when the boolean param named ``attr`` is set. The
+        figure's four-sided outline when the boolean param named ``param_name`` is set. The
         bottom (x) and left (y) axis lines are drawn separately by Bokeh and remain,
         so only the top and right edges disappear, leaving an open L-shaped frame.
         When the param is not set the freshly rendered figure keeps its full outline,
@@ -382,7 +382,7 @@ class ParameterizedPlotter(param.Parameterized):
         """
 
         def hook(plot: object, element: object) -> None:
-            if not getattr(self, attr):
+            if not getattr(self, param_name):
                 return
             plot.state.outline_line_color = None
 
@@ -509,17 +509,17 @@ class ParameterizedPlotter(param.Parameterized):
 
     @param.depends("event_selector_heatmap", watch=True)
     def _update_df(self) -> None:
-        cols = self.columns_dict[self.event_selector_heatmap]
-        trial_no = range(1, len(remove_cols(cols)[:-2]) + 1)
-        trial_ts = ["{} - {}".format(i, j) for i, j in zip(trial_no, remove_cols(cols)[:-2])] + ["All"]
+        columns = self.columns_dict[self.event_selector_heatmap]
+        trial_no = range(1, len(remove_cols(columns)[:-2]) + 1)
+        trial_ts = ["{} - {}".format(i, j) for i, j in zip(trial_no, remove_cols(columns)[:-2])] + ["All"]
         self.param["heatmap_y"].objects = trial_ts
         self.heatmap_y = [trial_ts[-1]]
 
     @param.depends("event_selector", watch=True)
     def _update_psth_y(self) -> None:
-        cols = self.columns_dict[self.event_selector]
-        trial_no = range(1, len(remove_cols(cols)[:-2]) + 1)
-        trial_ts = ["{} - {}".format(i, j) for i, j in zip(trial_no, remove_cols(cols)[:-2])]
+        columns = self.columns_dict[self.event_selector]
+        trial_no = range(1, len(remove_cols(columns)[:-2]) + 1)
+        trial_ts = ["{} - {}".format(i, j) for i, j in zip(trial_no, remove_cols(columns)[:-2])]
         self.param["psth_y"].objects = trial_ts
         self.psth_y = [trial_ts[0]]
 
@@ -563,69 +563,74 @@ class ParameterizedPlotter(param.Parameterized):
             Overlay of mean curves with spread bands, or ``None`` when no
             events are selected.
         """
-        data_curve, cols_curve, data_spread, cols_spread = [], [], [], []
-        arr = self.selector_for_multipe_events_plot
-        df1 = self.df_new
-        for i in range(len(arr)):
-            if "bin" in arr[i]:
-                split = arr[i].rsplit("_", 2)
+        data_curve, columns_curve, data_spread, columns_spread = [], [], [], []
+        selected_events = self.selector_for_multipe_events_plot
+        event_dataframes = self.df_new
+        for i in range(len(selected_events)):
+            if "bin" in selected_events[i]:
+                split = selected_events[i].rsplit("_", 2)
                 df_name = split[0]  #'{}_{}'.format(split[0], split[1])
                 col_name_mean = "{}_{}".format(split[-2], split[-1])
                 col_name_err = "{}_err_{}".format(split[-2], split[-1])
-                data_curve.append(df1[df_name][col_name_mean])
-                cols_curve.append(arr[i])
-                data_spread.append(df1[df_name][col_name_err])
-                cols_spread.append(arr[i])
+                data_curve.append(event_dataframes[df_name][col_name_mean])
+                columns_curve.append(selected_events[i])
+                data_spread.append(event_dataframes[df_name][col_name_err])
+                columns_spread.append(selected_events[i])
             else:
-                data_curve.append(df1[arr[i]]["mean"])
-                cols_curve.append(arr[i] + "_" + "mean")
-                data_spread.append(df1[arr[i]]["err"])
-                cols_spread.append(arr[i] + "_" + "mean")
+                data_curve.append(event_dataframes[selected_events[i]]["mean"])
+                columns_curve.append(selected_events[i] + "_" + "mean")
+                data_spread.append(event_dataframes[selected_events[i]]["err"])
+                columns_spread.append(selected_events[i] + "_" + "mean")
 
-        if len(arr) > 0:
-            self._reset_y_on_selection_change("overlay", "overlay_Y", tuple(arr))
+        if len(selected_events) > 0:
+            self._reset_y_on_selection_change("overlay", "overlay_Y", tuple(selected_events))
             if self.overlay_Y is None:
                 self.overlay_Y = (np.nanmin(np.asarray(data_curve)) - 0.5, np.nanmax(np.asarray(data_curve)) + 0.5)
 
-            if "bin" in arr[i]:
-                split = arr[i].rsplit("_", 2)
+            if "bin" in selected_events[i]:
+                split = selected_events[i].rsplit("_", 2)
                 df_name = split[0]
-                data_curve.append(df1[df_name]["timestamps"])
-                cols_curve.append("timestamps")
-                data_spread.append(df1[df_name]["timestamps"])
-                cols_spread.append("timestamps")
+                data_curve.append(event_dataframes[df_name]["timestamps"])
+                columns_curve.append("timestamps")
+                data_spread.append(event_dataframes[df_name]["timestamps"])
+                columns_spread.append("timestamps")
             else:
-                data_curve.append(df1[arr[i]]["timestamps"])
-                cols_curve.append("timestamps")
-                data_spread.append(df1[arr[i]]["timestamps"])
-                cols_spread.append("timestamps")
+                data_curve.append(event_dataframes[selected_events[i]]["timestamps"])
+                columns_curve.append("timestamps")
+                data_spread.append(event_dataframes[selected_events[i]]["timestamps"])
+                columns_spread.append("timestamps")
             df_curve = pd.concat(data_curve, axis=1)
             df_spread = pd.concat(data_spread, axis=1)
-            df_curve.columns = cols_curve
-            df_spread.columns = cols_spread
+            df_curve.columns = columns_curve
+            df_spread.columns = columns_spread
 
-            ts = df_curve["timestamps"]
-            index = np.arange(0, ts.shape[0], 3)
+            timestamps = df_curve["timestamps"]
+            index = np.arange(0, timestamps.shape[0], 3)
             df_curve = df_curve.loc[index, :]
             df_spread = df_spread.loc[index, :]
             overlay = hv.NdOverlay(
                 {
-                    c: hv.Curve((df_curve["timestamps"], df_curve[c]), kdims=["Time (s)"]).opts(
+                    curve_column: hv.Curve((df_curve["timestamps"], df_curve[curve_column]), kdims=["Time (s)"]).opts(
                         width=int(self.Width_Plot),
                         height=int(self.Height_Plot),
                         xlim=self.overlay_X,
                         ylim=self.overlay_Y,
                     )
-                    for c in cols_curve[:-1]
+                    for curve_column in columns_curve[:-1]
                 }
             )
             spread = hv.NdOverlay(
                 {
-                    d: hv.Spread(
-                        (df_spread["timestamps"], df_curve[d], df_spread[d], df_spread[d]),
+                    spread_column: hv.Spread(
+                        (
+                            df_spread["timestamps"],
+                            df_curve[spread_column],
+                            df_spread[spread_column],
+                            df_spread[spread_column],
+                        ),
                         vdims=["y", "yerrpos", "yerrneg"],
                     ).opts(line_width=0, fill_alpha=0.3)
-                    for d in cols_spread[:-1]
+                    for spread_column in columns_spread[:-1]
                 }
             )
             # Colour each event's curve (and its matching spread) from its effective
@@ -633,15 +638,15 @@ class ParameterizedPlotter(param.Parameterized):
             # are built in the same selection order, so a positional cycle over this
             # list assigns consistent per-event colours.
             effective_colors = self.overlay_effective_colors()
-            palette_colors = hv.Cycle([effective_colors[event] for event in arr])
+            palette_colors = hv.Cycle([effective_colors[event] for event in selected_events])
             plot_combine = (
                 (overlay * spread)
                 .opts(opts.NdOverlay(xlabel="Time (s)", ylabel=self.Y_Label))
                 .opts(opts.Curve(color=palette_colors), opts.Spread(fill_color=palette_colors))
                 .opts(shared_axes=False)
             )
-            op = make_dir(self.filepath)
-            op_filename = os.path.join(op, str(arr) + "_mean")
+            output_dir = make_dir(self.filepath)
+            output_filename = os.path.join(output_dir, str(selected_events) + "_mean")
 
             plot_combine = plot_combine.opts(
                 hooks=[
@@ -650,7 +655,7 @@ class ParameterizedPlotter(param.Parameterized):
                 ]
             )
             self.results_psth["plot_combine"] = plot_combine
-            self.results_psth["op_combine"] = op_filename
+            self.results_psth["op_combine"] = output_filename
             return plot_combine
 
     # function to plot mean PSTH, single trial in PSTH and all the trials of PSTH with mean
@@ -673,23 +678,32 @@ class ParameterizedPlotter(param.Parameterized):
             A ``Curve``, ``Spread``-overlaid ``Curve``, or datashaded
             ``NdOverlay``, depending on the value of ``y``.
         """
-        df1 = self.df_new[self.event_selector]
+        event_dataframe = self.df_new[self.event_selector]
         self._reset_y_on_selection_change("cont", "cont_Y", (self.event_selector, self.y))
         if self.y == "All":
             if self.cont_Y is None:
-                self.cont_Y = (np.nanmin(np.asarray(df1)) - 0.5, np.nanmax(np.asarray(df1)) - 0.5)
+                self.cont_Y = (
+                    np.nanmin(np.asarray(event_dataframe)) - 0.5,
+                    np.nanmax(np.asarray(event_dataframe)) - 0.5,
+                )
 
             # Individual trial columns come from the data (the y-selector lists only
             # overview views), i.e. everything left after dropping bins and the mean.
             bin_regex = re.compile("bin_")
-            trial_cols = [c for c in remove_cols(list(df1.columns)) if c != "mean" and not bin_regex.match(c)]
+            trial_columns = [
+                column
+                for column in remove_cols(list(event_dataframe.columns))
+                if column != "mean" and not bin_regex.match(column)
+            ]
 
-            ndoverlay = hv.NdOverlay({c: hv.Curve((df1[self.x], df1[c])) for c in trial_cols})
-            img1 = datashade(ndoverlay, normalization="linear", aggregator=ds.count())
-            x_points = df1[self.x]
-            y_points = df1["mean"]
-            img2 = hv.Curve((x_points, y_points))
-            img = (img1 * img2).opts(
+            ndoverlay = hv.NdOverlay(
+                {column: hv.Curve((event_dataframe[self.x], event_dataframe[column])) for column in trial_columns}
+            )
+            trials_image = datashade(ndoverlay, normalization="linear", aggregator=ds.count())
+            x_points = event_dataframe[self.x]
+            y_points = event_dataframe["mean"]
+            mean_curve = hv.Curve((x_points, y_points))
+            image = (trials_image * mean_curve).opts(
                 opts.Curve(
                     width=int(self.Width_Plot),
                     height=int(self.Height_Plot),
@@ -702,28 +716,28 @@ class ParameterizedPlotter(param.Parameterized):
                 )
             )
 
-            img = img.opts(
+            image = image.opts(
                 hooks=[
                     self._range_sync_hook("cont", "cont_X", "cont_Y"),
                     self._hide_minor_ticks_hook("hide_minor_ticks"),
                 ]
             )
-            op = make_dir(self.filepath)
-            op_filename = os.path.join(op, self.event_selector + "_" + self.y)
-            self.results_psth["plot"] = img
-            self.results_psth["op"] = op_filename
+            output_dir = make_dir(self.filepath)
+            output_filename = os.path.join(output_dir, self.event_selector + "_" + self.y)
+            self.results_psth["plot"] = image
+            self.results_psth["op"] = output_filename
 
-            return img
+            return image
 
         elif self.y == "mean" or "bin" in self.y:
 
-            xpoints = df1[self.x]
-            ypoints = df1[self.y]
+            xpoints = event_dataframe[self.x]
+            ypoints = event_dataframe[self.y]
             if self.y == "mean":
-                err = df1["err"]
+                standard_error = event_dataframe["err"]
             else:
                 split = self.y.split("_")
-                err = df1["{}_err_{}".format(split[0], split[1])]
+                standard_error = event_dataframe["{}_err_{}".format(split[0], split[1])]
 
             index = np.arange(0, xpoints.shape[0], 3)
 
@@ -748,7 +762,7 @@ class ParameterizedPlotter(param.Parameterized):
             )
 
             plot_curve = hv.Curve((xpoints[index], ypoints[index]))
-            plot_spread = hv.Spread((xpoints[index], ypoints[index], err[index], err[index]))
+            plot_spread = hv.Spread((xpoints[index], ypoints[index], standard_error[index], standard_error[index]))
             plot = (plot_curve * plot_spread).opts({"Curve": ropts_curve, "Spread": ropts_spread})
             plot = plot.opts(
                 hooks=[
@@ -756,16 +770,16 @@ class ParameterizedPlotter(param.Parameterized):
                     self._hide_minor_ticks_hook("hide_minor_ticks"),
                 ]
             )
-            op = make_dir(self.filepath)
-            op_filename = os.path.join(op, self.event_selector + "_" + self.y)
+            output_dir = make_dir(self.filepath)
+            output_filename = os.path.join(output_dir, self.event_selector + "_" + self.y)
             self.results_psth["plot"] = plot
-            self.results_psth["op"] = op_filename
+            self.results_psth["op"] = output_filename
 
             return plot
 
         else:
-            xpoints = df1[self.x]
-            ypoints = df1[self.y]
+            xpoints = event_dataframe[self.x]
+            ypoints = event_dataframe[self.y]
             if self.cont_Y is None:
                 self.cont_Y = (np.nanmin(ypoints) - 0.5, np.nanmax(ypoints) + 0.5)
 
@@ -785,10 +799,10 @@ class ParameterizedPlotter(param.Parameterized):
                     self._hide_minor_ticks_hook("hide_minor_ticks"),
                 ]
             )
-            op = make_dir(self.filepath)
-            op_filename = os.path.join(op, self.event_selector + "_" + self.y)
+            output_dir = make_dir(self.filepath)
+            output_filename = os.path.join(output_dir, self.event_selector + "_" + self.y)
             self.results_psth["plot"] = plot
-            self.results_psth["op"] = op_filename
+            self.results_psth["op"] = output_filename
 
             return plot
 
@@ -819,15 +833,15 @@ class ParameterizedPlotter(param.Parameterized):
 
         if not self.psth_y:
             return None
-        selected_trials = [s.split(" - ")[1] for s in list(self.psth_y)]
+        selected_trials = [trial_label.split(" - ")[1] for trial_label in list(self.psth_y)]
 
         # Refit the y-axis whenever the event / trial selection / display mode changes.
         self._reset_y_on_selection_change(
             "trials", "trials_Y", (self.event_selector, tuple(self.psth_y), tuple(self.select_trials_checkbox))
         )
         if self.trials_Y is None:
-            selected = np.asarray(df_psth[selected_trials])
-            self.trials_Y = (np.nanmin(selected) - 0.5, np.nanmax(selected) + 0.5)
+            selected_trial_data = np.asarray(df_psth[selected_trials])
+            self.trials_Y = (np.nanmin(selected_trial_data) - 0.5, np.nanmax(selected_trial_data) + 0.5)
 
         timestamps = df_psth["timestamps"]
         index = np.arange(0, timestamps.shape[0], 3)
@@ -848,13 +862,16 @@ class ParameterizedPlotter(param.Parameterized):
         layers = []
         if show_trials:
             overlay = hv.NdOverlay(
-                {c: hv.Curve((timestamps[index], df_psth[c][index]), kdims=["Time (s)"]) for c in selected_trials}
+                {
+                    trial: hv.Curve((timestamps[index], df_psth[trial][index]), kdims=["Time (s)"])
+                    for trial in selected_trials
+                }
             )
             layers.append(overlay.opts(**axis_opts))
         if show_mean:
-            arr = np.asarray(df_psth[selected_trials])
-            mean = np.nanmean(arr, axis=1)
-            err = np.nanstd(arr, axis=1) / math.sqrt(arr.shape[1])
+            trial_values = np.asarray(df_psth[selected_trials])
+            mean = np.nanmean(trial_values, axis=1)
+            standard_error = np.nanstd(trial_values, axis=1) / math.sqrt(trial_values.shape[1])
             # Contrast the mean against the trials when both are shown; otherwise use the trace colour.
             mean_curve_color = self.mean_color if show_trials else self.trace_color
             ropts_curve = dict(color=mean_curve_color, **axis_opts)
@@ -866,7 +883,7 @@ class ParameterizedPlotter(param.Parameterized):
                 line_width=0,
             )
             plot_curve = hv.Curve((timestamps[index], mean[index]))
-            plot_spread = hv.Spread((timestamps[index], mean[index], err[index], err[index]))
+            plot_spread = hv.Spread((timestamps[index], mean[index], standard_error[index], standard_error[index]))
             layers.append((plot_curve * plot_spread).opts({"Curve": ropts_curve, "Spread": ropts_spread}))
 
         result = layers[0]
@@ -879,10 +896,10 @@ class ParameterizedPlotter(param.Parameterized):
             ]
         )
 
-        op = make_dir(self.filepath)
-        op_filename = os.path.join(op, self.event_selector + "_selected_trials")
+        output_dir = make_dir(self.filepath)
+        output_filename = os.path.join(output_dir, self.event_selector + "_selected_trials")
         self.results_psth["trials"] = result
-        self.results_psth["op_trials"] = op_filename
+        self.results_psth["op_trials"] = output_filename
         return result
 
     # function to show heatmaps for each event
@@ -916,26 +933,26 @@ class ParameterizedPlotter(param.Parameterized):
         height = self.height_heatmap
         width = self.width_heatmap
         df_hm = self.df_new[self.event_selector_heatmap]
-        cols = list(df_hm.columns)
+        columns = list(df_hm.columns)
         regex = re.compile("bin_err_*")
-        drop_cols = [cols[i] for i in range(len(cols)) if regex.match(cols[i])]
-        drop_cols = ["err", "mean"] + drop_cols
-        df_hm = df_hm.drop(drop_cols, axis=1)
-        cols = list(df_hm.columns)
-        bin_cols = [cols[i] for i in range(len(cols)) if re.compile("bin_*").match(cols[i])]
+        columns_to_drop = [columns[i] for i in range(len(columns)) if regex.match(columns[i])]
+        columns_to_drop = ["err", "mean"] + columns_to_drop
+        df_hm = df_hm.drop(columns_to_drop, axis=1)
+        columns = list(df_hm.columns)
+        bin_columns = [columns[i] for i in range(len(columns)) if re.compile("bin_*").match(columns[i])]
         time = np.asarray(df_hm["timestamps"])
         event_ts_for_each_event = np.arange(1, len(df_hm.columns[:-1]) + 1)
         yticks = list(event_ts_for_each_event)
         z_score = np.asarray(df_hm[df_hm.columns[:-1]]).T
 
         if self.heatmap_y[0] == "All":
-            indices = np.arange(z_score.shape[0] - len(bin_cols))
+            indices = np.arange(z_score.shape[0] - len(bin_columns))
             z_score = z_score[indices, :]
             event_ts_for_each_event = np.arange(1, z_score.shape[0] + 1)
             yticks = list(event_ts_for_each_event)
         else:
             remove_all = list(set(self.heatmap_y) - set(["All"]))
-            indices = sorted([int(s.split("-")[0]) - 1 for s in remove_all])
+            indices = sorted([int(trial_label.split("-")[0]) - 1 for trial_label in remove_all])
             z_score = z_score[indices, :]
             event_ts_for_each_event = np.arange(1, z_score.shape[0] + 1)
             yticks = list(event_ts_for_each_event)
@@ -986,13 +1003,13 @@ class ParameterizedPlotter(param.Parameterized):
         # the legend actually matches the pixels. Without clims/cnorm here, datashade
         # auto-normalizes the data to its own min/max (and eq-hist), so the colour-scale
         # boxes would move only the colorbar and never recolour the data.
-        dynspread_img = datashade(
+        dynspread_image = datashade(
             actual_image,
             cmap=process_cmap(self.color_map, provider="matplotlib"),
             cnorm="linear",
             clims=clim,
         ).opts(**ropts)
-        image = ((dummy_image * dynspread_img).opts(opts.QuadMesh(width=int(width), height=int(height)))).opts(
+        image = ((dummy_image * dynspread_image).opts(opts.QuadMesh(width=int(width), height=int(height)))).opts(
             shared_axes=False
         )
         image = image.opts(
@@ -1004,9 +1021,9 @@ class ParameterizedPlotter(param.Parameterized):
             ]
         )
 
-        op = make_dir(self.filepath)
-        op_filename = os.path.join(op, self.event_selector_heatmap + "_" + "heatmap")
+        output_dir = make_dir(self.filepath)
+        output_filename = os.path.join(output_dir, self.event_selector_heatmap + "_" + "heatmap")
         self.results_hm["plot"] = image
-        self.results_hm["op"] = op_filename
+        self.results_hm["op"] = output_filename
 
         return image

--- a/src/guppy/frontend/progress.py
+++ b/src/guppy/frontend/progress.py
@@ -67,8 +67,8 @@ def readPBIncrementValues(
                         progressBar.bar_color = "danger"
                         os.remove(file_path)
                         if os.path.exists(error_file_path):
-                            with open(error_file_path, "r") as ef:
-                                error_message = ef.read().strip()
+                            with open(error_file_path, "r") as error_file:
+                                error_message = error_file.read().strip()
                             os.remove(error_file_path)
                         break
                     progressBar.max = maximum

--- a/src/guppy/frontend/storenames_instructions.py
+++ b/src/guppy/frontend/storenames_instructions.py
@@ -83,11 +83,11 @@ class StorenamesInstructionsNPM(StorenamesInstructions):
 
     def __init__(self, folder_path: str, *, channel_previews: dict[str, dict[str, np.ndarray]]) -> None:
         super().__init__(folder_path=folder_path)
-        self.d = {
+        self.channel_preview_arrays = {
             name: {"x": np.asarray(preview["x"]), "y": np.asarray(preview["y"])}
             for name, preview in channel_previews.items()
         }
-        keys = list(self.d.keys())
+        channel_names = list(self.channel_preview_arrays.keys())
         self.mark_down_np = pn.pane.Markdown(
             """
                                         ### Extra Instructions to follow when using Neurophotometrics data :
@@ -108,7 +108,7 @@ class StorenamesInstructionsNPM(StorenamesInstructions):
                                             """
         )
         self.plot_select = pn.widgets.Select(
-            name="Select channel to see correspondings channels", options=keys, value=keys[0]
+            name="Select channel to see correspondings channels", options=channel_names, value=channel_names[0]
         )
         self.plot_pane = pn.pane.HoloViews(self._make_plot(self.plot_select.value), width=550)
         self.plot_select.param.watch(self._on_plot_select_change, "value")
@@ -122,7 +122,8 @@ class StorenamesInstructionsNPM(StorenamesInstructions):
         )
 
     def _make_plot(self, plot_key: str) -> hv.Curve:
-        return hv.Curve((self.d[plot_key]["x"], self.d[plot_key]["y"])).opts(width=550)
+        preview = self.channel_preview_arrays[plot_key]
+        return hv.Curve((preview["x"], preview["y"])).opts(width=550)
 
     def _on_plot_select_change(self, event: object) -> None:
         self.plot_pane.object = self._make_plot(event.new)

--- a/src/guppy/frontend/storenames_selector.py
+++ b/src/guppy/frontend/storenames_selector.py
@@ -192,7 +192,7 @@ class StorenamesSelector:
             One entry per widget in ``take_widgets`` containing that widget's
             current value.
         """
-        return [w.value for w in self.take_widgets]
+        return [widget.value for widget in self.take_widgets]
 
     def set_change_widgets(self, value: object) -> None:
         """Set all ``change_widgets`` to ``value``.
@@ -202,8 +202,8 @@ class StorenamesSelector:
         value : object
             Value to assign to every widget in the ``change_widgets`` box.
         """
-        for w in self.change_widgets:
-            w.value = value
+        for widget in self.change_widgets:
+            widget.value = value
 
     def get_cross_selector(self) -> list[str]:
         """Return the storenames currently selected in the cross-selector.

--- a/src/guppy/frontend/visualization_dashboard.py
+++ b/src/guppy/frontend/visualization_dashboard.py
@@ -376,5 +376,5 @@ class VisualizationDashboard:
         """Serve the dashboard in a browser on an available port."""
         logger.info("app")
         template = self.build_template()
-        number = scanPortsAndFind(start_port=5000, end_port=5200)
-        template.show(port=number)
+        port = scanPortsAndFind(start_port=5000, end_port=5200)
+        template.show(port=port)

--- a/src/guppy/orchestration/home.py
+++ b/src/guppy/orchestration/home.py
@@ -103,10 +103,10 @@ def build_homepage(*, start_path: str | None = None) -> pn.template.BootstrapTem
             inputParameters["curr_dir"] = current_dir
         thread = Thread(target=worker, args=(inputParameters,))
         thread.start()
-        error_msg = readPBIncrementValues(progress_widget, file_path=PB_STEPS_FILE)
+        error_message = readPBIncrementValues(progress_widget, file_path=PB_STEPS_FILE)
         thread.join()
-        if error_msg:
-            pn.state.notifications.error(error_msg, duration=0)
+        if error_message:
+            pn.state.notifications.error(error_message, duration=0)
 
     def onclickImportCustomEvents(event: object = None) -> None:
         inputParameters = _getInputParametersOrNotify()

--- a/src/guppy/orchestration/preprocess.py
+++ b/src/guppy/orchestration/preprocess.py
@@ -120,7 +120,7 @@ def visualizeControlAndSignal(filepath: str, removeArtifacts: bool) -> list:
 
         ts_path = os.path.join(filepath, "timeCorrection_" + name_1[-1] + ".hdf5")
         cntrl_sig_fit_path = os.path.join(filepath, "cntrl_sig_fit_" + name_1[-1] + ".hdf5")
-        ts = read_hdf5("", ts_path, "timestampNew")
+        timestamps = read_hdf5("", ts_path, "timestampNew")
 
         control = read_hdf5("", path[0, i], "data").reshape(-1)
         signal = read_hdf5("", path[1, i], "data").reshape(-1)
@@ -131,7 +131,7 @@ def visualizeControlAndSignal(filepath: str, removeArtifacts: bool) -> list:
             (os.path.basename(path[1, i])).split(".")[0],
             (os.path.basename(cntrl_sig_fit_path)).split(".")[0],
         ]
-        widget = ArtifactRemovalWidget(filepath, ts, control, signal, cntrl_sig_fit, plot_name, removeArtifacts)
+        widget = ArtifactRemovalWidget(filepath, timestamps, control, signal, cntrl_sig_fit, plot_name, removeArtifacts)
         widgets.append(widget)
     return widgets
 
@@ -250,8 +250,8 @@ def execute_zscore(folderNames: list[str], inputParameters: dict[str, object]) -
         path_2 = find_files(filepath, "signal_*", ignore_case=True)
         path = sorted(path_1 + path_2, key=str.casefold)
         if len(path) % 2 != 0:
-            controls = sorted(p for p in path if "control_" in os.path.basename(p).lower())
-            signals = sorted(p for p in path if "signal_" in os.path.basename(p).lower())
+            controls = sorted(file_path for file_path in path if "control_" in os.path.basename(file_path).lower())
+            signals = sorted(file_path for file_path in path if "signal_" in os.path.basename(file_path).lower())
             message = (
                 f"Unequal number of control and signal files in '{filepath}': "
                 f"found {len(controls)} control and {len(signals)} signal file(s). "
@@ -276,7 +276,7 @@ def execute_zscore(folderNames: list[str], inputParameters: dict[str, object]) -
 
             control, signal, tsNew = read_corrected_data(path[0, i], path[1, i], filepath, name)
             coords = get_coords(filepath, name, tsNew, remove_artifacts)
-            z_score, dff, control_fit, temp_control_arr = compute_z_score(
+            z_score, dff, control_fit, control_array = compute_z_score(
                 control,
                 signal,
                 tsNew,
@@ -289,7 +289,7 @@ def execute_zscore(folderNames: list[str], inputParameters: dict[str, object]) -
                 baseline_end,
                 control_fit_method,
             )
-            write_zscore(filepath, name, z_score, dff, control_fit, temp_control_arr)
+            write_zscore(filepath, name, z_score, dff, control_fit, control_array)
 
         logger.info(f"z-score for the data in {filepath} computed.")
         writeToFile(str(10 + ((inputParameters["step"] + 1) * 10)) + "\n", file_path=PB_STEPS_FILE)
@@ -456,19 +456,19 @@ def execute_combine_data(folderNames: list[str], inputParameters: dict[str, obje
 
     Returns
     -------
-    op : list
+    combined_output_groups : list
         List of ``[output_filepath, ...]`` entries for combined output directories.
     """
     logger.debug("Combining Data from different data files...")
     timeForLightsTurnOn = inputParameters["timeForLightsTurnOn"]
     selected_outputs = inputParameters.get("selectedOutputs") or {}
-    op_folder = []
+    output_folders = []
     for i in range(len(folderNames)):
         filepath = folderNames[i]
-        op_folder.append(select_output_dirs(filepath, selected_outputs.get(filepath)))
+        output_folders.append(select_output_dirs(filepath, selected_outputs.get(filepath)))
 
-    op_folder = list(np.concatenate(op_folder).flatten())
-    sampling_rate_fp = []
+    output_folders = list(np.concatenate(output_folders).flatten())
+    sampling_rate_filepaths = []
     for i in range(len(folderNames)):
         filepath = folderNames[i]
         storesListPath = select_output_dirs(filepath, selected_outputs.get(filepath))
@@ -477,29 +477,29 @@ def execute_combine_data(folderNames: list[str], inputParameters: dict[str, obje
             storesList_new = np.genfromtxt(
                 os.path.join(filepath, "storesList.csv"), dtype="str", delimiter=","
             ).reshape(2, -1)
-            sampling_rate_fp.append(glob.glob(os.path.join(filepath, "timeCorrection_*")))
+            sampling_rate_filepaths.append(glob.glob(os.path.join(filepath, "timeCorrection_*")))
 
     # check if sampling rate is same for both data
-    sampling_rate_fp = np.concatenate(sampling_rate_fp)
+    sampling_rate_filepaths = np.concatenate(sampling_rate_filepaths)
     sampling_rate = []
-    for i in range(sampling_rate_fp.shape[0]):
-        sampling_rate.append(read_hdf5("", sampling_rate_fp[i], "sampling_rate"))
+    for i in range(sampling_rate_filepaths.shape[0]):
+        sampling_rate.append(read_hdf5("", sampling_rate_filepaths[i], "sampling_rate"))
 
-    res = all(i == sampling_rate[0] for i in sampling_rate)
-    if res == False:
+    all_sampling_rates_equal = all(i == sampling_rate[0] for i in sampling_rate)
+    if all_sampling_rates_equal == False:
         rates = [float(np.asarray(rate).reshape(-1)[0]) for rate in sampling_rate]
         message = (
-            f"Cannot combine data: sampling rates differ across files {sampling_rate_fp.tolist()} "
+            f"Cannot combine data: sampling rates differ across files {sampling_rate_filepaths.tolist()} "
             f"(rates={rates}). All files being combined must share the same sampling rate."
         )
         logger.error(message)
         raise ValueError(message)
 
     # get the output folders informatinos
-    op = get_all_stores_for_combining_data(op_folder)
+    combined_output_groups = get_all_stores_for_combining_data(output_folders)
 
     # processing timestamps for combining the data
-    for filepaths_to_combine in op:
+    for filepaths_to_combine in combined_output_groups:
         pair_name_to_filepath_to_timestamps = read_timestamps_for_combining_data(filepaths_to_combine)
         display_name_to_filepath_to_data = read_data_for_combining_data(filepaths_to_combine, storesList)
         compound_name_to_filepath_to_ttl_timestamps = read_ttl_timestamps_for_combining_data(
@@ -518,7 +518,7 @@ def execute_combine_data(folderNames: list[str], inputParameters: dict[str, obje
         write_combined_data(output_filepath, pair_name_to_tsNew, display_name_to_data, compound_name_to_ttl_timestamps)
     logger.info("Data is combined from different data files.")
 
-    return op
+    return combined_output_groups
 
 
 def extractTsAndSignal(inputParameters: dict[str, object]) -> None:
@@ -569,14 +569,14 @@ def extractTsAndSignal(inputParameters: dict[str, object]) -> None:
         writeToFile(str((pbMaxValue) * 10) + "\n" + str(10) + "\n", file_path=PB_STEPS_FILE)
         execute_timestamp_correction(folderNames, inputParameters)
         storesList = check_storeslistfile(folderNames)
-        op_folder = execute_combine_data(folderNames, inputParameters, storesList)
-        write_combined_stores_list(op_folder, storesList)
-        execute_zscore(op_folder, inputParameters)
+        combined_output_folders = execute_combine_data(folderNames, inputParameters, storesList)
+        write_combined_stores_list(combined_output_folders, storesList)
+        execute_zscore(combined_output_folders, inputParameters)
         headless = bool(os.environ.get("GUPPY_BASE_DIR"))
         if not headless:
-            visualize_z_score(inputParameters, op_folder)
+            visualize_z_score(inputParameters, combined_output_folders)
         if remove_artifacts == True:
-            execute_artifact_removal(op_folder, inputParameters)
+            execute_artifact_removal(combined_output_folders, inputParameters)
 
 
 @subprocess_main_handler

--- a/src/guppy/orchestration/psth.py
+++ b/src/guppy/orchestration/psth.py
@@ -90,12 +90,12 @@ def execute_compute_psth(filepath: str, event: str, inputParameters: dict[str, o
             just_use_signal = False
 
         sampling_rate = read_hdf5("timeCorrection_" + name_1, filepath, "sampling_rate")[0]
-        ts = read_hdf5(event + "_" + name_1, filepath, "ts")
+        timestamps = read_hdf5(event + "_" + name_1, filepath, "ts")
         if use_time_or_trials == "Time (min)" and bin_psth_trials > 0:
             corrected_timestamps = read_hdf5("timeCorrection_" + name_1, filepath, "timestampNew")
         else:
             corrected_timestamps = None
-        psth, psth_baselineUncorrected, cols, ts = compute_psth(
+        psth, psth_baselineUncorrected, columns, timestamps = compute_psth(
             z_score,
             event,
             filepath,
@@ -109,20 +109,20 @@ def execute_compute_psth(filepath: str, event: str, inputParameters: dict[str, o
             name_1,
             just_use_signal,
             sampling_rate,
-            ts,
+            timestamps,
             corrected_timestamps,
             timeForLightsTurnOn,
         )
-        write_hdf5(ts, event + "_" + name_1, filepath, "ts")
+        write_hdf5(timestamps, event + "_" + name_1, filepath, "ts")
 
         create_Df_for_psth(
             filepath,
             event + "_" + name_1 + "_baselineUncorrected",
             basename,
             psth_baselineUncorrected,
-            columns=cols,
+            columns=columns,
         )
-        create_Df_for_psth(filepath, event + "_" + name_1, basename, psth, columns=cols)
+        create_Df_for_psth(filepath, event + "_" + name_1, basename, psth, columns=columns)
         logger.info(f"PSTH for event {event} computed.")
 
 
@@ -160,11 +160,11 @@ def execute_compute_psth_peak_and_area(filepath: str, event: str, inputParameter
         name_1 = basename.split("_")[-1]
         sampling_rate = read_hdf5("timeCorrection_" + name_1, filepath, "sampling_rate")[0]
         psth = read_Df(filepath, event + "_" + name_1, basename)
-        cols = list(psth.columns)
+        columns = list(psth.columns)
         regex = re.compile("bin_[(]")
-        bin_names = [cols[i] for i in range(len(cols)) if regex.match(cols[i])]
+        bin_names = [columns[i] for i in range(len(columns)) if regex.match(columns[i])]
         regex_trials = re.compile("[+-]?([0-9]*[.])?[0-9]+")
-        trials_names = [cols[i] for i in range(len(cols)) if regex_trials.match(cols[i])]
+        trials_names = [columns[i] for i in range(len(columns)) if regex_trials.match(columns[i])]
         psth_mean_bin_names = trials_names + bin_names + ["mean"]
         psth_mean_bin_mean = np.asarray(psth[psth_mean_bin_names])
         timestamps = np.asarray(psth["timestamps"]).ravel()
@@ -172,7 +172,7 @@ def execute_compute_psth_peak_and_area(filepath: str, event: str, inputParameter
             psth_mean_bin_mean, timestamps, sampling_rate, peak_startPoint, peak_endPoint
         )
         fileName = [os.path.basename(os.path.dirname(filepath))]
-        index = [fileName[0] + "_" + s for s in psth_mean_bin_names]
+        index = [fileName[0] + "_" + name for name in psth_mean_bin_names]
         write_peak_and_area_to_hdf5(filepath, peak_area, event + "_" + name_1 + "_" + basename, index=index)
         write_peak_and_area_to_csv(filepath, peak_area, event + "_" + name_1 + "_" + basename, index=index)
         logger.info(f"Peak and Area for PSTH mean signal for event {event} computed.")
@@ -225,20 +225,20 @@ def execute_compute_cross_correlation(filepath: str, event: str, inputParameters
                     sample_rate = 1 / (psth_a["timestamps"][1] - psth_a["timestamps"][0])
                     psth_a = psth_a.drop(columns=["timestamps", "err", "mean"])
                     psth_b = psth_b.drop(columns=["timestamps", "err", "mean"])
-                    cols_a, cols_b = np.array(psth_a.columns), np.array(psth_b.columns)
-                    if np.intersect1d(cols_a, cols_b).size > 0:
-                        cols = list(np.intersect1d(cols_a, cols_b))
+                    columns_a, columns_b = np.array(psth_a.columns), np.array(psth_b.columns)
+                    if np.intersect1d(columns_a, columns_b).size > 0:
+                        columns = list(np.intersect1d(columns_a, columns_b))
                     else:
-                        cols = list(cols_a)
-                    arr_A, arr_B = np.array(psth_a).T, np.array(psth_b).T
-                    cross_corr = compute_cross_correlation(arr_A, arr_B, sample_rate)
-                    cols.append("timestamps")
+                        columns = list(columns_a)
+                    psth_array_a, psth_array_b = np.array(psth_a).T, np.array(psth_b).T
+                    cross_corr = compute_cross_correlation(psth_array_a, psth_array_b, sample_rate)
+                    columns.append("timestamps")
                     create_Df_for_cross_correlation(
                         make_dir_for_cross_correlation(filepath),
                         "corr_" + event,
                         type[j] + "_" + corr_info[i - 1] + "_" + corr_info[i],
                         cross_corr,
-                        cols,
+                        columns,
                     )
                 logger.info(f"Cross-correlation for event {event} computed.")
 
@@ -271,16 +271,18 @@ def orchestrate_psth(inputParameters: dict[str, object]) -> None:
                 2, -1
             )
 
-            with mp.Pool(numProcesses) as p:
-                p.starmap(execute_compute_psth, zip(repeat(filepath), storesList[1, :], repeat(inputParameters)))
+            with mp.Pool(numProcesses) as psth_pool:
+                psth_pool.starmap(
+                    execute_compute_psth, zip(repeat(filepath), storesList[1, :], repeat(inputParameters))
+                )
 
-            with mp.Pool(numProcesses) as pq:
-                pq.starmap(
+            with mp.Pool(numProcesses) as peak_area_pool:
+                peak_area_pool.starmap(
                     execute_compute_psth_peak_and_area, zip(repeat(filepath), storesList[1, :], repeat(inputParameters))
                 )
 
-            with mp.Pool(numProcesses) as cr:
-                cr.starmap(
+            with mp.Pool(numProcesses) as cross_correlation_pool:
+                cross_correlation_pool.starmap(
                     execute_compute_cross_correlation, zip(repeat(filepath), storesList[1, :], repeat(inputParameters))
                 )
 
@@ -303,23 +305,28 @@ def execute_psth_combined(inputParameters: dict[str, object]) -> None:
     for i in range(len(folderNames)):
         storesListPath.append(select_output_dirs(folderNames[i], selected_outputs.get(folderNames[i])))
     storesListPath = list(np.concatenate(storesListPath).flatten())
-    op = get_all_stores_for_combining_data(storesListPath)
-    writeToFile(str((len(op) + len(op) + 1) * 10) + "\n" + str(10) + "\n", file_path=PB_STEPS_FILE)
-    for i in range(len(op)):
+    combined_output_groups = get_all_stores_for_combining_data(storesListPath)
+    writeToFile(
+        str((len(combined_output_groups) + len(combined_output_groups) + 1) * 10) + "\n" + str(10) + "\n",
+        file_path=PB_STEPS_FILE,
+    )
+    for i in range(len(combined_output_groups)):
         storesList = np.asarray([[], []])
-        for j in range(len(op[i])):
+        for j in range(len(combined_output_groups[i])):
             storesList = np.concatenate(
                 (
                     storesList,
-                    np.genfromtxt(os.path.join(op[i][j], "storesList.csv"), dtype="str", delimiter=",").reshape(2, -1),
+                    np.genfromtxt(
+                        os.path.join(combined_output_groups[i][j], "storesList.csv"), dtype="str", delimiter=","
+                    ).reshape(2, -1),
                 ),
                 axis=1,
             )
         storesList = np.unique(storesList, axis=1)
         for k in range(storesList.shape[1]):
-            execute_compute_psth(op[i][0], storesList[1, k], inputParameters)
-            execute_compute_psth_peak_and_area(op[i][0], storesList[1, k], inputParameters)
-            execute_compute_cross_correlation(op[i][0], storesList[1, k], inputParameters)
+            execute_compute_psth(combined_output_groups[i][0], storesList[1, k], inputParameters)
+            execute_compute_psth_peak_and_area(combined_output_groups[i][0], storesList[1, k], inputParameters)
+            execute_compute_cross_correlation(combined_output_groups[i][0], storesList[1, k], inputParameters)
         writeToFile(str(10 + ((inputParameters["step"] + 1) * 10)) + "\n", file_path=PB_STEPS_FILE)
         inputParameters["step"] += 1
 
@@ -440,8 +447,8 @@ def execute_average_for_group(inputParameters: dict[str, object]) -> None:
             axis=1,
         )
     storesList = np.unique(storesList, axis=1)
-    op = makeAverageDir(inputParameters["abspath"])
-    np.savetxt(os.path.join(op, "storesList.csv"), storesList, delimiter=",", fmt="%s")
+    average_dir = makeAverageDir(inputParameters["abspath"])
+    np.savetxt(os.path.join(average_dir, "storesList.csv"), storesList, delimiter=",", fmt="%s")
     pbMaxValue = 0
     for j in range(storesList.shape[1]):
         if "control" in storesList[1, j].lower() or "signal" in storesList[1, j].lower():

--- a/src/guppy/orchestration/read_raw_data.py
+++ b/src/guppy/orchestration/read_raw_data.py
@@ -90,32 +90,34 @@ def _build_event_to_extractor(*, folder_path: str, storesList: np.ndarray, input
     if inputParameters is not None and inputParameters.get("mode") == "dandi":
         dandi_uri = inputParameters["dandi_uri_map"][folder_path]
         extractor = DandiNwbRecordingExtractor(folder_path=dandi_uri)
-        fmt_events, _ = DandiNwbRecordingExtractor.discover_events_and_flags(folder_path=dandi_uri)
-        for event in fmt_events:
+        format_events, _ = DandiNwbRecordingExtractor.discover_events_and_flags(folder_path=dandi_uri)
+        for event in format_events:
             event_to_extractor[event] = extractor
         return event_to_extractor
 
     num_ch = inputParameters["noChannels"]
     all_formats = detect_acquisition_formats(folder_path)
     # Doric extractor requires a store-name→event-type mapping built from storesList
-    event_name_to_event_type = {storesList[0, col]: storesList[1, col] for col in range(storesList.shape[1])}
+    event_name_to_event_type = {
+        storesList[0, column_index]: storesList[1, column_index] for column_index in range(storesList.shape[1])
+    }
 
-    for fmt in sorted(all_formats):
-        if fmt == "nwb":
+    for acquisition_format in sorted(all_formats):
+        if acquisition_format == "nwb":
             extractor = NwbRecordingExtractor(folder_path=folder_path)
-            fmt_events, _ = NwbRecordingExtractor.discover_events_and_flags(folder_path=folder_path)
-        elif fmt == "tdt":
+            format_events, _ = NwbRecordingExtractor.discover_events_and_flags(folder_path=folder_path)
+        elif acquisition_format == "tdt":
             extractor = TdtRecordingExtractor(folder_path=folder_path)
-            fmt_events, _ = TdtRecordingExtractor.discover_events_and_flags(folder_path=folder_path)
-        elif fmt == "doric":
+            format_events, _ = TdtRecordingExtractor.discover_events_and_flags(folder_path=folder_path)
+        elif acquisition_format == "doric":
             extractor = DoricRecordingExtractor(
                 folder_path=folder_path, event_name_to_event_type=event_name_to_event_type
             )
-            fmt_events, _ = DoricRecordingExtractor.discover_events_and_flags(folder_path=folder_path)
-        elif fmt == "csv":
+            format_events, _ = DoricRecordingExtractor.discover_events_and_flags(folder_path=folder_path)
+        elif acquisition_format == "csv":
             extractor = CsvRecordingExtractor(folder_path=folder_path)
-            fmt_events, _ = CsvRecordingExtractor.discover_events_and_flags(folder_path=folder_path)
-        elif fmt == "npm":
+            format_events, _ = CsvRecordingExtractor.discover_events_and_flags(folder_path=folder_path)
+        elif acquisition_format == "npm":
             extractor = NpmRecordingExtractor(
                 folder_path=folder_path,
                 num_ch=num_ch,
@@ -123,13 +125,15 @@ def _build_event_to_extractor(*, folder_path: str, storesList: np.ndarray, input
                 npm_time_units=inputParameters.get("npm_time_units"),
                 npm_split_events=inputParameters.get("npm_split_events"),
             )
-            fmt_events, _ = NpmRecordingExtractor.discover_events_and_flags(
+            format_events, _ = NpmRecordingExtractor.discover_events_and_flags(
                 folder_path=folder_path, num_ch=num_ch, inputParameters=inputParameters
             )
         else:
-            raise ValueError(f"Format not recognized: '{fmt}'. Expected one of 'nwb', 'tdt', 'csv', 'doric', 'npm'.")
+            raise ValueError(
+                f"Format not recognized: '{acquisition_format}'. Expected one of 'nwb', 'tdt', 'csv', 'doric', 'npm'."
+            )
 
-        for event in fmt_events:
+        for event in format_events:
             if event not in event_to_extractor:
                 event_to_extractor[event] = extractor
 
@@ -170,12 +174,12 @@ def orchestrate_read_raw_data(inputParameters: dict[str, object]) -> None:
     tasks = []
     total_samples = 0
     for filepath in folderNames:
-        for op in select_output_dirs(filepath, selected_outputs.get(filepath)):
-            storesList = _load_stores_list(op)
+        for output_dir in select_output_dirs(filepath, selected_outputs.get(filepath)):
+            storesList = _load_stores_list(output_dir)
             events = np.unique(storesList[0, :])
             # NPM decomposition params chosen in Step 1 are persisted in the output dir;
             # merge them so the NPM extractor reproduces the same streams (e.g. split events).
-            effective_parameters = {**inputParameters, **load_npm_params(op)}
+            effective_parameters = {**inputParameters, **load_npm_params(output_dir)}
             event_to_extractor = _build_event_to_extractor(
                 folder_path=filepath,
                 storesList=storesList,
@@ -203,7 +207,7 @@ def orchestrate_read_raw_data(inputParameters: dict[str, object]) -> None:
                     (
                         extractor,
                         grouped_events,
-                        op,
+                        output_dir,
                         {event: event_total_samples[event] for event in grouped_events},
                     )
                 )

--- a/src/guppy/orchestration/save_parameters.py
+++ b/src/guppy/orchestration/save_parameters.py
@@ -67,8 +67,8 @@ def save_parameters(inputParameters: dict[str, object]) -> None:
         else:
             destinations = select_output_dirs(session, selected_outputs.get(session))
         for destination in destinations:
-            with open(os.path.join(destination, "GuPPyParamtersUsed.json"), "w") as f:
-                json.dump(analysisParameters, f, indent=4)
+            with open(os.path.join(destination, "GuPPyParamtersUsed.json"), "w") as parameters_file:
+                json.dump(analysisParameters, parameters_file, indent=4)
             logger.info(f"Input Parameters file saved at {destination}")
 
     logger.info("#" * 400)

--- a/src/guppy/orchestration/storenames.py
+++ b/src/guppy/orchestration/storenames.py
@@ -64,11 +64,11 @@ def show_dir(filepath: str, run_name: str | None = None) -> str:
 
     i = 1
     while True:
-        op = output_dir_for_run(filepath, str(i))
-        if not os.path.exists(op):
+        output_dir = output_dir_for_run(filepath, str(i))
+        if not os.path.exists(output_dir):
             break
         i += 1
-    return op
+    return output_dir
 
 
 def make_dir(filepath: str, run_name: str | None = None, run_name_policy: str = "create") -> str:
@@ -95,26 +95,26 @@ def make_dir(filepath: str, run_name: str | None = None, run_name_policy: str = 
     if run_name is None:
         i = 1
         while True:
-            op = output_dir_for_run(filepath, str(i))
-            if not os.path.exists(op):
-                os.mkdir(op)
-                return op
+            output_dir = output_dir_for_run(filepath, str(i))
+            if not os.path.exists(output_dir):
+                os.mkdir(output_dir)
+                return output_dir
             i += 1
 
     validate_run_name(run_name)
     if run_name_policy not in ("create", "overwrite"):
         raise ValueError(f"run_name_policy must be 'create' or 'overwrite'; got {run_name_policy!r}.")
-    op = output_dir_for_run(filepath, run_name)
-    if os.path.exists(op):
+    output_dir = output_dir_for_run(filepath, run_name)
+    if os.path.exists(output_dir):
         if run_name_policy == "create":
             raise ValueError(
-                f"Output directory already exists: {op!r}. "
+                f"Output directory already exists: {output_dir!r}. "
                 "Choose a different runName or set runNamePolicy='overwrite' to replace it."
             )
-        shutil.rmtree(op)
-        logger.info(f"Cleared output directory for overwrite: {op}")
-    os.mkdir(op)
-    return op
+        shutil.rmtree(output_dir)
+        logger.info(f"Cleared output directory for overwrite: {output_dir}")
+    os.mkdir(output_dir)
+    return output_dir
 
 
 def _fetchValues(
@@ -204,26 +204,28 @@ def _fetchValues(
 
 
 def _save(storenames_config: dict, select_location: str, npm_params: dict[str, object] | None = None) -> str:
-    arr1, arr2 = np.asarray(storenames_config["storenames"]), np.asarray(storenames_config["names_for_storenames"])
+    storenames_array = np.asarray(storenames_config["storenames"])
+    names_for_storenames_array = np.asarray(storenames_config["names_for_storenames"])
 
-    empty_indices = np.where(arr2 == "")[0].tolist()
+    empty_indices = np.where(names_for_storenames_array == "")[0].tolist()
     if empty_indices:
         detail = (
             f"Empty string in the list names_for_storenames at index {empty_indices[0]} "
-            f"(storename {arr1[empty_indices[0]]!r})."
+            f"(storename {storenames_array[empty_indices[0]]!r})."
             if len(empty_indices) == 1
             else (
                 f"Empty strings in the list names_for_storenames at {len(empty_indices)} indices: "
-                f"{empty_indices} (storenames {[str(arr1[i]) for i in empty_indices]})."
+                f"{empty_indices} (storenames {[str(storenames_array[i]) for i in empty_indices]})."
             )
         )
         alert_message = f"#### Alert !! \n {detail} Provide a semantic name for each storename."
         logger.error(detail)
         return alert_message
 
-    if arr1.shape[0] != arr2.shape[0]:
+    if storenames_array.shape[0] != names_for_storenames_array.shape[0]:
         detail = (
-            f"Length of list storenames ({arr1.shape[0]}) and names_for_storenames ({arr2.shape[0]}) "
+            f"Length of list storenames ({storenames_array.shape[0]}) and names_for_storenames "
+            f"({names_for_storenames_array.shape[0]}) "
             "is not equal; each storename must be paired with exactly one semantic name."
         )
         alert_message = f"#### Alert !! \n {detail}"
@@ -233,42 +235,42 @@ def _save(storenames_config: dict, select_location: str, npm_params: dict[str, o
     if not os.path.exists(os.path.join(Path.home(), ".storesList.json")):
         storenames_cache = dict()
 
-        for i in range(arr1.shape[0]):
-            if arr1[i] in storenames_cache:
-                storenames_cache[arr1[i]].append(arr2[i])
-                storenames_cache[arr1[i]] = list(set(storenames_cache[arr1[i]]))
+        for i in range(storenames_array.shape[0]):
+            if storenames_array[i] in storenames_cache:
+                storenames_cache[storenames_array[i]].append(names_for_storenames_array[i])
+                storenames_cache[storenames_array[i]] = list(set(storenames_cache[storenames_array[i]]))
             else:
-                storenames_cache[arr1[i]] = [arr2[i]]
+                storenames_cache[storenames_array[i]] = [names_for_storenames_array[i]]
 
-        with open(os.path.join(Path.home(), ".storesList.json"), "w") as f:
-            json.dump(storenames_cache, f, indent=4)
+        with open(os.path.join(Path.home(), ".storesList.json"), "w") as cache_file:
+            json.dump(storenames_cache, cache_file, indent=4)
     else:
-        with open(os.path.join(Path.home(), ".storesList.json")) as f:
-            storenames_cache = json.load(f)
+        with open(os.path.join(Path.home(), ".storesList.json")) as cache_file:
+            storenames_cache = json.load(cache_file)
 
-        for i in range(arr1.shape[0]):
-            if arr1[i] in storenames_cache:
-                storenames_cache[arr1[i]].append(arr2[i])
-                storenames_cache[arr1[i]] = list(set(storenames_cache[arr1[i]]))
+        for i in range(storenames_array.shape[0]):
+            if storenames_array[i] in storenames_cache:
+                storenames_cache[storenames_array[i]].append(names_for_storenames_array[i])
+                storenames_cache[storenames_array[i]] = list(set(storenames_cache[storenames_array[i]]))
             else:
-                storenames_cache[arr1[i]] = [arr2[i]]
+                storenames_cache[storenames_array[i]] = [names_for_storenames_array[i]]
 
-        with open(os.path.join(Path.home(), ".storesList.json"), "w") as f:
-            json.dump(storenames_cache, f, indent=4)
+        with open(os.path.join(Path.home(), ".storesList.json"), "w") as cache_file:
+            json.dump(storenames_cache, cache_file, indent=4)
 
-    arr = np.asarray([arr1, arr2])
-    logger.info(arr)
+    stores_list_array = np.asarray([storenames_array, names_for_storenames_array])
+    logger.info(stores_list_array)
     if os.path.exists(select_location):
         # Overwrite mode: clear all derived data from the previous run before saving the new storesList.
         shutil.rmtree(select_location)
         logger.info(f"Cleared output directory for overwrite: {select_location}")
     os.mkdir(select_location)
 
-    np.savetxt(os.path.join(select_location, "storesList.csv"), arr, delimiter=",", fmt="%s")
+    np.savetxt(os.path.join(select_location, "storesList.csv"), stores_list_array, delimiter=",", fmt="%s")
     if npm_params is not None:
         write_npm_params(output_dir=select_location, npm_params=npm_params)
     logger.info(f"Storeslist file saved at {select_location}")
-    logger.info("Storeslist : \n" + str(arr))
+    logger.info("Storeslist : \n" + str(stores_list_array))
     return "#### No alerts !!"
 
 
@@ -362,13 +364,13 @@ def build_storenames_template(
     def update_values(event: object) -> None:
         global storenames, vars_list
 
-        arr = storenames_selector.get_take_widgets()
-        new_arr = []
-        for i in range(len(arr[1])):
-            for j in range(arr[1][i]):
-                new_arr.append(arr[0][i])
-        if len(new_arr) > 0:
-            storenames = storenames_selector.get_cross_selector() + new_arr
+        take_widgets = storenames_selector.get_take_widgets()
+        expanded_storenames = []
+        for i in range(len(take_widgets[1])):
+            for j in range(take_widgets[1][i]):
+                expanded_storenames.append(take_widgets[0][i])
+        if len(expanded_storenames) > 0:
+            storenames = storenames_selector.get_cross_selector() + expanded_storenames
         else:
             storenames = storenames_selector.get_cross_selector()
         storenames_selector.set_change_widgets(storenames)
@@ -446,13 +448,13 @@ def build_storenames_page(
     if isinstance(storenames_map, dict) and len(storenames_map) > 0:
         run_name = inputParameters.get("runName") or None
         run_name_policy = inputParameters.get("runNamePolicy", "create")
-        op = make_dir(folder_path, run_name=run_name, run_name_policy=run_name_policy)
-        arr = np.asarray([list(storenames_map.keys()), list(storenames_map.values())], dtype=str)
-        np.savetxt(os.path.join(op, "storesList.csv"), arr, delimiter=",", fmt="%s")
+        output_dir = make_dir(folder_path, run_name=run_name, run_name_policy=run_name_policy)
+        stores_list_array = np.asarray([list(storenames_map.keys()), list(storenames_map.values())], dtype=str)
+        np.savetxt(os.path.join(output_dir, "storesList.csv"), stores_list_array, delimiter=",", fmt="%s")
         if npm_params is not None:
-            write_npm_params(output_dir=op, npm_params=npm_params)
-        logger.info(f"Storeslist file saved at {op}")
-        logger.info("Storeslist : \n" + str(arr))
+            write_npm_params(output_dir=output_dir, npm_params=npm_params)
+        logger.info(f"Storeslist file saved at {output_dir}")
+        logger.info("Storeslist : \n" + str(stores_list_array))
         return
 
     channel_previews = _compute_npm_channel_previews(inputParameters, folder_path) if is_npm else None

--- a/src/guppy/orchestration/transients.py
+++ b/src/guppy/orchestration/transients.py
@@ -60,14 +60,20 @@ def findFreqAndAmp(
         name_1 = basename.split("_")[-1]
         sampling_rate = read_hdf5("timeCorrection_" + name_1, filepath, "sampling_rate")[0]
         z_score = read_hdf5("", path[i], "data")
-        ts = read_hdf5("timeCorrection_" + name_1, filepath, "timestampNew")
-        z_score, ts, peaksInd, peaks_occurrences, arr = analyze_transients(
-            ts, window, numProcesses, highAmpFilt, transientsThresh, sampling_rate, z_score
+        timestamps = read_hdf5("timeCorrection_" + name_1, filepath, "timestampNew")
+        z_score, timestamps, peaksInd, peaks_occurrences, freq_and_amp = analyze_transients(
+            timestamps, window, numProcesses, highAmpFilt, transientsThresh, sampling_rate, z_score
         )
         fileName = [os.path.basename(os.path.dirname(filepath))]
-        write_freq_and_amp_to_hdf5(filepath, arr, basename, index=fileName, columns=["freq (events/min)", "amplitude"])
+        write_freq_and_amp_to_hdf5(
+            filepath, freq_and_amp, basename, index=fileName, columns=["freq (events/min)", "amplitude"]
+        )
         write_freq_and_amp_to_csv(
-            filepath, arr, "freqAndAmp_" + basename + ".csv", index=fileName, columns=["freq (events/min)", "amplitude"]
+            filepath,
+            freq_and_amp,
+            "freqAndAmp_" + basename + ".csv",
+            index=fileName,
+            columns=["freq (events/min)", "amplitude"],
         )
         write_freq_and_amp_to_csv(
             filepath,
@@ -76,7 +82,7 @@ def findFreqAndAmp(
             index=np.arange(peaks_occurrences.shape[0]),
             columns=["timestamps", "amplitude"],
         )
-        write_transients_to_hdf5(filepath, basename, z_score, ts, peaksInd)
+        write_transients_to_hdf5(filepath, basename, z_score, timestamps, peaksInd)
     logger.info("Frequency and amplitude of transients in z_score data are calculated.")
 
 
@@ -107,11 +113,11 @@ def execute_visualize_peaks(folderNames: list[str], inputParameters: dict[str, o
 
             for i in range(len(path)):
                 basename = (os.path.basename(path[i])).split(".")[0]
-                z_score, ts, peaksInd = read_transients_from_hdf5(filepath, basename)
+                z_score, timestamps, peaksInd = read_transients_from_hdf5(filepath, basename)
 
                 suptitle = os.path.basename(os.path.dirname(path[i]))
                 title = (os.path.basename(path[i])).split(".")[0]
-                visualize_peaks(title, suptitle, z_score, ts, peaksInd)
+                visualize_peaks(title, suptitle, z_score, timestamps, peaksInd)
 
     logger.info("Frequency and amplitude of transients in z_score data are visualized.")
     plt.show()
@@ -135,9 +141,9 @@ def execute_visualize_peaks_combined(folderNames: list[str], inputParameters: di
         filepath = folderNames[i]
         storesListPath.append(select_output_dirs(filepath, selected_outputs.get(filepath)))
     storesListPath = list(np.concatenate(storesListPath).flatten())
-    op = get_all_stores_for_combining_data(storesListPath)
-    for i in range(len(op)):
-        filepath = op[i][0]
+    combined_output_groups = get_all_stores_for_combining_data(storesListPath)
+    for i in range(len(combined_output_groups)):
+        filepath = combined_output_groups[i][0]
 
         if selectForTransientsComputation == "z_score":
             path = glob.glob(os.path.join(filepath, "z_score_*"))
@@ -148,11 +154,11 @@ def execute_visualize_peaks_combined(folderNames: list[str], inputParameters: di
 
         for i in range(len(path)):
             basename = (os.path.basename(path[i])).split(".")[0]
-            z_score, ts, peaksInd = read_transients_from_hdf5(filepath, basename)
+            z_score, timestamps, peaksInd = read_transients_from_hdf5(filepath, basename)
 
             suptitle = os.path.basename(os.path.dirname(path[i]))
             title = (os.path.basename(path[i])).split(".")[0]
-            visualize_peaks(title, suptitle, z_score, ts, peaksInd)
+            visualize_peaks(title, suptitle, z_score, timestamps, peaksInd)
 
     logger.info("Frequency and amplitude of transients in z_score data are calculated.")
     plt.show()
@@ -255,9 +261,9 @@ def execute_find_freq_and_amp_combined(
         filepath = folderNames[i]
         storesListPath.append(select_output_dirs(filepath, selected_outputs.get(filepath)))
     storesListPath = list(np.concatenate(storesListPath).flatten())
-    op = get_all_stores_for_combining_data(storesListPath)
-    for i in range(len(op)):
-        filepath = op[i][0]
+    combined_output_groups = get_all_stores_for_combining_data(storesListPath)
+    for i in range(len(combined_output_groups)):
+        filepath = combined_output_groups[i][0]
         storesList = np.genfromtxt(os.path.join(filepath, "storesList.csv"), dtype="str", delimiter=",").reshape(2, -1)
         findFreqAndAmp(filepath, inputParameters, window=moving_window, numProcesses=numProcesses)
         writeToFile(str(10 + ((inputParameters["step"] + 1) * 10)) + "\n", file_path=PB_STEPS_FILE)

--- a/src/guppy/orchestration/visualize.py
+++ b/src/guppy/orchestration/visualize.py
@@ -71,22 +71,22 @@ def helper_plots(filepath: str, event: list[str], name: list[str] | str, inputPa
             for j in range(len(name)):
                 new_event.append(event_name[i] + "_" + name[j].split("_")[-1])
                 new_name = name[j]
-                temp_df = read_Df(filepath, new_event[-1], new_name)
-                cols = list(temp_df.columns)
+                event_df = read_Df(filepath, new_event[-1], new_name)
+                columns = list(event_df.columns)
                 regex = re.compile("bin_[(]")
-                bins[new_event[-1]] = [cols[i] for i in range(len(cols)) if regex.match(cols[i])]
-                frames.append(temp_df)
+                bins[new_event[-1]] = [columns[i] for i in range(len(columns)) if regex.match(columns[i])]
+                frames.append(event_df)
 
         df = pd.concat(frames, keys=new_event, axis=1)
     else:
         new_event = list(np.unique(np.array(event)))
         frames, bins = [], {}
         for i in range(len(new_event)):
-            temp_df = read_Df(filepath, new_event[i], "")
-            cols = list(temp_df.columns)
+            event_df = read_Df(filepath, new_event[i], "")
+            columns = list(event_df.columns)
             regex = re.compile("bin_[(]")
-            bins[new_event[i]] = [cols[i] for i in range(len(cols)) if regex.match(cols[i])]
-            frames.append(temp_df)
+            bins[new_event[i]] = [columns[i] for i in range(len(columns)) if regex.match(columns[i])]
+            frames.append(event_df)
 
         df = pd.concat(frames, keys=new_event, axis=1)
 
@@ -108,9 +108,9 @@ def helper_plots(filepath: str, event: list[str], name: list[str] | str, inputPa
     if len(bins_keys) > 0:
         bins_new = bins
         for i in range(len(bins_keys)):
-            arr = bins[bins_keys[i]]
-            if len(arr) > 0:
-                for j in arr:
+            bin_columns = bins[bins_keys[i]]
+            if len(bin_columns) > 0:
+                for j in bin_columns:
                     multiple_plots_options.append("{}_{}".format(bins_keys[i], j))
 
         multiple_plots_options = new_event + multiple_plots_options
@@ -122,9 +122,9 @@ def helper_plots(filepath: str, event: list[str], name: list[str] | str, inputPa
     x_max = float(inputParameters["nSecPost"])
     colormaps = plt.colormaps()
     new_colormaps = ["plasma", "plasma_r", "magma", "magma_r", "inferno", "inferno_r", "viridis", "viridis_r"]
-    set_a = set(colormaps)
-    set_b = set(new_colormaps)
-    colormaps = new_colormaps + list(set_a.difference(set_b))
+    all_colormaps_set = set(colormaps)
+    preferred_colormaps_set = set(new_colormaps)
+    colormaps = new_colormaps + list(all_colormaps_set.difference(preferred_colormaps_set))
     x = [columns_dict[new_event[0]][-4]]
     y = overview_y_options(columns_dict[new_event[0]])
     trial_no = range(1, len(remove_cols(columns_dict[heatmap_options[0]])[:-2]) + 1)
@@ -185,8 +185,8 @@ def createPlots(filepath: str, event: np.ndarray, inputParameters: dict[str, obj
         elif visualize_zscore_or_dff == "dff":
             path = glob.glob(os.path.join(filepath, "dff_*"))
 
-    name_arr = []
-    event_arr = []
+    names = []
+    event_names = []
 
     index = []
     for i in range(len(event)):
@@ -198,13 +198,13 @@ def createPlots(filepath: str, event: np.ndarray, inputParameters: dict[str, obj
     for i in range(len(path)):
         name = (os.path.basename(path[i])).split(".")
         name = name[0]
-        name_arr.append(name)
+        names.append(name)
 
     if average == True:
         logger.info("average")
-        helper_plots(filepath, name_arr, "", inputParameters)
+        helper_plots(filepath, names, "", inputParameters)
     else:
-        helper_plots(filepath, event, name_arr, inputParameters)
+        helper_plots(filepath, event, names, inputParameters)
 
 
 def _validate_metric_against_step4_outputs(inputParameters: dict[str, object]) -> None:
@@ -260,7 +260,7 @@ def _validate_metric_against_step4_outputs(inputParameters: dict[str, object]) -
     else:
         pattern = "*_dff_*.h5"
 
-    missing_sessions = [od for od in output_dirs if not glob.glob(os.path.join(od, pattern))]
+    missing_sessions = [output_dir for output_dir in output_dirs if not glob.glob(os.path.join(output_dir, pattern))]
 
     if missing_sessions:
         other_metric = "dff" if visualize_zscore_or_dff == "z_score" else "z_score"
@@ -400,21 +400,23 @@ def visualizeResults(inputParameters: dict[str, object]) -> None:
                 filepath = folderNames[i]
                 storesListPath.append(select_output_dirs(filepath, selected_outputs.get(filepath)))
             storesListPath = list(np.concatenate(storesListPath).flatten())
-            op = get_all_stores_for_combining_data(storesListPath)
-            for i in range(len(op)):
+            combined_output_groups = get_all_stores_for_combining_data(storesListPath)
+            for i in range(len(combined_output_groups)):
                 storesList = np.asarray([[], []])
-                for j in range(len(op[i])):
+                for j in range(len(combined_output_groups[i])):
                     storesList = np.concatenate(
                         (
                             storesList,
-                            np.genfromtxt(os.path.join(op[i][j], "storesList.csv"), dtype="str", delimiter=",").reshape(
-                                2, -1
-                            ),
+                            np.genfromtxt(
+                                os.path.join(combined_output_groups[i][j], "storesList.csv"),
+                                dtype="str",
+                                delimiter=",",
+                            ).reshape(2, -1),
                         ),
                         axis=1,
                     )
                 storesList = np.unique(storesList, axis=1)
-                filepath = op[i][0]
+                filepath = combined_output_groups[i][0]
                 createPlots(filepath, storesList[1, :], inputParameters)
         else:
             for i in range(len(folderNames)):

--- a/src/guppy/testing/api.py
+++ b/src/guppy/testing/api.py
@@ -52,7 +52,11 @@ def _normalize_selected_runs(
                 f"{parameter_name} key {session_key!r} is not in selected_folders; "
                 f"expected one of {sorted(abs_sessions_set)!r}."
             )
-        if not isinstance(run_names, list) or not run_names or not all(isinstance(r, str) and r for r in run_names):
+        if (
+            not isinstance(run_names, list)
+            or not run_names
+            or not all(isinstance(run_name, str) and run_name for run_name in run_names)
+        ):
             raise ValueError(
                 f"{parameter_name}[{session_key!r}] must be a non-empty list of non-empty strings; "
                 f"got {run_names!r}."
@@ -230,30 +234,30 @@ def step1(
     sessions = list(selected_folders or [])
     if not sessions:
         raise ValueError("selected_folders must be a non-empty iterable of session directories")
-    abs_sessions = [os.path.abspath(s) for s in sessions]
-    for s in abs_sessions:
-        if not os.path.isdir(s):
-            raise ValueError(f"Session path does not exist or is not a directory: {s}")
-        parent = os.path.dirname(s)
+    abs_sessions = [os.path.abspath(session) for session in sessions]
+    for session in abs_sessions:
+        if not os.path.isdir(session):
+            raise ValueError(f"Session path does not exist or is not a directory: {session}")
+        parent = os.path.dirname(session)
         if parent != base_dir:
             raise ValueError(
                 f"All selected_folders must share the same parent equal to base_dir. "
-                f"Got parent {parent!r} for session {s!r}, expected {base_dir!r}"
+                f"Got parent {parent!r} for session {session!r}, expected {base_dir!r}"
             )
 
     # Validate storenames_map
     if not isinstance(storenames_map, dict) or not storenames_map:
         raise ValueError("storenames_map must be a non-empty dict[str, str]")
-    for k, v in storenames_map.items():
-        if not isinstance(k, str) or not k.strip():
+    for raw_storename, semantic_name in storenames_map.items():
+        if not isinstance(raw_storename, str) or not raw_storename.strip():
             raise ValueError(
-                f"Invalid storename key: {k!r}. Keys must be non-empty strings (the raw store name "
+                f"Invalid storename key: {raw_storename!r}. Keys must be non-empty strings (the raw store name "
                 "from the acquisition file)."
             )
-        if not isinstance(v, str) or not v.strip():
+        if not isinstance(semantic_name, str) or not semantic_name.strip():
             raise ValueError(
-                f"Invalid semantic name for key {k!r}: {v!r}. Values must be non-empty strings "
-                "(the semantic label such as 'control_DMS' or 'signal_NAc')."
+                f"Invalid semantic name for key {raw_storename!r}: {semantic_name!r}. Values must be non-empty "
+                "strings (the semantic label such as 'control_DMS' or 'signal_NAc')."
             )
 
     # Headless build: set base_dir and construct the template
@@ -348,15 +352,15 @@ def step2(
     sessions = list(selected_folders or [])
     if not sessions:
         raise ValueError("selected_folders must be a non-empty iterable of session directories")
-    abs_sessions = [os.path.abspath(s) for s in sessions]
-    for s in abs_sessions:
-        if not os.path.isdir(s):
-            raise ValueError(f"Session path does not exist or is not a directory: {s}")
-        parent = os.path.dirname(s)
+    abs_sessions = [os.path.abspath(session) for session in sessions]
+    for session in abs_sessions:
+        if not os.path.isdir(session):
+            raise ValueError(f"Session path does not exist or is not a directory: {session}")
+        parent = os.path.dirname(session)
         if parent != base_dir:
             raise ValueError(
                 f"All selected_folders must share the same parent equal to base_dir. "
-                f"Got parent {parent!r} for session {s!r}, expected {base_dir!r}"
+                f"Got parent {parent!r} for session {session!r}, expected {base_dir!r}"
             )
 
     # Headless build: set base_dir and construct the template
@@ -482,15 +486,15 @@ def step3(
     sessions = list(selected_folders or [])
     if not sessions:
         raise ValueError("selected_folders must be a non-empty iterable of session directories")
-    abs_sessions = [os.path.abspath(s) for s in sessions]
-    for s in abs_sessions:
-        if not os.path.isdir(s):
-            raise ValueError(f"Session path does not exist or is not a directory: {s}")
-        parent = os.path.dirname(s)
+    abs_sessions = [os.path.abspath(session) for session in sessions]
+    for session in abs_sessions:
+        if not os.path.isdir(session):
+            raise ValueError(f"Session path does not exist or is not a directory: {session}")
+        parent = os.path.dirname(session)
         if parent != base_dir:
             raise ValueError(
                 f"All selected_folders must share the same parent equal to base_dir. "
-                f"Got parent {parent!r} for session {s!r}, expected {base_dir!r}"
+                f"Got parent {parent!r} for session {session!r}, expected {base_dir!r}"
             )
 
     # Headless build: set base_dir and construct the template
@@ -635,15 +639,15 @@ def step4(
     sessions = list(selected_folders or [])
     if not sessions:
         raise ValueError("selected_folders must be a non-empty iterable of session directories")
-    abs_sessions = [os.path.abspath(s) for s in sessions]
-    for s in abs_sessions:
-        if not os.path.isdir(s):
-            raise ValueError(f"Session path does not exist or is not a directory: {s}")
-        parent = os.path.dirname(s)
+    abs_sessions = [os.path.abspath(session) for session in sessions]
+    for session in abs_sessions:
+        if not os.path.isdir(session):
+            raise ValueError(f"Session path does not exist or is not a directory: {session}")
+        parent = os.path.dirname(session)
         if parent != base_dir:
             raise ValueError(
                 f"All selected_folders must share the same parent equal to base_dir. "
-                f"Got parent {parent!r} for session {s!r}, expected {base_dir!r}"
+                f"Got parent {parent!r} for session {session!r}, expected {base_dir!r}"
             )
 
     # Headless build: set base_dir and construct the template
@@ -673,7 +677,7 @@ def step4(
 
     # Inject group analysis parameters
     input_params["averageForGroup"] = average_for_group
-    abs_group_folders = [os.path.abspath(f) for f in group_folders] if group_folders else []
+    abs_group_folders = [os.path.abspath(folder) for folder in group_folders] if group_folders else []
     input_params["folderNamesForAvg"] = abs_group_folders
 
     # Per-session output-directory subset filter for individual + group analysis
@@ -763,15 +767,15 @@ def step5(
     sessions = list(selected_folders or [])
     if not sessions:
         raise ValueError("selected_folders must be a non-empty iterable of session directories")
-    abs_sessions = [os.path.abspath(s) for s in sessions]
-    for s in abs_sessions:
-        if not os.path.isdir(s):
-            raise ValueError(f"Session path does not exist or is not a directory: {s}")
-        parent = os.path.dirname(s)
+    abs_sessions = [os.path.abspath(session) for session in sessions]
+    for session in abs_sessions:
+        if not os.path.isdir(session):
+            raise ValueError(f"Session path does not exist or is not a directory: {session}")
+        parent = os.path.dirname(session)
         if parent != base_dir:
             raise ValueError(
                 f"All selected_folders must share the same parent equal to base_dir. "
-                f"Got parent {parent!r} for session {s!r}, expected {base_dir!r}"
+                f"Got parent {parent!r} for session {session!r}, expected {base_dir!r}"
             )
 
     # Headless build: set base_dir and construct the template
@@ -798,7 +802,7 @@ def step5(
 
     # Inject group-average visualization selection
     input_params["visualizeAverageResults"] = visualize_average_results
-    abs_group_folders = [os.path.abspath(f) for f in group_folders] if group_folders else []
+    abs_group_folders = [os.path.abspath(folder) for folder in group_folders] if group_folders else []
     input_params["folderNamesForAvg"] = abs_group_folders
 
     # Per-session output-directory subset filter for individual + group visualization

--- a/src/guppy/testing/consistency.py
+++ b/src/guppy/testing/consistency.py
@@ -110,12 +110,12 @@ def compare_output_folders(
             mismatches.append(f"MISSING in actual: {detail}")
             continue
 
-        ext = Path(rel_path).suffix.lower()
-        if ext in {".hdf5", ".h5"}:
+        extension = Path(rel_path).suffix.lower()
+        if extension in {".hdf5", ".h5"}:
             _compare_hdf5(actual_path, expected_path, rel_path, mismatches, rtol, atol, event_ts_offset)
-        elif ext == ".csv":
+        elif extension == ".csv":
             _compare_csv(actual_path, expected_path, rel_path, mismatches, rtol, atol, event_ts_offset)
-        elif ext == ".json":
+        elif extension == ".json":
             _compare_json(actual_path, expected_path, rel_path, mismatches)
         # Unknown extensions are skipped silently.
 
@@ -156,27 +156,29 @@ def _normalize_psth_label(label: str, *, bare_offset: float = 0.0, prefixed_offs
     """
     if _BARE_FLOAT_RE.match(label):
         return f"{float(label) + bare_offset:.10g}"
-    m = _PREFIXED_FLOAT_RE.match(label)
-    if m:
-        return f"{m.group(1)}_{float(m.group(2)) + prefixed_offset:.10g}"
+    match = _PREFIXED_FLOAT_RE.match(label)
+    if match:
+        return f"{match.group(1)}_{float(match.group(2)) + prefixed_offset:.10g}"
     return label
 
 
-def _normalize_psth_index(idx: pd.Index, *, bare_offset: float = 0.0, prefixed_offset: float = 0.0) -> pd.Index:
+def _normalize_psth_index(index: pd.Index, *, bare_offset: float = 0.0, prefixed_offset: float = 0.0) -> pd.Index:
     """Apply :func:`_normalize_psth_label` to every element of a pandas Index."""
     return pd.Index(
-        [_normalize_psth_label(str(lbl), bare_offset=bare_offset, prefixed_offset=prefixed_offset) for lbl in idx]
+        [_normalize_psth_label(str(label), bare_offset=bare_offset, prefixed_offset=prefixed_offset) for label in index]
     )
 
 
-def _normalize_psth_str_array(arr: np.ndarray, *, bare_offset: float = 0.0, prefixed_offset: float = 0.0) -> np.ndarray:
+def _normalize_psth_str_array(
+    string_array: np.ndarray, *, bare_offset: float = 0.0, prefixed_offset: float = 0.0
+) -> np.ndarray:
     """Apply :func:`_normalize_psth_label` to every element of a string/bytes array."""
     flat = []
-    for item in arr.flat:
+    for item in string_array.flat:
         if isinstance(item, (bytes, np.bytes_)):
             item = item.decode("utf-8", errors="replace")
         flat.append(_normalize_psth_label(str(item), bare_offset=bare_offset, prefixed_offset=prefixed_offset))
-    return np.array(flat, dtype=object).reshape(arr.shape)
+    return np.array(flat, dtype=object).reshape(string_array.shape)
 
 
 def _collect_relative_paths(root: str) -> list[str]:
@@ -184,10 +186,10 @@ def _collect_relative_paths(root: str) -> list[str]:
     result: list[str] = []
     for dirpath, dirnames, filenames in os.walk(root):
         # Prune skipped directories in-place so os.walk does not descend into them.
-        dirnames[:] = [d for d in dirnames if d not in _SKIP_DIRS]
-        for fname in filenames:
-            full = os.path.join(dirpath, fname)
-            result.append(os.path.relpath(full, root))
+        dirnames[:] = [dirname for dirname in dirnames if dirname not in _SKIP_DIRS]
+        for filename in filenames:
+            full_path = os.path.join(dirpath, filename)
+            result.append(os.path.relpath(full_path, root))
     return result
 
 
@@ -341,10 +343,10 @@ def _compare_json(
     mismatches: list[str],
 ) -> None:
     """Compare two JSON files with NaN-safe value comparison."""
-    with open(actual_path) as f:
-        actual_data = json.load(f)
-    with open(expected_path) as f:
-        expected_data = json.load(f)
+    with open(actual_path) as actual_file:
+        actual_data = json.load(actual_file)
+    with open(expected_path) as expected_file:
+        expected_data = json.load(expected_file)
 
     json_mismatches: list[str] = []
     _compare_json_values(actual_data, expected_data, rel_path, "", json_mismatches)
@@ -365,11 +367,13 @@ def _compare_json_values(
         if not isinstance(actual, dict):
             mismatches.append(f"{location}: expected dict, got {type(actual).__name__}")
             return
-        for k in expected:
-            if k not in actual:
-                mismatches.append(f"{location}: missing key '{k}' in actual")
+        for key in expected:
+            if key not in actual:
+                mismatches.append(f"{location}: missing key '{key}' in actual")
             else:
-                _compare_json_values(actual[k], expected[k], rel_path, f"{key_path}.{k}" if key_path else k, mismatches)
+                _compare_json_values(
+                    actual[key], expected[key], rel_path, f"{key_path}.{key}" if key_path else key, mismatches
+                )
 
     elif isinstance(expected, list):
         if not isinstance(actual, list):
@@ -378,8 +382,8 @@ def _compare_json_values(
         if len(actual) != len(expected):
             mismatches.append(f"{location}: list length mismatch: actual={len(actual)} expected={len(expected)}")
             return
-        for i, (a, e) in enumerate(zip(actual, expected)):
-            _compare_json_values(a, e, rel_path, f"{key_path}[{i}]", mismatches)
+        for i, (actual_item, expected_item) in enumerate(zip(actual, expected)):
+            _compare_json_values(actual_item, expected_item, rel_path, f"{key_path}[{i}]", mismatches)
 
     else:
         # Scalar: handle NaN

--- a/src/guppy/testing/scripts/summarize_stubbed_testing_data.py
+++ b/src/guppy/testing/scripts/summarize_stubbed_testing_data.py
@@ -263,8 +263,8 @@ def _summarize_session(session: _SessionConfig, working_folder_path: Path) -> _S
     if ttl_event is not None:
         if hasattr(extractor, "_readtev"):
             # TDT: use _readtev directly to avoid storesList.csv dependency for multi-behavior epocs
-            S = extractor._readtev(ttl_event)
-            number_of_ttls = len(S["timestamps"])
+            readtev_result = extractor._readtev(ttl_event)
+            number_of_ttls = len(readtev_result["timestamps"])
         else:
             ttl_result = extractor.read(events=[ttl_event], outputPath="")
             number_of_ttls = len(ttl_result[0]["timestamps"])
@@ -309,7 +309,7 @@ def main() -> None:
 
     modality_width = max(len(col_modality), max(len(row["modality"]) for row in rows))
     name_width = max(len(col_name), max(len(row["name"]) for row in rows))
-    size_width = max(len(col_size), max(len(s) for s in size_strings))
+    size_width = max(len(col_size), max(len(size_string) for size_string in size_strings))
     duration_width = max(len(col_duration), max(len(f"{row['duration']:.1f}") for row in rows))
     ttl_channel_width = max(len(col_ttl_channel), max(len(row["ttl_channel"]) for row in rows))
     number_of_ttls_width = max(len(col_number_of_ttls), max(len(str(row["number_of_ttls"])) for row in rows))

--- a/src/guppy/utils/_hdf5_io.py
+++ b/src/guppy/utils/_hdf5_io.py
@@ -18,44 +18,44 @@ def read_hdf5(event: str, filepath: str, key: str) -> np.ndarray:
     if event:
         event = event.replace("\\", "_")
         event = event.replace("/", "_")
-        op = os.path.join(filepath, event + ".hdf5")
+        hdf5_path = os.path.join(filepath, event + ".hdf5")
     else:
-        op = filepath
+        hdf5_path = filepath
 
-    if os.path.exists(op):
-        with h5py.File(op, "r") as f:
-            arr = np.asarray(f[key])
+    if os.path.exists(hdf5_path):
+        with h5py.File(hdf5_path, "r") as hdf5_file:
+            data = np.asarray(hdf5_file[key])
     else:
-        message = f"HDF5 file '{op}' does not exist (event={event!r}, key={key!r})."
+        message = f"HDF5 file '{hdf5_path}' does not exist (event={event!r}, key={key!r})."
         logger.error(message)
         raise FileNotFoundError(message)
 
-    return arr
+    return data
 
 
 def write_hdf5(data: np.ndarray | float | int | str | bool, storename: str, output_path: str, key: str) -> None:
     storename = storename.replace("\\", "_")
     storename = storename.replace("/", "_")
-    op = os.path.join(output_path, storename + ".hdf5")
+    hdf5_path = os.path.join(output_path, storename + ".hdf5")
 
-    if not os.path.exists(op):
-        with h5py.File(op, "w") as f:
+    if not os.path.exists(hdf5_path):
+        with h5py.File(hdf5_path, "w") as hdf5_file:
             if isinstance(data, np.ndarray):
-                f.create_dataset(key, data=data, maxshape=(None,), chunks=True)
+                hdf5_file.create_dataset(key, data=data, maxshape=(None,), chunks=True)
             else:
-                f.create_dataset(key, data=data)
+                hdf5_file.create_dataset(key, data=data)
     else:
-        with h5py.File(op, "r+") as f:
-            if key in list(f.keys()):
+        with h5py.File(hdf5_path, "r+") as hdf5_file:
+            if key in list(hdf5_file.keys()):
                 if isinstance(data, np.ndarray):
-                    f[key].resize(data.shape)
-                    arr = f[key]
-                    arr[:] = data
+                    hdf5_file[key].resize(data.shape)
+                    dataset = hdf5_file[key]
+                    dataset[:] = data
                 else:
-                    arr = f[key]
-                    arr[()] = data
+                    dataset = hdf5_file[key]
+                    dataset[()] = data
             else:
                 if isinstance(data, np.ndarray):
-                    f.create_dataset(key, data=data, maxshape=(None,), chunks=True)
+                    hdf5_file.create_dataset(key, data=data, maxshape=(None,), chunks=True)
                 else:
-                    f.create_dataset(key, data=data)
+                    hdf5_file.create_dataset(key, data=data)

--- a/src/guppy/utils/utils.py
+++ b/src/guppy/utils/utils.py
@@ -69,9 +69,9 @@ def takeOnlyDirs(paths: list[str]) -> list[str]:
         Subset of ``paths`` containing only directories.
     """
     removePaths = []
-    for p in paths:
-        if os.path.isfile(p):
-            removePaths.append(p)
+    for path in paths:
+        if os.path.isfile(path):
+            removePaths.append(path)
     return list(set(paths) - set(removePaths))
 
 
@@ -189,7 +189,9 @@ def select_output_dirs(session_path: str, selected_runs: list[str]) -> list[str]
         )
 
     selected = [available_by_name[run] for run in selected_runs]
-    missing_stores_list = [d for d in selected if not os.path.exists(os.path.join(d, "storesList.csv"))]
+    missing_stores_list = [
+        output_dir for output_dir in selected if not os.path.exists(os.path.join(output_dir, "storesList.csv"))
+    ]
     if missing_stores_list:
         raise ValueError(
             f"Selected output directories are missing storesList.csv: {missing_stores_list!r}. "
@@ -302,9 +304,9 @@ def read_Df(filepath: str, event: str, name: str) -> pd.DataFrame:
     event = event.replace("\\", "_")
     event = event.replace("/", "_")
     if name:
-        op = os.path.join(filepath, event + "_{}.h5".format(name))
+        hdf5_path = os.path.join(filepath, event + "_{}.h5".format(name))
     else:
-        op = os.path.join(filepath, event + ".h5")
-    df = pd.read_hdf(op, key="df", mode="r")
+        hdf5_path = os.path.join(filepath, event + ".h5")
+    df = pd.read_hdf(hdf5_path, key="df", mode="r")
 
     return df

--- a/src/guppy/utils/validation.py
+++ b/src/guppy/utils/validation.py
@@ -191,9 +191,9 @@ def validate_same_parent_directory(*, paths: Sequence[str]) -> np.ndarray:
     ValueError
         If the paths span more than one parent directory.
     """
-    parents = np.unique(np.asarray([os.path.dirname(p) for p in paths]))
+    parents = np.unique(np.asarray([os.path.dirname(path) for path in paths]))
     if len(parents) > 1:
-        path_to_parent = "\n".join(f"  - {p} (parent: {os.path.dirname(p)})" for p in paths)
+        path_to_parent = "\n".join(f"  - {path} (parent: {os.path.dirname(path)})" for path in paths)
         message = (
             "All the folders selected should be at the same location, but the selected folders "
             f"span {len(parents)} parent directories:\n{path_to_parent}"

--- a/tests/unit/analysis/test_artifact_removal.py
+++ b/tests/unit/analysis/test_artifact_removal.py
@@ -49,7 +49,7 @@ def test_eliminate_data_single_window_output_length():
     data = np.arange(501, dtype=float)
     coords = np.array([[1.0, 4.0]])
     result_data, result_ts = eliminateData(
-        data=data, ts=ts, coords=coords, timeForLightsTurnOn=0.0, sampling_rate=100.0
+        data=data, timestamps=ts, coords=coords, timeForLightsTurnOn=0.0, sampling_rate=100.0
     )
     expected_count = np.sum((ts > 1.0) & (ts < 4.0))
     assert result_data.shape[0] == expected_count
@@ -62,7 +62,7 @@ def test_eliminate_data_single_window_timestamps_start_at_light_turn_on():
     coords = np.array([[1.0, 4.0]])
     time_for_lights_turn_on = 0.5
     _, result_ts = eliminateData(
-        data=data, ts=ts, coords=coords, timeForLightsTurnOn=time_for_lights_turn_on, sampling_rate=100.0
+        data=data, timestamps=ts, coords=coords, timeForLightsTurnOn=time_for_lights_turn_on, sampling_rate=100.0
     )
     np.testing.assert_allclose(result_ts[0], time_for_lights_turn_on, atol=1e-6)
 
@@ -72,7 +72,7 @@ def test_eliminate_data_two_windows_output_length_is_sum_of_windows():
     data = np.arange(1001, dtype=float)
     coords = np.array([[1.0, 4.0], [6.0, 9.0]])
     result_data, result_ts = eliminateData(
-        data=data, ts=ts, coords=coords, timeForLightsTurnOn=0.0, sampling_rate=100.0
+        data=data, timestamps=ts, coords=coords, timeForLightsTurnOn=0.0, sampling_rate=100.0
     )
     count_window_1 = np.sum((ts > 1.0) & (ts < 4.0))
     count_window_2 = np.sum((ts > 6.0) & (ts < 9.0))
@@ -84,7 +84,9 @@ def test_eliminate_data_all_zeros_returns_zero_array():
     ts = np.linspace(0, 5, 501)
     data = np.zeros(501)
     coords = np.array([[1.0, 4.0]])
-    result_data, _ = eliminateData(data=data, ts=ts, coords=coords, timeForLightsTurnOn=0.0, sampling_rate=100.0)
+    result_data, _ = eliminateData(
+        data=data, timestamps=ts, coords=coords, timeForLightsTurnOn=0.0, sampling_rate=100.0
+    )
     assert (result_data == 0).all()
 
 
@@ -93,7 +95,9 @@ def test_eliminate_ts_all_ttls_inside_window_are_preserved():
     tsNew = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
     ttl_ts = np.array([1.5, 2.0, 3.5])
     coords = np.array([[0.0, 4.0]])
-    result = eliminateTs(ts=ttl_ts, tsNew=tsNew, coords=coords, timeForLightsTurnOn=0.0, sampling_rate=100.0)
+    result = eliminateTs(
+        ttl_timestamps=ttl_ts, tsNew=tsNew, coords=coords, timeForLightsTurnOn=0.0, sampling_rate=100.0
+    )
     np.testing.assert_allclose(result, np.array([0.5, 1.0, 2.5]), atol=1e-6)
 
 
@@ -103,7 +107,9 @@ def test_eliminate_ts_ttls_outside_window_are_dropped():
     tsNew = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
     ttl_ts = np.array([0.0, 1.5, 2.0, 4.5])
     coords = np.array([[0.0, 4.0]])
-    result = eliminateTs(ts=ttl_ts, tsNew=tsNew, coords=coords, timeForLightsTurnOn=0.0, sampling_rate=100.0)
+    result = eliminateTs(
+        ttl_timestamps=ttl_ts, tsNew=tsNew, coords=coords, timeForLightsTurnOn=0.0, sampling_rate=100.0
+    )
     np.testing.assert_allclose(result, np.array([0.5, 1.0]), atol=1e-6)
 
 
@@ -111,7 +117,7 @@ def test_adding_nan_values_out_of_window_indices_are_nan():
     ts = np.linspace(0, 5, 501)
     data = np.ones(501)
     coords = np.array([[1.0, 4.0]])
-    result = addingNaNValues(data=data.copy(), ts=ts, coords=coords)
+    result = addingNaNValues(data=data.copy(), timestamps=ts, coords=coords)
     outside_indices = np.where((ts <= 1.0) | (ts >= 4.0))[0]
     assert np.all(np.isnan(result[outside_indices]))
 
@@ -120,7 +126,7 @@ def test_adding_nan_values_in_window_values_unchanged():
     ts = np.linspace(0, 5, 501)
     data = np.arange(501, dtype=float)
     coords = np.array([[1.0, 4.0]])
-    result = addingNaNValues(data=data.copy(), ts=ts, coords=coords)
+    result = addingNaNValues(data=data.copy(), timestamps=ts, coords=coords)
     inside_indices = np.where((ts > 1.0) & (ts < 4.0))[0]
     np.testing.assert_array_equal(result[inside_indices], data[inside_indices])
 
@@ -130,7 +136,7 @@ def test_adding_nan_values_touching_windows_no_double_counting():
     ts = np.linspace(0, 10, 1001)
     data = np.ones(1001)
     coords = np.array([[1.0, 5.0], [5.0, 9.0]])
-    result = addingNaNValues(data=data.copy(), ts=ts, coords=coords)
+    result = addingNaNValues(data=data.copy(), timestamps=ts, coords=coords)
     # Points strictly inside either window should not be NaN
     inside = np.where(((ts > 1.0) & (ts < 5.0)) | ((ts > 5.0) & (ts < 9.0)))[0]
     assert not np.any(np.isnan(result[inside]))
@@ -139,7 +145,7 @@ def test_adding_nan_values_touching_windows_no_double_counting():
 def test_remove_ttls_returns_only_timestamps_inside_windows():
     ts = np.array([0.5, 1.5, 2.5, 3.5, 4.5])
     coords = np.array([[1.0, 3.0]])
-    result = removeTTLs(ts=ts, coords=coords)
+    result = removeTTLs(ttl_timestamps=ts, coords=coords)
     # 0.5, 3.5, 4.5 outside [1.0, 3.0]; 1.5 and 2.5 inside
     np.testing.assert_array_equal(result, np.array([1.5, 2.5]))
 
@@ -147,14 +153,14 @@ def test_remove_ttls_returns_only_timestamps_inside_windows():
 def test_remove_ttls_empty_result_when_no_timestamps_in_windows():
     ts = np.array([0.1, 0.2, 4.5, 4.8])
     coords = np.array([[1.0, 4.0]])
-    result = removeTTLs(ts=ts, coords=coords)
+    result = removeTTLs(ttl_timestamps=ts, coords=coords)
     assert result.shape[0] == 0
 
 
 def test_remove_ttls_two_windows_returns_timestamps_from_both():
     ts = np.array([0.5, 1.5, 2.5, 5.5, 6.5, 9.5])
     coords = np.array([[1.0, 4.0], [5.0, 8.0]])
-    result = removeTTLs(ts=ts, coords=coords)
+    result = removeTTLs(ttl_timestamps=ts, coords=coords)
     # 1.5, 2.5 inside [1,4]; 5.5, 6.5 inside [5,8]; 0.5 and 9.5 are outside both windows
     expected = np.array([1.5, 2.5, 5.5, 6.5])
     np.testing.assert_array_equal(result, expected)

--- a/tests/unit/analysis/test_compute_psth.py
+++ b/tests/unit/analysis/test_compute_psth.py
@@ -118,7 +118,7 @@ def test_compute_psth_single_timestamp_no_corrections_returns_expected_row():
         naming="",
         just_use_signal=False,
         sampling_rate=10.0,
-        ts=ts,
+        event_timestamps=ts,
         corrected_timestamps=corrected_timestamps,
         timeForLightsTurnOn=0.0,
     )
@@ -149,7 +149,7 @@ def test_compute_psth_early_timestamps_filtered_by_baseline_window():
         naming="",
         just_use_signal=False,
         sampling_rate=10.0,
-        ts=ts,
+        event_timestamps=ts,
         corrected_timestamps=corrected_timestamps,
         timeForLightsTurnOn=0.0,
     )
@@ -176,7 +176,7 @@ def test_compute_psth_burst_timestamps_within_time_interval_are_dropped():
         naming="",
         just_use_signal=False,
         sampling_rate=10.0,
-        ts=ts,
+        event_timestamps=ts,
         corrected_timestamps=corrected_timestamps,
         timeForLightsTurnOn=0.0,
     )
@@ -204,7 +204,7 @@ def test_compute_psth_binning_by_trials_produces_correct_bin_mean_and_sem():
         naming="",
         just_use_signal=False,
         sampling_rate=10.0,
-        ts=ts,
+        event_timestamps=ts,
         corrected_timestamps=corrected_timestamps,
         timeForLightsTurnOn=0.0,
     )
@@ -237,7 +237,7 @@ def test_compute_psth_just_use_signal_true_z_scores_each_trial():
         naming="",
         just_use_signal=True,
         sampling_rate=10.0,
-        ts=ts,
+        event_timestamps=ts,
         corrected_timestamps=corrected_timestamps,
         timeForLightsTurnOn=0.0,
     )
@@ -268,7 +268,7 @@ def test_compute_psth_index_is_relative_to_lights_on_origin():
         naming="",
         just_use_signal=False,
         sampling_rate=sampling_rate,
-        ts=ts,
+        event_timestamps=ts,
         corrected_timestamps=corrected_timestamps,
         timeForLightsTurnOn=5.0,
     )
@@ -297,7 +297,7 @@ def test_compute_psth_index_shifts_with_lights_on_origin():
         naming="",
         just_use_signal=False,
         sampling_rate=10.0,
-        ts=ts,
+        event_timestamps=ts,
         corrected_timestamps=corrected_timestamps,
         timeForLightsTurnOn=0.0,
     )

--- a/tests/unit/analysis/test_standard_io.py
+++ b/tests/unit/analysis/test_standard_io.py
@@ -64,7 +64,7 @@ def test_write_zscore_creates_four_hdf5_files(tmp_path):
     dff = np.array([0.1, 0.2, 0.3])
     control_fit = np.array([2.0, 2.1, 2.2])
 
-    write_zscore(str(tmp_path), "dms", z_score, dff, control_fit, temp_control_arr=None)
+    write_zscore(str(tmp_path), "dms", z_score, dff, control_fit, synthetic_control=None)
 
     assert (tmp_path / "z_score_dms.hdf5").exists()
     assert (tmp_path / "dff_dms.hdf5").exists()
@@ -76,7 +76,7 @@ def test_write_zscore_creates_four_hdf5_files(tmp_path):
 def test_write_zscore_with_temp_control_writes_control_file(tmp_path):
     z_score = np.array([0.5])
     temp_control = np.array([1.0, np.nan, 2.0])
-    write_zscore(str(tmp_path), "dms", z_score, z_score, z_score, temp_control_arr=temp_control)
+    write_zscore(str(tmp_path), "dms", z_score, z_score, z_score, synthetic_control=temp_control)
 
     result = h5py.File(tmp_path / "control_dms.hdf5", "r")["data"][:]
     np.testing.assert_array_equal(result[0], 1.0)

--- a/tests/unit/analysis/test_transients.py
+++ b/tests/unit/analysis/test_transients.py
@@ -169,7 +169,7 @@ def test_analyze_transients_output_shapes_are_correct():
     timestamps = np.linspace(0, 4, 40)
 
     cleaned_z, cleaned_ts, peaks_ind, peaks_occurrences, arr = analyze_transients(
-        ts=timestamps,
+        timestamps=timestamps,
         window=2,
         numProcesses=1,
         highAmpFilt=3.0,


### PR DESCRIPTION
Closes #344.

Aggressive, behavior-preserving rename of vague identifiers across `src/guppy/` — `arr`, `d`, `ts`, `op`, `cols`, `idx`, `res`, `temp`, `msg`, and all suffixed `*_arr` names — to descriptive, context-appropriate names (the same old token maps to different names per function: `arr` → `concatenated_data` / `freq_and_amplitude` / `indices` / `fitted_control`, etc.). Vague function parameters were renamed too, and the affected test call sites updated to match.

Preserved as idiomatic/domain conventions (per CLAUDE.md's "acceptable exceptions"): loop counters `i`/`j`/`k`, math `x`/`y`/`n`, pandas `df`, matplotlib `fig`/`ax`, signal-processing `a`/`b`/`mad`/`dff`/`ttl`/`lag`/`p0`, format tokens, `key`, and module aliases.

An AST inventory of flagged identifiers dropped from ~403 to ~81, the remainder being those preserved idioms.

Behavior-preserving: the full `tests/consistency` suite passes (20 passed), and every touched module's unit tests pass. No function/method/class renames and no logic changes.

**Stacked on #377** (branched off `issue-174-deduplicate-code` to avoid conflicts) — base will retarget to `main` once #377 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)