### PR TITLE
Soft-deprecate the concatenate artifact-removal method (#354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Features
 - Added a baseline-epoch mode for isosbestic control fitting: fit coefficients can now be estimated from a user-specified pre-injection window and applied across the whole recording, so a step-change (e.g. a drug injection) no longer corrupts the control fit. [PR #392](https://github.com/LernerLab/GuPPy/pull/392)
 - Added support for pynwb 4.0, including the new core `EventsTable` event type (NWB Schema 2.10.0); each `EventsTable` becomes a store, split into one store per unique value of its optional text `annotation` column. Dropped support for the `ndx-events` 0.4 extension, which is unreadable under pynwb 4.0. [PR #367](https://github.com/LernerLab/GuPPy/pull/367)
+- Soft-deprecated the `concatenate` artifact-removal method: `replace with NaN` is now the default because `concatenate` re-times the kept samples onto a fresh timeline, breaking alignment to the acquisition clock. [PR #396](https://github.com/LernerLab/GuPPy/pull/396)
 
 ## Fixes
 - Doric TTL/digital-event channels no longer drop the final event when a recording stops mid-pulse: onset detection now flags every observed low→high transition directly, instead of scanning for gaps between low samples (which could only see a pulse bracketed by a low sample on both sides, so a pulse still high at the last sample was silently dropped). [PR #395](https://github.com/LernerLab/GuPPy/pull/395)

--- a/src/guppy/frontend/input_parameters.py
+++ b/src/guppy/frontend/input_parameters.py
@@ -156,10 +156,13 @@ class ParameterForm:
                                 or "LedState".
                                 - ***removeArtifacts? :*** Make this parameter ``` True``` if there are
                                 artifacts and user wants to remove the artifacts.
-                                - ***removeArtifacts method :*** Selecting ```concatenate``` will remove bad
-                                chunks and concatenate the selected good chunks together.
-                                Selecting ```replace with NaN``` will replace bad chunks with NaN
-                                values.
+                                - ***removeArtifacts method :*** Selecting ```replace with NaN```
+                                (recommended, default) will replace bad chunks with NaN values,
+                                preserving the original recording timeline.
+                                Selecting ```concatenate``` will remove bad chunks and concatenate the
+                                selected good chunks together; this is discouraged because it re-times
+                                the kept samples onto a new timeline (breaking alignment to the
+                                acquisition clock) and is not supported by NWB export.
                                 """,
             width=350,
         )
@@ -241,7 +244,10 @@ class ParameterForm:
         )
 
         self.artifactsRemovalMethod = pn.widgets.Select(
-            name="removeArtifacts method", value="concatenate", options=["concatenate", "replace with NaN"], width=150
+            name="removeArtifacts method",
+            value="replace with NaN",
+            options=["concatenate", "replace with NaN"],
+            width=150,
         )
 
         self.no_channels_np = pn.widgets.IntInput(

--- a/tests/integration/test_integration_save_parameters.py
+++ b/tests/integration/test_integration_save_parameters.py
@@ -20,7 +20,7 @@ def default_parameters():
         "timeForLightsTurnOn": 1,
         "filter_window": 100,
         "removeArtifacts": False,
-        "artifactsRemovalMethod": "concatenate",
+        "artifactsRemovalMethod": "replace with NaN",
         "noChannels": 2,
         "zscore_method": "standard z-score",
         "baselineWindowStart": 0,

--- a/tests/unit/frontend/test_input_parameters.py
+++ b/tests/unit/frontend/test_input_parameters.py
@@ -176,7 +176,7 @@ class TestParameterForm:
         assert parameter_form.removeArtifacts.options == [True, False]
 
     def test_artifacts_removal_method_default(self, parameter_form):
-        assert parameter_form.artifactsRemovalMethod.value == "concatenate"
+        assert parameter_form.artifactsRemovalMethod.value == "replace with NaN"
         assert "concatenate" in parameter_form.artifactsRemovalMethod.options
         assert "replace with NaN" in parameter_form.artifactsRemovalMethod.options
 


### PR DESCRIPTION
Extracted from the stalled NWB-export PR #357 so the artifact fix can land in `main` on its own while the larger feature keeps cooking.

Flips the `removeArtifacts method` default from `concatenate` to `replace with NaN` and reworks the help text to discourage `concatenate`. See #354 for why `concatenate` is the wrong default — it re-times the kept samples onto a fresh timeline and breaks alignment to the acquisition clock.

Scope is just the frontend default + help text and the matching unit-test assertion. The NWB-export-specific abort (which refuses to export a `concatenate`-processed session) stays on the NWB-export branch, since it lives in a file that doesn't exist on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)