### PR TITLE
Avoid global variables where possible (#133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - The Heat Map's first and last trial rows no longer render at half height: the Trials (Y) axis now always spans the full cell edges on every render, and its manual axis-limit boxes (which could clip the edge rows) were removed since the axis only encodes trial number. [PR #374](https://github.com/LernerLab/GuPPy/pull/374)
 
 ## Improvements
-- Removed global-variable state where avoidable: the Label Stores GUI's store selection now lives on the `StoreLabelingSelector` object instead of a module global shared through button callbacks, and the duplicated headless-mode check is centralized in a single `is_headless()` helper. [PR #NNN](https://github.com/LernerLab/GuPPy/pull/NNN)
+- Removed global-variable state where avoidable: the Label Stores GUI's store selection now lives on the `StoreLabelingSelector` object instead of a module global shared through button callbacks, and the duplicated headless-mode check is centralized in a single `is_headless()` helper. [PR #380](https://github.com/LernerLab/GuPPy/pull/380)
 - Renamed vague variable names (`arr`, `d`, `ts`, `op`, `cols`, suffixed `*_arr`, etc.) throughout `src/guppy/` to descriptive, context-appropriate names; behavior-preserving (consistency suite unchanged). [PR #378](https://github.com/LernerLab/GuPPy/pull/378)
 - Deduplicated copy-pasted code: shared timestamp-realignment kernels for artifact-removal and multi-session combining, a shared group-averaging preamble, a single pipeline-step launch helper in the homepage, and shared ndx-fiber-photometry boilerplate across the mock-NWB generators. [PR #377](https://github.com/LernerLab/GuPPy/pull/377)
 - Removed commented-out dead code throughout `src/guppy/` and clarified the remaining comments. [PR #376](https://github.com/LernerLab/GuPPy/pull/376)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - The Heat Map's first and last trial rows no longer render at half height: the Trials (Y) axis now always spans the full cell edges on every render, and its manual axis-limit boxes (which could clip the edge rows) were removed since the axis only encodes trial number. [PR #374](https://github.com/LernerLab/GuPPy/pull/374)
 
 ## Improvements
+- Removed global-variable state where avoidable: the Label Stores GUI's store selection now lives on the `StoreLabelingSelector` object instead of a module global shared through button callbacks, and the duplicated headless-mode check is centralized in a single `is_headless()` helper. [PR #NNN](https://github.com/LernerLab/GuPPy/pull/NNN)
 - Renamed vague variable names (`arr`, `d`, `ts`, `op`, `cols`, suffixed `*_arr`, etc.) throughout `src/guppy/` to descriptive, context-appropriate names; behavior-preserving (consistency suite unchanged). [PR #378](https://github.com/LernerLab/GuPPy/pull/378)
 - Deduplicated copy-pasted code: shared timestamp-realignment kernels for artifact-removal and multi-session combining, a shared group-averaging preamble, a single pipeline-step launch helper in the homepage, and shared ndx-fiber-photometry boilerplate across the mock-NWB generators. [PR #377](https://github.com/LernerLab/GuPPy/pull/377)
 - Removed commented-out dead code throughout `src/guppy/` and clarified the remaining comments. [PR #376](https://github.com/LernerLab/GuPPy/pull/376)

--- a/docs/take_screenshots.py
+++ b/docs/take_screenshots.py
@@ -236,12 +236,8 @@ def screenshot_label_stores_configured(page: Page, tmp_path: Path) -> None:
     selector = StoreLabelingSelector(allnames=events)
     selector.cross_selector.value = events
     selector.set_change_widgets(events)
-    selector.configure_store_ids(
-        store_id_dropdowns={},
-        store_id_textboxes={},
-        store_ids=events,
-        store_id_to_store_labels={},
-    )
+    selector.store_ids = events
+    selector.configure_store_ids(store_id_to_store_labels={})
 
     template = pn.template.BootstrapTemplate(title="Label Stores GUI - sample_data_csv_1")
     template.main.append(selector.widget)

--- a/src/guppy/frontend/store_labeling_selector.py
+++ b/src/guppy/frontend/store_labeling_selector.py
@@ -93,6 +93,14 @@ class StoreLabelingSelector:
         self.store_id_config_widgets = pn.Column(visible=False)
         self.show_config_button = pn.widgets.Button(name="Show Selected Configuration", width=600)
 
+        # Store-selection state shared across the GUI button callbacks. ``store_ids``
+        # is the list of store_ids the user selected; ``store_id_dropdowns`` and
+        # ``store_id_textboxes`` are populated by ``configure_store_ids`` and read
+        # back when the configuration is applied.
+        self.store_ids: list[str] = []
+        self.store_id_dropdowns: dict[str, pn.widgets.Select] = {}
+        self.store_id_textboxes: dict[str, pn.widgets.TextInput] = {}
+
         self.widget = pn.Column(
             self.repeat_stores,
             self.repeat_store_wd,
@@ -278,35 +286,27 @@ class StoreLabelingSelector:
         """
         return self._current_overwrite_mode
 
-    def configure_store_ids(
-        self,
-        store_id_dropdowns: dict[str, pn.widgets.Select],
-        store_id_textboxes: dict[str, pn.widgets.TextInput],
-        store_ids: list[str],
-        store_id_to_store_labels: dict[str, list[str]],
-    ) -> None:
-        """Build the store_id-configuration panel and make it visible.
+    def configure_store_ids(self, store_id_to_store_labels: dict[str, list[str]]) -> None:
+        """Build the store_id-configuration panel for ``self.store_ids`` and make it visible.
+
+        Reads the currently selected store_ids from ``self.store_ids`` and
+        populates ``self.store_id_dropdowns`` / ``self.store_id_textboxes`` with
+        the per-store dropdown and text-input widgets.
 
         Parameters
         ----------
-        store_id_dropdowns : dict
-            Mutable mapping populated by ``StoreLabelingConfig`` with dropdown widgets.
-        store_id_textboxes : dict
-            Mutable mapping populated by ``StoreLabelingConfig`` with text-input widgets.
-        store_ids : list of str
-            Raw store_ids selected by the user.
         store_id_to_store_labels : dict
             Previously saved store_id assignments for pre-population.
         """
         # Create Panel widgets for store_id configuration
         self.store_labeling_config = StoreLabelingConfig(
             show_config_button=self.show_config_button,
-            store_id_dropdowns=store_id_dropdowns,
-            store_id_textboxes=store_id_textboxes,
-            store_ids=store_ids,
+            store_id_dropdowns=self.store_id_dropdowns,
+            store_id_textboxes=self.store_id_textboxes,
+            store_ids=self.store_ids,
             store_id_to_store_labels=store_id_to_store_labels,
         )
 
         # Update the configuration panel
         self.store_id_config_widgets.objects = self.store_labeling_config.config_widgets
-        self.store_id_config_widgets.visible = len(store_ids) > 0
+        self.store_id_config_widgets.visible = len(self.store_ids) > 0

--- a/src/guppy/orchestration/preprocess.py
+++ b/src/guppy/orchestration/preprocess.py
@@ -42,14 +42,17 @@ from ..analysis.timestamp_correction import correct_timestamps
 from ..analysis.z_score import compute_z_score
 from ..frontend.artifact_removal import ArtifactRemovalWidget
 from ..frontend.progress import PB_STEPS_FILE, subprocess_main_handler, writeToFile
-from ..utils.utils import get_all_stores_for_combining_data, select_run_folders
+from ..utils.utils import (
+    get_all_stores_for_combining_data,
+    is_headless,
+    select_run_folders,
+)
 from ..visualization.preprocessing import visualize_preprocessing
 
 logger = logging.getLogger(__name__)
 
 # Only set matplotlib backend if not in CI or headless (GUPPY_BASE_DIR) environment
-headless = bool(os.environ.get("GUPPY_BASE_DIR"))
-if not os.getenv("CI") and not headless:
+if not os.getenv("CI") and not is_headless():
     plt.switch_backend("TKAgg")
 
 
@@ -295,8 +298,7 @@ def execute_zscore(session_folders: list[str], inputParameters: dict[str, object
         writeToFile(str(10 + ((inputParameters["step"] + 1) * 10)) + "\n", file_path=PB_STEPS_FILE)
         inputParameters["step"] += 1
 
-    headless = bool(os.environ.get("GUPPY_BASE_DIR"))
-    if not headless:
+    if not is_headless():
         plt.show()
     logger.info("Z-score computation completed.")
 
@@ -399,8 +401,7 @@ def execute_artifact_removal(session_folders: list[str], inputParameters: dict[s
         writeToFile(str(10 + ((inputParameters["step"] + 1) * 10)) + "\n", file_path=PB_STEPS_FILE)
         inputParameters["step"] += 1
 
-    headless = bool(os.environ.get("GUPPY_BASE_DIR"))
-    if not headless:
+    if not is_headless():
         visualize_artifact_removal(session_folders, inputParameters)
     logger.info("Artifact removal completed.")
 
@@ -555,8 +556,7 @@ def extractTsAndSignal(inputParameters: dict[str, object]) -> None:
         writeToFile(str((pbMaxValue + 1) * 10) + "\n" + str(10) + "\n", file_path=PB_STEPS_FILE)
         execute_timestamp_correction(session_folders, inputParameters)
         execute_zscore(session_folders, inputParameters)
-        headless = bool(os.environ.get("GUPPY_BASE_DIR"))
-        if not headless:
+        if not is_headless():
             visualize_z_score(inputParameters, session_folders)
         if remove_artifacts == True:
             execute_artifact_removal(session_folders, inputParameters)
@@ -568,8 +568,7 @@ def extractTsAndSignal(inputParameters: dict[str, object]) -> None:
         combined_output_folders = execute_combine_data(session_folders, inputParameters, store_array)
         write_combined_stores_list(combined_output_folders, store_array)
         execute_zscore(combined_output_folders, inputParameters)
-        headless = bool(os.environ.get("GUPPY_BASE_DIR"))
-        if not headless:
+        if not is_headless():
             visualize_z_score(inputParameters, combined_output_folders)
         if remove_artifacts == True:
             execute_artifact_removal(combined_output_folders, inputParameters)

--- a/src/guppy/orchestration/store_labeling.py
+++ b/src/guppy/orchestration/store_labeling.py
@@ -30,6 +30,7 @@ from guppy.frontend.store_labeling_selector import StoreLabelingSelector
 from guppy.utils.utils import (
     NPM_PARAM_KEYS,
     discover_run_folders,
+    is_headless,
     run_folder_for_run,
     validate_run_name,
     write_npm_params,
@@ -318,10 +319,6 @@ def build_store_labeling_template(
         store_labeling_instructions = StoreLabelingInstructions(folder_path=folder_path)
     store_labeling_selector = StoreLabelingSelector(allnames=allnames)
 
-    store_ids = []
-    store_id_dropdowns = {}
-    store_id_textboxes = {}
-
     # ------------------------------------------------------------------------------------------------------------------
     # onclick closure functions
     # on clicking overwrite_button, following function is executed
@@ -347,13 +344,12 @@ def build_store_labeling_template(
         store_labeling_selector.set_alert_message("#### No alerts !!")
 
     def fetchValues(event: object) -> None:
-        global store_ids
         store_labeling_config = dict()
         alert_message = _fetchValues(
             text=store_labeling_selector.text,
-            store_ids=store_ids,
-            store_id_dropdowns=store_id_dropdowns,
-            store_id_textboxes=store_id_textboxes,
+            store_ids=store_labeling_selector.store_ids,
+            store_id_dropdowns=store_labeling_selector.store_id_dropdowns,
+            store_id_textboxes=store_labeling_selector.store_id_textboxes,
             store_labeling_config=store_labeling_config,
             isosbestic_control=isosbestic_control,
         )
@@ -362,8 +358,6 @@ def build_store_labeling_template(
 
     # on clicking 'Select Stores' button, following function is executed
     def update_values(event: object) -> None:
-        global store_ids, vars_list
-
         take_widgets = store_labeling_selector.get_take_widgets()
         expanded_store_ids = []
         for i in range(len(take_widgets[1])):
@@ -373,6 +367,7 @@ def build_store_labeling_template(
             store_ids = store_labeling_selector.get_cross_selector() + expanded_store_ids
         else:
             store_ids = store_labeling_selector.get_cross_selector()
+        store_labeling_selector.store_ids = store_ids
         store_labeling_selector.set_change_widgets(store_ids)
 
         store_id_to_store_labels = dict()
@@ -380,16 +375,10 @@ def build_store_labeling_template(
             with open(os.path.join(Path.home(), ".storesList.json")) as f:
                 store_id_to_store_labels = json.load(f)
 
-        store_labeling_selector.configure_store_ids(
-            store_id_dropdowns=store_id_dropdowns,
-            store_id_textboxes=store_id_textboxes,
-            store_ids=store_ids,
-            store_id_to_store_labels=store_id_to_store_labels,
-        )
+        store_labeling_selector.configure_store_ids(store_id_to_store_labels=store_id_to_store_labels)
 
     # on clicking save button, following function is executed
     def save_button(event: object = None) -> None:
-        global store_ids
         store_labeling_config = store_labeling_selector.get_literal_input_2()
         select_location = store_labeling_selector.get_select_location()
         alert_message = _save(
@@ -602,7 +591,7 @@ def orchestrate_store_labeling_page(inputParameters: dict[str, object]) -> None:
     session_folders = inputParameters["session_folders"]
     isosbestic_control = inputParameters["isosbestic_control"]
     num_ch = inputParameters["noChannels"]
-    headless = bool(os.environ.get("GUPPY_BASE_DIR"))
+    headless = is_headless()
 
     logger.info(session_folders)
 

--- a/src/guppy/orchestration/transients.py
+++ b/src/guppy/orchestration/transients.py
@@ -21,7 +21,11 @@ from ..analysis.standard_io import (
 from ..analysis.transients import analyze_transients
 from ..analysis.transients_average import averageForGroup
 from ..frontend.progress import PB_STEPS_FILE, subprocess_main_handler, writeToFile
-from ..utils.utils import get_all_stores_for_combining_data, select_run_folders
+from ..utils.utils import (
+    get_all_stores_for_combining_data,
+    is_headless,
+    select_run_folders,
+)
 from ..visualization.transients import visualize_peaks
 
 logger = logging.getLogger(__name__)
@@ -196,7 +200,7 @@ def executeFindFreqAndAmp(inputParameters: dict[str, object]) -> None:
     if average == True:
         execute_average_for_group(inputParameters, group_session_folders)
     else:
-        headless = bool(os.environ.get("GUPPY_BASE_DIR"))
+        headless = is_headless()
         if combine_data == True:
             execute_find_freq_and_amp_combined(inputParameters, session_folders, moving_window, numProcesses)
             if not headless:

--- a/src/guppy/utils/utils.py
+++ b/src/guppy/utils/utils.py
@@ -16,6 +16,22 @@ NPM_PARAMS_FILENAME = ".npm_params.json"
 NPM_PARAM_KEYS = ("npm_split_events", "npm_time_units", "npm_timestamp_column_names")
 
 
+def is_headless() -> bool:
+    """Report whether GuPPy is running in headless/test mode.
+
+    Headless mode is signalled by the ``GUPPY_BASE_DIR`` environment variable,
+    which the testing API sets to bypass the Tk folder dialog. Code paths that
+    open GUI dialogs or interactive matplotlib backends should be skipped when
+    this returns ``True``.
+
+    Returns
+    -------
+    bool
+        ``True`` when ``GUPPY_BASE_DIR`` is set, ``False`` otherwise.
+    """
+    return bool(os.environ.get("GUPPY_BASE_DIR"))
+
+
 def write_npm_params(*, run_folder: str, npm_params: dict[str, object]) -> None:
     """Persist the NPM decomposition parameters for one output directory.
 

--- a/tests/unit/frontend/test_store_labeling_selector.py
+++ b/tests/unit/frontend/test_store_labeling_selector.py
@@ -64,20 +64,12 @@ class TestStoreLabelingSelector:
 
     def test_configure_store_ids_visible_when_store_ids_present(self, panel_extension):
         selector = StoreLabelingSelector(allnames=["Dv1A"])
-        selector.configure_store_ids(
-            store_id_dropdowns={},
-            store_id_textboxes={},
-            store_ids=["Dv1A"],
-            store_id_to_store_labels={},
-        )
+        selector.store_ids = ["Dv1A"]
+        selector.configure_store_ids(store_id_to_store_labels={})
         assert selector.store_id_config_widgets.visible is True
 
     def test_configure_store_ids_hidden_when_store_ids_empty(self, panel_extension):
         selector = StoreLabelingSelector(allnames=["Dv1A"])
-        selector.configure_store_ids(
-            store_id_dropdowns={},
-            store_id_textboxes={},
-            store_ids=[],
-            store_id_to_store_labels={},
-        )
+        selector.store_ids = []
+        selector.configure_store_ids(store_id_to_store_labels={})
         assert selector.store_id_config_widgets.visible is False

--- a/tests/unit/orchestration/test_preprocess.py
+++ b/tests/unit/orchestration/test_preprocess.py
@@ -2,9 +2,11 @@ import numpy as np
 import pytest
 
 from guppy.orchestration.preprocess import (
+    execute_artifact_removal,
     execute_combine_data,
     execute_preprocessing_visualization,
     execute_zscore,
+    extractTsAndSignal,
     visualize_artifact_removal,
     visualize_z_score,
     visualizeControlAndSignal,
@@ -254,3 +256,156 @@ def test_execute_zscore_shows_plot_when_not_headless(monkeypatch, base_input_par
 
     assert write_calls == [("/tmp/session_output_1", "DMS")]
     assert len(show_calls) == 1
+
+
+@pytest.fixture
+def stub_artifact_removal_io(monkeypatch):
+    """Patch execute_artifact_removal's disk I/O so only its visualization branch is exercised."""
+    monkeypatch.setattr(
+        "guppy.orchestration.preprocess.select_run_folders", lambda session, selected: ["/tmp/session_1/run_1"]
+    )
+    monkeypatch.setattr(
+        "guppy.orchestration.preprocess.np.genfromtxt", lambda *a, **k: np.array([["ctrl0"], ["control_dms"]])
+    )
+    monkeypatch.setattr("guppy.orchestration.preprocess.read_corrected_data_dict", lambda filepath, store_array: {})
+    monkeypatch.setattr("guppy.orchestration.preprocess.read_corrected_timestamps_pairwise", lambda filepath: ({}, {}))
+    monkeypatch.setattr("guppy.orchestration.preprocess.read_coords_pairwise", lambda filepath, tsNew: {})
+    monkeypatch.setattr(
+        "guppy.orchestration.preprocess.read_corrected_ttl_timestamps", lambda filepath, store_array: {}
+    )
+    monkeypatch.setattr("guppy.orchestration.preprocess.remove_artifacts", lambda *a, **k: ({}, {}, {}))
+    monkeypatch.setattr("guppy.orchestration.preprocess.write_artifact_removal", lambda *a, **k: None)
+    monkeypatch.setattr("guppy.orchestration.preprocess.writeToFile", lambda text, file_path: None)
+
+
+def test_execute_artifact_removal_visualizes_when_not_headless(
+    monkeypatch, base_input_parameters, stub_artifact_removal_io
+):
+    """When not headless, execute_artifact_removal calls visualize_artifact_removal after processing."""
+    base_input_parameters["combine_data"] = False
+    monkeypatch.delenv("GUPPY_BASE_DIR", raising=False)
+
+    visualize_calls = []
+    monkeypatch.setattr(
+        "guppy.orchestration.preprocess.visualize_artifact_removal",
+        lambda folders, params: visualize_calls.append((folders, params)),
+    )
+
+    execute_artifact_removal(["/tmp/session_1"], base_input_parameters)
+
+    assert visualize_calls == [(["/tmp/session_1"], base_input_parameters)]
+
+
+def test_execute_artifact_removal_skips_visualization_when_headless(
+    monkeypatch, base_input_parameters, stub_artifact_removal_io
+):
+    """When headless, execute_artifact_removal does not open the artifact-removal visualization."""
+    base_input_parameters["combine_data"] = False
+    monkeypatch.setenv("GUPPY_BASE_DIR", "/tmp/base")
+
+    visualize_calls = []
+    monkeypatch.setattr(
+        "guppy.orchestration.preprocess.visualize_artifact_removal",
+        lambda folders, params: visualize_calls.append((folders, params)),
+    )
+
+    execute_artifact_removal(["/tmp/session_1"], base_input_parameters)
+
+    assert visualize_calls == []
+
+
+@pytest.fixture
+def stub_extract_ts_and_signal_io(monkeypatch):
+    """Patch extractTsAndSignal's sub-steps so only its dispatch/visualization branches run."""
+    monkeypatch.setattr("guppy.orchestration.preprocess.save_parameters", lambda *, inputParameters: None)
+    monkeypatch.setattr(
+        "guppy.orchestration.preprocess.select_run_folders", lambda session, selected: ["/tmp/session_1/run_1"]
+    )
+    monkeypatch.setattr("guppy.orchestration.preprocess.writeToFile", lambda text, file_path: None)
+    monkeypatch.setattr("guppy.orchestration.preprocess.execute_timestamp_correction", lambda folders, params: None)
+    monkeypatch.setattr("guppy.orchestration.preprocess.execute_zscore", lambda folders, params: None)
+    monkeypatch.setattr(
+        "guppy.orchestration.preprocess.check_storeslistfile", lambda folders: np.array([["ctrl0"], ["control_dms"]])
+    )
+    monkeypatch.setattr(
+        "guppy.orchestration.preprocess.execute_combine_data", lambda folders, params, store_array: ["/tmp/combined_1"]
+    )
+    monkeypatch.setattr("guppy.orchestration.preprocess.write_combined_stores_list", lambda folders, store_array: None)
+
+
+def test_extract_ts_and_signal_visualizes_and_removes_artifacts_when_not_headless(
+    monkeypatch, base_input_parameters, stub_extract_ts_and_signal_io
+):
+    """Non-combine path: extractTsAndSignal visualizes z-score and runs artifact removal when not headless."""
+    base_input_parameters["session_folders"] = ["/tmp/session_1"]
+    base_input_parameters["combine_data"] = False
+    base_input_parameters["removeArtifacts"] = True
+    monkeypatch.delenv("GUPPY_BASE_DIR", raising=False)
+
+    visualize_calls = []
+    monkeypatch.setattr(
+        "guppy.orchestration.preprocess.visualize_z_score",
+        lambda params, folders: visualize_calls.append((params, folders)),
+    )
+    artifact_calls = []
+    monkeypatch.setattr(
+        "guppy.orchestration.preprocess.execute_artifact_removal",
+        lambda folders, params: artifact_calls.append((folders, params)),
+    )
+
+    extractTsAndSignal(base_input_parameters)
+
+    assert visualize_calls == [(base_input_parameters, ["/tmp/session_1"])]
+    assert artifact_calls == [(["/tmp/session_1"], base_input_parameters)]
+
+
+def test_extract_ts_and_signal_combine_visualizes_when_not_headless(
+    monkeypatch, base_input_parameters, stub_extract_ts_and_signal_io
+):
+    """Combine path: extractTsAndSignal visualizes z-score and runs artifact removal on the combined folders."""
+    base_input_parameters["session_folders"] = ["/tmp/session_1"]
+    base_input_parameters["combine_data"] = True
+    base_input_parameters["removeArtifacts"] = True
+    monkeypatch.delenv("GUPPY_BASE_DIR", raising=False)
+
+    visualize_calls = []
+    monkeypatch.setattr(
+        "guppy.orchestration.preprocess.visualize_z_score",
+        lambda params, folders: visualize_calls.append((params, folders)),
+    )
+    artifact_calls = []
+    monkeypatch.setattr(
+        "guppy.orchestration.preprocess.execute_artifact_removal",
+        lambda folders, params: artifact_calls.append((folders, params)),
+    )
+
+    extractTsAndSignal(base_input_parameters)
+
+    assert visualize_calls == [(base_input_parameters, ["/tmp/combined_1"])]
+    assert artifact_calls == [(["/tmp/combined_1"], base_input_parameters)]
+
+
+def test_extract_ts_and_signal_combine_skips_visualization_when_headless(
+    monkeypatch, base_input_parameters, stub_extract_ts_and_signal_io
+):
+    """Combine path when headless: z-score visualization is skipped but artifact removal still runs."""
+    base_input_parameters["session_folders"] = ["/tmp/session_1"]
+    base_input_parameters["combine_data"] = True
+    base_input_parameters["removeArtifacts"] = True
+    monkeypatch.setenv("GUPPY_BASE_DIR", "/tmp/base")
+
+    visualize_calls = []
+    monkeypatch.setattr(
+        "guppy.orchestration.preprocess.visualize_z_score",
+        lambda params, folders: visualize_calls.append((params, folders)),
+    )
+    artifact_calls = []
+    monkeypatch.setattr(
+        "guppy.orchestration.preprocess.execute_artifact_removal",
+        lambda folders, params: artifact_calls.append((folders, params)),
+    )
+
+    extractTsAndSignal(base_input_parameters)
+
+    assert visualize_calls == []
+    assert artifact_calls == [(["/tmp/combined_1"], base_input_parameters)]

--- a/tests/unit/orchestration/test_store_labeling.py
+++ b/tests/unit/orchestration/test_store_labeling.py
@@ -7,7 +7,6 @@ import panel as pn
 import pytest
 from conftest import STUBBED_TESTING_DATA
 
-import guppy.orchestration.store_labeling as store_labeling_module
 from guppy.extractors import NpmRecordingExtractor
 from guppy.orchestration.store_labeling import (
     _compute_npm_channel_previews,
@@ -542,6 +541,9 @@ class CapturingStoreLabelingSelector:
         self._take_widgets = [[], []]
         self._select_location_value = ""
         self.widget = types.SimpleNamespace()
+        self.store_ids = []
+        self.store_id_dropdowns = {}
+        self.store_id_textboxes = {}
         self.configure_store_ids_calls = []
 
     def set_select_location_options(self, options):
@@ -583,9 +585,9 @@ class CapturingStoreLabelingSelector:
     def get_overwrite_mode(self):
         return getattr(self, "_overwrite_mode_value", "create_new_file")
 
-    def configure_store_ids(self, store_id_dropdowns, store_id_textboxes, store_ids, store_id_to_store_labels):
+    def configure_store_ids(self, store_id_to_store_labels):
         self.configure_store_ids_calls.append(
-            {"store_ids": list(store_ids), "store_id_to_store_labels": dict(store_id_to_store_labels)}
+            {"store_ids": list(self.store_ids), "store_id_to_store_labels": dict(store_id_to_store_labels)}
         )
 
 
@@ -709,18 +711,18 @@ def test_run_name_input_changed_invalid_run_name_sets_alert(store_labeling_closu
 # ---------------------------------------------------------------------------
 
 
-def test_fetch_values_sets_alert_message_when_no_store_ids_configured(store_labeling_closures, monkeypatch):
+def test_fetch_values_sets_alert_message_when_no_store_ids_configured(store_labeling_closures):
     selector, _ = store_labeling_closures
-    monkeypatch.setattr(store_labeling_module, "store_ids", [], raising=False)
+    selector.store_ids = []
 
     selector.callbacks["show_config_button"](types.SimpleNamespace())
 
     assert "Alert" in selector.alert_message
 
 
-def test_fetch_values_always_calls_set_literal_input_2(store_labeling_closures, monkeypatch):
+def test_fetch_values_always_calls_set_literal_input_2(store_labeling_closures):
     selector, _ = store_labeling_closures
-    monkeypatch.setattr(store_labeling_module, "store_ids", [], raising=False)
+    selector.store_ids = []
 
     selector.callbacks["show_config_button"](types.SimpleNamespace())
 
@@ -729,9 +731,9 @@ def test_fetch_values_always_calls_set_literal_input_2(store_labeling_closures, 
 
 
 def test_fetch_values_delegates_to_fetch_values_function(store_labeling_closures, monkeypatch):
-    """fetchValues passes the module-level store_ids to _fetchValues and relays results to the selector."""
+    """fetchValues passes the selector's store_ids to _fetchValues and relays results to the selector."""
     selector, _ = store_labeling_closures
-    monkeypatch.setattr(store_labeling_module, "store_ids", ["Dv1A"], raising=False)
+    selector.store_ids = ["Dv1A"]
 
     captured_args = {}
 

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -5,6 +5,7 @@ from guppy.utils.utils import (
     NPM_PARAM_KEYS,
     discover_run_folders,
     get_all_stores_for_combining_data,
+    is_headless,
     load_npm_params,
     parse_run_name,
     read_Df,
@@ -377,3 +378,16 @@ def test_load_npm_params_returns_empty_when_file_absent(tmp_path):
     run_folder = tmp_path / "session_output_1"
     run_folder.mkdir()
     assert load_npm_params(str(run_folder)) == {}
+
+
+# ── is_headless ───────────────────────────────────────────────────────────────
+
+
+def test_is_headless_true_when_base_dir_set(monkeypatch):
+    monkeypatch.setenv("GUPPY_BASE_DIR", "/some/base/dir")
+    assert is_headless() is True
+
+
+def test_is_headless_false_when_base_dir_unset(monkeypatch):
+    monkeypatch.delenv("GUPPY_BASE_DIR", raising=False)
+    assert is_headless() is False


### PR DESCRIPTION
Addresses the "Avoid global variables where possible" checklist item in #133.

An inventory of `src/guppy/` turned up two avoidable module-global patterns:

- The Label Stores GUI kept its store selection in a module global (`store_ids`, declared `global` across three button callbacks, plus a dead `vars_list`), which leaked across GUI invocations. The selection now lives on the `StoreLabelingSelector` object as `store_ids`/`store_id_dropdowns`/`store_id_textboxes`, and `configure_store_ids` reads them from `self`.
- The `headless = bool(os.environ.get("GUPPY_BASE_DIR"))` check, duplicated across seven sites, is now a single `is_headless()` helper in `utils`.

The multiprocessing progress counter (`_SAMPLES_DONE`, installed via the pool initializer) is left as-is — it's the canonical pool-worker global that can't be passed as an argument.

Behavior-preserving; targeted unit + step-1/step-3 integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)