### PR TITLE
Add whole-session time-binned metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Features
 - Added a **Use Transients as Events?** parameter for spontaneous activity, where there is no external event to align to: the transients detected in each recording site now become that recording site's event timestamps, so the PSTH, peak and AUC are computed against them directly instead of requiring an artificial TTL file to be exported and re-imported by hand. [PR #424](https://github.com/LernerLab/GuPPy/pull/424)
 - Added tonic/basal fluorescence analysis for pharmacological experiments as a new optional **Tonic Analysis** step: name epoch windows (e.g. baseline vs. post-injection) per recording site on the preprocessed traces, and saving averages the z-score and ΔF/F over each window into `tonic_<recording_site>.h5`. The visualization's Tonic tab charts each epoch's change from a selectable baseline epoch as bars, alongside the windows shaded on the traces and a table of the absolute means. PSTH analysis is unaffected. [PR #397](https://github.com/LernerLab/GuPPy/pull/397)
+- Added a **Compute Binned Metrics?** parameter: the whole session can now be divided into fixed-width time bins, each reporting its mean z-score, mean ΔF/F and transient count, for correlating the signal against a behavioral measure scored on its own fixed schedule instead of against discrete events. Results are written per recording site and shown on a new **Binned** tab in Step 5. [PR #422](https://github.com/LernerLab/GuPPy/pull/422)
 
 ## Fixes
 

--- a/docs/reference/outputs.md
+++ b/docs/reference/outputs.md
@@ -36,16 +36,11 @@ Raw HDF5 written with h5py, following GuPPy's convention of one file per store w
 
 ### `.h5`
 
-A pandas DataFrame written with `DataFrame.to_hdf`, holding exactly one DataFrame under the key `df`, and read back through pandas rather than h5py. These are the PSTH, peak/AUC, transient-summary, cross-correlation and tonic tables.
+A pandas DataFrame written with `DataFrame.to_hdf`, holding exactly one DataFrame under the key `df`, and read back through pandas rather than h5py. These are the PSTH, peak/AUC, transient-summary, binned-metrics, cross-correlation and tonic tables.
 
 ### `.csv`
 
-Flat text. Inside a run folder: the store mappings (`storesList.csv`, `combine_storesList.csv`), tables that also exist as an `.h5` (peak/AUC, transient frequency and amplitude), and the two tables written as CSV only — `transientsOccurrences_<metric>.csv` and `tonic_epochs_<site>.csv`. The channel exports written outside the run folder are CSV too.
-A pandas DataFrame written with `DataFrame.to_hdf`, holding exactly one DataFrame under the key `df`, and read back through pandas rather than h5py. These are the PSTH, peak/AUC, transient-summary, binned-metrics and cross-correlation tables.
-
-### `.csv`
-
-Flat text. Inside a run folder: the store mappings (`storesList.csv`, `combine_storesList.csv`), tables that also exist as an `.h5` (peak/AUC, transient frequency and amplitude, binned metrics), and `transientsOccurrences_<metric>.csv`, the one table written as CSV only. The channel exports written outside the run folder are CSV too.
+Flat text. Inside a run folder: the store mappings (`storesList.csv`, `combine_storesList.csv`), tables that also exist as an `.h5` (peak/AUC, transient frequency and amplitude, binned metrics), and the two tables written as CSV only — `transientsOccurrences_<metric>.csv` and `tonic_epochs_<site>.csv`. The channel exports written outside the run folder are CSV too.
 
 ### `.npy`
 

--- a/docs/reference/outputs.md
+++ b/docs/reference/outputs.md
@@ -41,6 +41,11 @@ A pandas DataFrame written with `DataFrame.to_hdf`, holding exactly one DataFram
 ### `.csv`
 
 Flat text. Inside a run folder: the store mappings (`storesList.csv`, `combine_storesList.csv`), tables that also exist as an `.h5` (peak/AUC, transient frequency and amplitude), and the two tables written as CSV only — `transientsOccurrences_<metric>.csv` and `tonic_epochs_<site>.csv`. The channel exports written outside the run folder are CSV too.
+A pandas DataFrame written with `DataFrame.to_hdf`, holding exactly one DataFrame under the key `df`, and read back through pandas rather than h5py. These are the PSTH, peak/AUC, transient-summary, binned-metrics and cross-correlation tables.
+
+### `.csv`
+
+Flat text. Inside a run folder: the store mappings (`storesList.csv`, `combine_storesList.csv`), tables that also exist as an `.h5` (peak/AUC, transient frequency and amplitude, binned metrics), and `transientsOccurrences_<metric>.csv`, the one table written as CSV only. The channel exports written outside the run folder are CSV too.
 
 ### `.npy`
 
@@ -197,6 +202,7 @@ The means are computed at save time from the traces then on disk, and the differ
 | `transientsOccurrences_<metric>.csv` | One row per detected transient |
 | `transient_outputs_<metric>.hdf5` | The trace and peak indices behind the transient results |
 | `transients_<metric>.hdf5` | The transient times as an event train, **Use Transients as Events?** runs only |
+| `binned_metrics_<site>.h5` and `.csv` | One row per fixed-width time bin, when **Compute Binned Metrics?** is enabled |
 | `cross_correlation_output/corr_<event>_<metric-prefix>_<siteA>_<siteB>.h5` | Cross-correlation between two recording sites |
 
 **The PSTH files** hold a `float32` DataFrame under the key `df`, with one row per time point in the peri-event window. The columns, in order: one column per trial, labeled with that trial's event timestamp as a string; then, when trial binning is enabled, a `bin_(<label>)` and `bin_err_(<label>)` pair per bin; then `timestamps` (the peri-event time axis, running from `-nSecPrev` to `+nSecPost`); then `mean` and `err`, the mean and standard error across the single-trial columns only. The `_baselineUncorrected_` file is the same table before the baseline correction was subtracted.
@@ -210,6 +216,14 @@ The means are computed at save time from the traces then on disk, and the differ
 **`transient_outputs_<metric>.hdf5`** holds the inputs the transient plot is drawn from: `z_score` (the NaN-free trace the detector ran on), `timestamps`, and `peaksInd` (the integer indices of the detected peaks within that trace).
 
 **`transients_<metric>.hdf5`** appears only when **Use Transients as Events?** is on. It holds a single dataset `ts` — the detected transient times — in exactly the shape of an `<event>_<site>.hdf5` event file, which is how the transients stand in for a TTL train. The event label is `transients_z_score` (or `transients_dff`), so the recording site is the metric's own site: `transients_z_score_DMS.hdf5` is the DMS transient train, and the PSTH computed from it lands in `transients_z_score_DMS_z_score_DMS.h5` with a matching `peak_AUC_` pair. As with any event file, Step 4 rewrites `ts` in place with the subset of transients the PSTH actually used.
+
+**`binned_metrics_<site>.h5` and `.csv`** are written only when **Compute Binned Metrics?** is enabled. They hold the same table: one row per fixed-width time bin, indexed `0..n-1` (index name `bin`). The columns are `bin_start` and `bin_end` (seconds of absolute session time, on the same timebase as `timestampNew`), `n_samples`, `mean_zscore`, `mean_dff`, and a `transient_count_z_score` and/or `transient_count_dff` column.
+
+Bins start at the first corrected timestamp and run in **Bin Width** steps to the last. The final bin is kept even when the session does not divide evenly, so it may be shorter than the rest — compare `bin_end - bin_start` against the others to spot it. Bins are half-open, `[bin_start, bin_end)`, except the last, which includes its own end; the transient counts follow the same convention. `n_samples` counts the samples behind the means, so a bin lost entirely to artifact removal reads `0` with `NaN` means.
+
+Which count columns appear depends on **z_score and/or ΔF/F? (transients)**: the detector only runs on the metrics you select, and only those get a count column. The two mean columns are always present.
+
+Two cases where a bin does not correspond to a fixed stretch of wall-clock time: with **Combine Data?** enabled the sessions are re-timed onto one synthetic timeline, so a bin can straddle the boundary between two of them; and with the `concatenate` artifact-removal method the time axis is compressed where artifacts were cut, so a 60-second bin spans more than 60 seconds of the original recording.
 
 **The cross-correlation files** hold a `float32` DataFrame under the key `df`, one row per lag. Columns are the trial labels the two recording sites have in common, then `timestamps`, then `mean` and `err`. Despite its name, the `timestamps` column holds **lag values in seconds**, not times. Cross-correlation cannot run on a recording processed with the `concatenate` artifact-removal method; Step 4 raises instead.
 
@@ -276,7 +290,7 @@ The group PSTH has the same shape as a per-session PSTH, but its trial columns a
 
 A JSON snapshot of the analysis parameters, written into every run folder the step operated on. Each of Steps 2, 3 and 4 rewrites it, so the file always reflects the most recent step to touch that run. Group averaging is the one exception: it writes no snapshot into `average/`. When a session has no run folder yet, the snapshot is written at the session folder root instead.
 
-The first key is `guppy_version`, the installed version of the `guppy-neuro` package that produced the run. The rest are the analysis parameters themselves: `combine_data`, `isosbestic_control`, `control_fit_method`, `controlFitWindowMode`, `controlFitWindowStart`, `controlFitWindowEnd`, `photobleaching_detrend`, `timeForLightsTurnOn`, `filter_window`, `removeArtifacts`, `artifactsRemovalMethod`, `noChannels`, `zscore_method`, `baselineWindowStart`, `baselineWindowEnd`, `nSecPrev`, `nSecPost`, `computeCorr`, `useTransientsAsEvents`, `timeInterval`, `bin_psth_trials`, `use_time_or_trials`, `baselineCorrectionStart`, `baselineCorrectionEnd`, `peak_startPoint`, `peak_endPoint`, `auc_units`, `selectForComputePsth`, `selectForTransientsComputation`, `moving_window`, `highAmpFilt`, `transientsThresh`, `visualize_zscore_or_dff` and `averageForGroup`. See the [Input parameter reference](parameters.md) for what each one controls.
+The first key is `guppy_version`, the installed version of the `guppy-neuro` package that produced the run. The rest are the analysis parameters themselves: `combine_data`, `isosbestic_control`, `control_fit_method`, `controlFitWindowMode`, `controlFitWindowStart`, `controlFitWindowEnd`, `photobleaching_detrend`, `timeForLightsTurnOn`, `filter_window`, `removeArtifacts`, `artifactsRemovalMethod`, `noChannels`, `zscore_method`, `baselineWindowStart`, `baselineWindowEnd`, `nSecPrev`, `nSecPost`, `computeCorr`, `useTransientsAsEvents`, `timeInterval`, `bin_psth_trials`, `use_time_or_trials`, `baselineCorrectionStart`, `baselineCorrectionEnd`, `peak_startPoint`, `peak_endPoint`, `auc_units`, `selectForComputePsth`, `selectForTransientsComputation`, `moving_window`, `highAmpFilt`, `transientsThresh`, `computeBinnedMetrics`, `binnedMetricsWidth`, `visualize_zscore_or_dff` and `averageForGroup`. See the [Input parameter reference](parameters.md) for what each one controls.
 
 `removeArtifacts` and `artifactsRemovalMethod` describe what was applied to that run rather than what the form currently holds: each step carries them forward from whatever the run folder already records. Saving artifact windows patches these two keys in place and leaves everything else untouched.
 
@@ -335,6 +349,8 @@ The first key is `guppy_version`, the installed version of the `guppy-neuro` pac
     freqAndAmp_<metric>.csv                        step 4
     transientsOccurrences_<metric>.csv             step 4
     transient_outputs_<metric>.hdf5                step 4   z_score, timestamps, peaksInd
+    binned_metrics_<site>.h5                       step 4   DataFrame, key "df"
+    binned_metrics_<site>.csv                      step 4
     cross_correlation_output/
       corr_<event>_<metric-prefix>_<siteA>_<siteB>.h5   step 4   DataFrame, key "df"
     saved_plots/                                   step 5, created empty

--- a/docs/reference/parameters.md
+++ b/docs/reference/parameters.md
@@ -113,6 +113,19 @@ The largest card on the homepage, collapsed by default (only Input Folder Select
 
 **TD Thresh** (Transients Detection threshold) is the detection threshold proper: local maxima exceeding this multiple of MAD above the median (computed after the high-amplitude filter) are flagged as transients.
 
+### Binned metrics
+
+*Used by: Step 4 (Compute the PSTH), after transient detection.*
+
+| Parameter | Description | Type | Default | Options / range |
+|-----------|-------------|------|---------|-----------------|
+| Compute Binned Metrics? | Reduce the whole session to one row per fixed time bin. | bool | `False` | `True` / `False` |
+| Bin Width (s) | Width of those bins. | int | `120` | positive seconds |
+
+**Compute Binned Metrics?** divides the whole recording into equal time bins and reports, for each bin and each recording site, the mean z-score, the mean ΔF/F and the number of transients detected in it. Use it when you want to relate the signal to something measured on its own fixed schedule across the session — a behavior score rated every couple of minutes, say — rather than to discrete events. The results are written as `binned_metrics_<site>.csv` and `.h5`, and shown on the **Binned** tab in Step 5. Off by default; see the [output data model](outputs.md#step-4-compute-the-psth) for the exact table.
+
+**Bin Width (s)** is how wide each bin is. Bins start at the first corrected timestamp; the last bin is kept even when the session does not divide evenly, so it can be shorter than the rest. Whole seconds only.
+
 ### Format-specific (Neurophotometrics)
 
 *Used by: Step 2 (Load the raw data) when the recording is an NPM CSV without `Flags` or `LedState` columns.*
@@ -261,7 +274,9 @@ The table is sorted alphabetically by internal name. Each row links to the secti
 | `baselineWindowEnd` | Baseline Window End Time (s) | [Z-score Parameters](#z-score-parameters) |
 | `baselineWindowStart` | Baseline Window Start Time (s) | [Z-score Parameters](#z-score-parameters) |
 | `bin_psth_trials` | Time(min) / # of trials for binning | [PSTH Parameters](#psth-parameters) |
+| `binnedMetricsWidth` | Bin Width (s) | [Binned metrics](#binned-metrics) |
 | `combine_data` | Combine Data? | [Compute and batching](#compute-and-batching) |
+| `computeBinnedMetrics` | Compute Binned Metrics? | [Binned metrics](#binned-metrics) |
 | `computeCorr` | Compute Cross-correlation | [PSTH Parameters](#psth-parameters) |
 | `control_fit_method` | Control Channel Fitting Method | [Signal preprocessing](#signal-preprocessing) |
 | `controlFitWindowEnd` | Control Fit Window End Time (s) | [Signal preprocessing](#signal-preprocessing) |

--- a/src/guppy/analysis/binned_metrics.py
+++ b/src/guppy/analysis/binned_metrics.py
@@ -1,0 +1,162 @@
+"""Whole-session time-binned metrics.
+
+Some experiments score a continuous behavioral variable at a coarse cadence --
+akinesia severity rated once every two minutes, say -- and ask how the photometry
+signal tracks it. That question needs the session reduced to one value per fixed
+time bin rather than to event-triggered averages. This module tiles a recording
+into fixed-width bins and reduces each bin to a mean z-score, a mean dF/F and a
+count of detected transients.
+
+The tiling is derived from the recording alone: bins start at the first timestamp
+and run in ``bin_width`` steps to the last. The final bin is kept even when it is
+shorter than the others, and its true bounds are reported so a caller can drop it.
+"""
+
+import logging
+
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+# A final bin narrower than this fraction of bin_width is a floating-point
+# artifact of snapping the last edge, not a real bin.
+_SLIVER_TOLERANCE = 1e-9
+
+
+def compute_bin_edges(*, start: float, end: float, bin_width: float) -> np.ndarray:
+    """Tile ``[start, end]`` with bins of ``bin_width``, keeping a short final bin.
+
+    Parameters
+    ----------
+    start, end : float
+        First and last timestamps (s) of the recording.
+    bin_width : float
+        Bin width in seconds.
+
+    Returns
+    -------
+    np.ndarray
+        Monotonically increasing bin edges, ``n_bins + 1`` of them. The first is
+        ``start`` and the last is exactly ``end``.
+
+    Raises
+    ------
+    ValueError
+        If ``bin_width`` is not positive, or ``end`` is not after ``start``.
+    """
+    if not bin_width > 0:
+        message = f"bin_width={bin_width} must be positive; choose a bin width greater than 0 seconds."
+        logger.error(message)
+        raise ValueError(message)
+    if not end > start:
+        message = (
+            f"The recording spans [{start:.4g}, {end:.4g}]s, which has no duration to bin; "
+            "check that preprocessing produced a corrected time axis."
+        )
+        logger.error(message)
+        raise ValueError(message)
+
+    n_bins = int(np.ceil((end - start) / bin_width))
+    edges = start + bin_width * np.arange(n_bins + 1, dtype=float)
+    # The last edge lands on or past `end`; snap it back so no bin claims time
+    # the recording does not cover.
+    edges[-1] = end
+
+    # Snapping can leave a zero-width final bin when the duration is an exact
+    # multiple of bin_width but rounds up, which np.histogram rejects.
+    if n_bins > 1 and edges[-1] - edges[-2] < _SLIVER_TOLERANCE * bin_width:
+        edges = np.delete(edges, -2)
+
+    return edges
+
+
+def _bin_sums_and_counts(*, trace: np.ndarray, bin_index: np.ndarray, n_bins: int) -> tuple[np.ndarray, np.ndarray]:
+    """Sum ``trace`` and count its finite samples within each bin."""
+    finite = ~np.isnan(trace)
+    sums = np.bincount(bin_index[finite], weights=trace[finite], minlength=n_bins)
+    counts = np.bincount(bin_index[finite], minlength=n_bins)
+    return sums, counts
+
+
+def _bin_mean(*, trace: np.ndarray, bin_index: np.ndarray, n_bins: int) -> tuple[np.ndarray, np.ndarray]:
+    """Mean of ``trace`` within each bin, NaN where the bin holds no finite sample."""
+    sums, counts = _bin_sums_and_counts(trace=trace, bin_index=bin_index, n_bins=n_bins)
+    # np.maximum guards the division only; the where() picks NaN for empty bins.
+    return np.where(counts > 0, sums / np.maximum(counts, 1), np.nan), counts
+
+
+def compute_binned_metrics(
+    *,
+    z_score: np.ndarray,
+    dff: np.ndarray,
+    timestamps: np.ndarray,
+    transient_timestamps: dict[str, np.ndarray],
+    bin_width: float,
+) -> pd.DataFrame:
+    """Reduce a whole session to one row per fixed-width time bin.
+
+    Bins are half-open -- a sample at an interior edge belongs to the bin that
+    edge opens -- except the final bin, which includes its own end. Transient
+    counts follow the same convention, so a transient and the samples around it
+    are always attributed to the same bin.
+
+    Parameters
+    ----------
+    z_score, dff : np.ndarray
+        Full-session preprocessed traces for a single recording site, sampled on
+        ``timestamps``.
+    timestamps : np.ndarray
+        Corrected time axis (s) shared by both traces, monotonically increasing.
+    transient_timestamps : dict of str to np.ndarray
+        Detected transient occurrence times (s), keyed by the metric they were
+        detected on (``"z_score"`` and/or ``"dff"``). One
+        ``transient_count_<metric>`` column is produced per entry.
+    bin_width : float
+        Bin width in seconds.
+
+    Returns
+    -------
+    pd.DataFrame
+        One row per bin, indexed ``0..n_bins-1`` (index name ``"bin"``), with
+        columns ``bin_start``, ``bin_end``, ``n_samples``, ``mean_zscore``,
+        ``mean_dff``, and one ``transient_count_<metric>`` per entry in
+        ``transient_timestamps``. ``n_samples`` counts the finite samples behind
+        the means, so a bin lost to artifact removal reads ``0`` with NaN means.
+
+    Raises
+    ------
+    ValueError
+        If ``bin_width`` is not positive, or the recording has no duration.
+    """
+    z_score = np.asarray(z_score, dtype=float).ravel()
+    dff = np.asarray(dff, dtype=float).ravel()
+    timestamps = np.asarray(timestamps, dtype=float).ravel()
+
+    edges = compute_bin_edges(start=float(timestamps[0]), end=float(timestamps[-1]), bin_width=bin_width)
+    n_bins = edges.shape[0] - 1
+
+    # side="right" gives half-open [edge_k, edge_k+1); clipping folds the sample
+    # sitting exactly on the final edge into the last bin.
+    bin_index = np.searchsorted(edges, timestamps, side="right") - 1
+    np.clip(bin_index, 0, n_bins - 1, out=bin_index)
+
+    mean_zscore, n_samples = _bin_mean(trace=z_score, bin_index=bin_index, n_bins=n_bins)
+    mean_dff, _ = _bin_mean(trace=dff, bin_index=bin_index, n_bins=n_bins)
+
+    binned = pd.DataFrame(
+        {
+            "bin_start": edges[:-1],
+            "bin_end": edges[1:],
+            "n_samples": n_samples,
+            "mean_zscore": mean_zscore,
+            "mean_dff": mean_dff,
+        },
+        index=pd.RangeIndex(n_bins, name="bin"),
+    )
+
+    for metric in sorted(transient_timestamps):
+        occurrences = np.asarray(transient_timestamps[metric], dtype=float).ravel()
+        binned["transient_count_" + metric] = np.histogram(occurrences, bins=edges)[0]
+
+    return binned

--- a/src/guppy/analysis/io_utils.py
+++ b/src/guppy/analysis/io_utils.py
@@ -91,6 +91,35 @@ def recording_site_from_preprocessed_label(label: str) -> str:
     return label
 
 
+def metric_from_preprocessed_label(label: str) -> str:
+    """
+    Return the metric name of a ``z_score_*`` / ``dff_*`` label or basename.
+
+    Parameters
+    ----------
+    label : str
+        Label or extension-stripped basename, e.g. ``"z_score_left_hemisphere"``.
+
+    Returns
+    -------
+    str
+        ``"z_score"`` or ``"dff"``.
+
+    Raises
+    ------
+    ValueError
+        If the label carries neither prefix.
+    """
+    if label.startswith(ZSCORE_PREFIX):
+        return ZSCORE_PREFIX.rstrip("_")
+    if label.startswith(DFF_PREFIX):
+        return DFF_PREFIX.rstrip("_")
+
+    message = f"Preprocessed label {label!r} starts with neither {ZSCORE_PREFIX!r} nor {DFF_PREFIX!r}."
+    logger.error(message)
+    raise ValueError(message)
+
+
 def recording_site_from_channel_path(path: str) -> str:
     """
     Return the recording-site name of a ``control_*`` / ``signal_*`` HDF5 file path.

--- a/src/guppy/analysis/standard_io.py
+++ b/src/guppy/analysis/standard_io.py
@@ -876,3 +876,63 @@ def read_transients_from_hdf5(filepath: str, name: str) -> tuple[np.ndarray, np.
     timestamps = read_hdf5(event, filepath, "timestamps")
     peaksInd = read_hdf5(event, filepath, "peaksInd")
     return z_score, timestamps, peaksInd
+
+
+def write_binned_metrics_to_hdf5(filepath: str, binned_metrics: pd.DataFrame, recording_site: str) -> None:
+    """
+    Save whole-session time-binned metrics to an HDF5 file.
+
+    Parameters
+    ----------
+    filepath : str
+        Output directory.
+    binned_metrics : pd.DataFrame
+        One row per time bin, as returned by
+        :func:`guppy.analysis.binned_metrics.compute_binned_metrics`.
+    recording_site : str
+        Recording site name; the file is written as ``binned_metrics_<recording_site>.h5``.
+    """
+    output_path = os.path.join(filepath, "binned_metrics_" + recording_site + ".h5")
+
+    binned_metrics.to_hdf(output_path, key="df", mode="w")
+
+
+def write_binned_metrics_to_csv(filepath: str, binned_metrics: pd.DataFrame, recording_site: str) -> None:
+    """
+    Save whole-session time-binned metrics to a CSV file.
+
+    Parameters
+    ----------
+    filepath : str
+        Output directory.
+    binned_metrics : pd.DataFrame
+        One row per time bin, as returned by
+        :func:`guppy.analysis.binned_metrics.compute_binned_metrics`.
+    recording_site : str
+        Recording site name; the file is written as ``binned_metrics_<recording_site>.csv``.
+    """
+    output_path = os.path.join(filepath, "binned_metrics_" + recording_site + ".csv")
+
+    binned_metrics.to_csv(output_path)
+
+
+def read_binned_metrics_from_hdf5(filepath: str, recording_site: str) -> pd.DataFrame:
+    """
+    Load whole-session time-binned metrics from an HDF5 file.
+
+    Parameters
+    ----------
+    filepath : str
+        Directory containing the ``binned_metrics_<recording_site>.h5`` file.
+    recording_site : str
+        Recording site name (without the ``binned_metrics_`` prefix or ``.h5`` suffix).
+
+    Returns
+    -------
+    binned_metrics : pd.DataFrame
+        One row per time bin.
+    """
+    output_path = os.path.join(filepath, "binned_metrics_" + recording_site + ".h5")
+    binned_metrics = pd.read_hdf(output_path, key="df", mode="r")
+
+    return binned_metrics

--- a/src/guppy/frontend/binned_metrics_view.py
+++ b/src/guppy/frontend/binned_metrics_view.py
@@ -1,0 +1,130 @@
+"""Step-5 dashboard tab for whole-session time-binned metrics.
+
+Reads the ``binned_metrics_<site>.h5`` tables Step 4 wrote and plots the selected
+metric as bars under the trace it was reduced from. Sessions analysed without the
+binned metrics parameter have no such tables, so the tab renders a short note
+instead and can be added to the dashboard unconditionally.
+"""
+
+import glob
+import logging
+import os
+
+import holoviews as hv
+import numpy as np
+import panel as pn
+
+from ..analysis.io_utils import read_hdf5
+from ..analysis.standard_io import read_binned_metrics_from_hdf5
+from ..visualization.binned_metrics import build_binned_metrics_panel
+
+logger = logging.getLogger(__name__)
+
+_FILE_PREFIX = "binned_metrics_"
+
+# Column -> (menu label, axis label, the trace the metric was reduced from).
+_METRICS = {
+    "mean_zscore": ("Mean z-score", "mean z-score", "z_score"),
+    "mean_dff": ("Mean ΔF/F", "mean ΔF/F", "dff"),
+    "transient_count_z_score": ("Transient count (z-score)", "transients per bin", "z_score"),
+    "transient_count_dff": ("Transient count (ΔF/F)", "transients per bin", "dff"),
+}
+
+_TRACE_LABELS = {"z_score": "z-score", "dff": "ΔF/F"}
+
+
+def binned_metrics_sites(filepath: str) -> list[str]:
+    """Return the recording sites with binned metrics in ``filepath``, sorted.
+
+    Parameters
+    ----------
+    filepath : str
+        Session output directory.
+
+    Returns
+    -------
+    list of str
+        Recording site names, empty when the session has no binned metrics.
+    """
+    paths = glob.glob(os.path.join(filepath, _FILE_PREFIX + "*.h5"))
+    return sorted(os.path.basename(path)[len(_FILE_PREFIX) : -len(".h5")] for path in paths)
+
+
+class BinnedMetricsView:
+    """Site and metric selectors over the binned metrics of one session.
+
+    Parameters
+    ----------
+    filepath : str
+        Session output directory holding the ``binned_metrics_<site>.h5`` tables.
+    """
+
+    def __init__(self, filepath: str) -> None:
+        self.filepath = filepath
+        self.sites = binned_metrics_sites(filepath)
+
+        self.site_select = pn.widgets.Select(name="Recording site", options=self.sites, value=self.sites[0], width=220)
+        self.metric_select = pn.widgets.Select(name="Metric", options=self._metric_options(self.sites[0]), width=220)
+        self.plot_pane = pn.pane.HoloViews(self._make_plot(), sizing_mode="stretch_width")
+
+        self.site_select.param.watch(self._on_site_change, "value")
+        self.metric_select.param.watch(self._on_metric_change, "value")
+
+    def _metric_options(self, site: str) -> dict[str, str]:
+        """Menu label -> column, for the metric columns this site actually has."""
+        columns = read_binned_metrics_from_hdf5(self.filepath, site).columns
+        return {_METRICS[column][0]: column for column in _METRICS if column in columns}
+
+    def _make_plot(self) -> hv.Layout:
+        site = self.site_select.value
+        column = self.metric_select.value
+        _, value_label, trace_name = _METRICS[column]
+
+        binned_metrics = read_binned_metrics_from_hdf5(self.filepath, site)
+        timestamps = np.asarray(read_hdf5("timeCorrection_" + site, self.filepath, "timestampNew")).ravel()
+        trace = np.asarray(read_hdf5(trace_name + "_" + site, self.filepath, "data")).ravel()
+
+        return build_binned_metrics_panel(
+            timestamps=timestamps,
+            trace=trace,
+            trace_label=_TRACE_LABELS[trace_name],
+            bin_starts=binned_metrics["bin_start"].to_numpy(),
+            bin_ends=binned_metrics["bin_end"].to_numpy(),
+            values=binned_metrics[column].to_numpy(),
+            value_label=value_label,
+            suptitle=site,
+        )
+
+    def _on_site_change(self, event: object) -> None:
+        # A different site may have been analysed with a different transient
+        # selection, so the metric menu is rebuilt before the plot is redrawn.
+        self.metric_select.options = self._metric_options(self.site_select.value)
+        self.plot_pane.object = self._make_plot()
+
+    def _on_metric_change(self, event: object) -> None:
+        self.plot_pane.object = self._make_plot()
+
+    @property
+    def widget(self) -> pn.Column:
+        """The composed selectors and plot."""
+        return pn.Column(pn.Row(self.site_select, self.metric_select), self.plot_pane)
+
+
+def build_binned_metrics_view(filepath: str) -> pn.Column:
+    """Build the Binned tab for one session.
+
+    Parameters
+    ----------
+    filepath : str
+        Session output directory.
+
+    Returns
+    -------
+    pn.Column
+        The selectors and plot, or a short note when the session was analysed
+        without binned metrics.
+    """
+    if not binned_metrics_sites(filepath):
+        return pn.Column(pn.pane.Markdown("_No binned metrics in this session._"))
+
+    return BinnedMetricsView(filepath).widget

--- a/src/guppy/frontend/input_parameters.py
+++ b/src/guppy/frontend/input_parameters.py
@@ -156,6 +156,13 @@ class ParameterForm:
                                 - ***Transients detection threshold (TD Thresh):*** Peaks with local maxima greater than x times
                                 the MAD above the median of the trace (after filtering high amplitude events) are detected
                                 as transients. Here, x is transients detection threshold. Default is 3.
+                                - ***Compute Binned Metrics? :*** Make this parameter ``` True ``` to divide the
+                                whole session into equal time bins and report the mean z-score, mean &#916;F/F and
+                                number of transients in each one. Useful for correlating the signal against a
+                                behavioral measure scored at a fixed cadence. Default is ``` False ```.<br>
+                                - ***Bin Width :*** Width of those bins in seconds. The last bin is kept even
+                                when the session does not divide evenly, so it may be shorter than the rest.
+                                Default is 120 seconds.<br>
                                 - ***Number of channels (Neurophotometrics only) :*** Number of
                                 channels used while recording, when data files has no column names mentioning "Flags"
                                 or "LedState".
@@ -227,6 +234,12 @@ class ParameterForm:
         self.highAmpFilt = pn.widgets.IntInput(name="HAFT (int)", value=2, width=150)
 
         self.transientsThresh = pn.widgets.IntInput(name="TD Thresh (int)", value=3, width=150)
+
+        self.computeBinnedMetrics = pn.widgets.Select(
+            name="Compute Binned Metrics? (bool)", options=[True, False], value=False, width=200
+        )
+
+        self.binnedMetricsWidth = pn.widgets.IntInput(name="Bin Width (s) (int)", value=120, width=150)
 
         self.moving_avg_filter = pn.widgets.IntInput(
             name="Window for Moving Average filter (int)", value=100, width=320
@@ -392,6 +405,7 @@ class ParameterForm:
             self.transients,
             self.moving_wd,
             pn.Row(self.highAmpFilt, self.transientsThresh),
+            pn.Row(self.computeBinnedMetrics, self.binnedMetricsWidth),
             self.no_channels_np,
         )
 
@@ -678,6 +692,7 @@ class ParameterForm:
         validate_positive(value=self.moving_wd.value, name="moving_window")
         validate_positive(value=self.highAmpFilt.value, name="highAmpFilt")
         validate_positive(value=self.transientsThresh.value, name="transientsThresh")
+        validate_positive(value=self.binnedMetricsWidth.value, name="binnedMetricsWidth")
 
         if self.nSecPrev.value >= self.nSecPost.value:
             message = (
@@ -749,6 +764,8 @@ class ParameterForm:
             "moving_window": self.moving_wd.value,
             "highAmpFilt": self.highAmpFilt.value,
             "transientsThresh": self.transientsThresh.value,
+            "computeBinnedMetrics": self.computeBinnedMetrics.value,
+            "binnedMetricsWidth": self.binnedMetricsWidth.value,
             "visualize_zscore_or_dff": self.visualize_zscore_or_dff.value,
             "group_session_folders": self.files_2.value,
             "averageForGroup": self.averageForGroup.value,
@@ -801,6 +818,8 @@ class ParameterForm:
             "moving_window": self.moving_wd,
             "highAmpFilt": self.highAmpFilt,
             "transientsThresh": self.transientsThresh,
+            "computeBinnedMetrics": self.computeBinnedMetrics,
+            "binnedMetricsWidth": self.binnedMetricsWidth,
             "visualize_zscore_or_dff": self.visualize_zscore_or_dff,
             "averageForGroup": self.averageForGroup,
         }

--- a/src/guppy/frontend/visualization_dashboard.py
+++ b/src/guppy/frontend/visualization_dashboard.py
@@ -4,6 +4,7 @@ from io import BytesIO
 
 import panel as pn
 
+from .binned_metrics_view import build_binned_metrics_view
 from .frontend_utils import scanPortsAndFind
 from .tonic_epochs import build_tonic_results_view
 
@@ -35,6 +36,7 @@ class VisualizationDashboard:
         self._psth_tab = self._build_psth_tab()
         self._heatmap_tab = self._build_heatmap_tab()
         self._tonic_tab = build_tonic_results_view(plotter.filepath)
+        self._binned_tab = build_binned_metrics_view(plotter.filepath)
 
     def _range_number_inputs(self, *, name: str, label: str) -> pn.Row:
         """Return two-way-bound min/max number boxes for a plotter ``Range`` param.
@@ -375,6 +377,7 @@ class VisualizationDashboard:
             ("Heat Map", self._heatmap_tab),
             ("Tonic", self._tonic_tab),
         )
+        app = pn.Tabs(("PSTH", self._psth_tab), ("Heat Map", self._heatmap_tab), ("Binned", self._binned_tab))
         template.main.append(app)
         return template
 

--- a/src/guppy/frontend/visualization_dashboard.py
+++ b/src/guppy/frontend/visualization_dashboard.py
@@ -376,8 +376,8 @@ class VisualizationDashboard:
             ("PSTH", self._psth_tab),
             ("Heat Map", self._heatmap_tab),
             ("Tonic", self._tonic_tab),
+            ("Binned", self._binned_tab),
         )
-        app = pn.Tabs(("PSTH", self._psth_tab), ("Heat Map", self._heatmap_tab), ("Binned", self._binned_tab))
         template.main.append(app)
         return template
 

--- a/src/guppy/orchestration/save_parameters.py
+++ b/src/guppy/orchestration/save_parameters.py
@@ -135,6 +135,8 @@ def save_parameters(
         "moving_window": inputParameters["moving_window"],
         "highAmpFilt": inputParameters["highAmpFilt"],
         "transientsThresh": inputParameters["transientsThresh"],
+        "computeBinnedMetrics": inputParameters["computeBinnedMetrics"],
+        "binnedMetricsWidth": inputParameters["binnedMetricsWidth"],
         "visualize_zscore_or_dff": inputParameters["visualize_zscore_or_dff"],
         "averageForGroup": inputParameters["averageForGroup"],
     }

--- a/src/guppy/orchestration/transients.py
+++ b/src/guppy/orchestration/transients.py
@@ -6,11 +6,15 @@ import os
 import numpy as np
 
 from .group_utils import gather_group_run_folders
+from ..analysis.binned_metrics import compute_binned_metrics
 from ..analysis.io_utils import (
+    metric_from_preprocessed_label,
     read_hdf5,
     recording_site_from_preprocessed_label,
 )
 from ..analysis.standard_io import (
+    write_binned_metrics_to_csv,
+    write_binned_metrics_to_hdf5,
     write_freq_and_amp_to_csv,
     write_freq_and_amp_to_hdf5,
     write_transients_as_event_to_hdf5,
@@ -56,6 +60,11 @@ def findFreqAndAmp(
     else:
         path = glob.glob(os.path.join(filepath, "z_score_*")) + glob.glob(os.path.join(filepath, "dff_*"))
 
+    # Occurrence times per recording site per metric, kept for the binned metrics
+    # below; with "Both" selected each site is visited twice, so they are
+    # accumulated here and consumed once the loop is done.
+    site_to_transient_timestamps = {}
+
     for i in range(len(path)):
         basename = (os.path.basename(path[i])).split(".")[0]
         name_1 = recording_site_from_preprocessed_label(basename)
@@ -84,9 +93,54 @@ def findFreqAndAmp(
             columns=["timestamps", "amplitude"],
         )
         write_transients_to_hdf5(filepath, basename, z_score, timestamps, peaksInd)
+        site_to_transient_timestamps.setdefault(name_1, {})[metric_from_preprocessed_label(basename)] = (
+            peaks_occurrences[:, 0]
+        )
         if useTransientsAsEvents == True:
             write_transients_as_event_to_hdf5(filepath, basename, peaks_occurrences[:, 0])
     logger.info("Frequency and amplitude of transients in z_score data are calculated.")
+
+    if inputParameters["computeBinnedMetrics"] == True:
+        findBinnedMetrics(filepath, inputParameters, site_to_transient_timestamps)
+
+
+def findBinnedMetrics(
+    filepath: str, inputParameters: dict[str, object], site_to_transient_timestamps: dict[str, dict[str, np.ndarray]]
+) -> None:
+    """Reduce each recording site to one row per fixed-width time bin.
+
+    Parameters
+    ----------
+    filepath : str
+        Path to the session output directory.
+    inputParameters : dict
+        Full pipeline input parameters; uses ``binnedMetricsWidth``.
+    site_to_transient_timestamps : dict
+        Detected transient occurrence times (s), keyed by recording site and then
+        by the metric they were detected on.
+    """
+    logger.debug("Computing binned metrics over the whole session....")
+    bin_width = inputParameters["binnedMetricsWidth"]
+
+    for recording_site in sorted(site_to_transient_timestamps):
+        # Read the traces fresh: the detection loop above rebinds its own
+        # z_score/timestamps to the NaN-stripped arrays, which carry a compressed
+        # time axis that would misplace every bin edge.
+        timestamps = read_hdf5("timeCorrection_" + recording_site, filepath, "timestampNew")
+        z_score = read_hdf5("z_score_" + recording_site, filepath, "data")
+        dff = read_hdf5("dff_" + recording_site, filepath, "data")
+
+        binned_metrics = compute_binned_metrics(
+            z_score=z_score,
+            dff=dff,
+            timestamps=timestamps,
+            transient_timestamps=site_to_transient_timestamps[recording_site],
+            bin_width=bin_width,
+        )
+        write_binned_metrics_to_hdf5(filepath, binned_metrics, recording_site)
+        write_binned_metrics_to_csv(filepath, binned_metrics, recording_site)
+
+    logger.info("Binned metrics computed.")
 
 
 def executeFindFreqAndAmp(inputParameters: dict[str, object]) -> None:

--- a/src/guppy/testing/api.py
+++ b/src/guppy/testing/api.py
@@ -861,6 +861,8 @@ def step4(
     use_time_or_trials: str = "Time (min)",
     time_for_lights_turn_on: float = 1.0,
     auc_units: str = "samples",
+    compute_binned_metrics: bool = False,
+    binned_metrics_width: int = 120,
     selected_runs: dict[str, list[str]],
     group_selected_runs: dict[str, list[str]] | None = None,
 ) -> None:
@@ -925,6 +927,12 @@ def step4(
         Integration spacing for the peak/AUC areas. ``'samples'`` (the default) integrates
         with one-sample spacing; ``'seconds'`` integrates against the PSTH time axis, giving
         areas in z-score (or ΔF/F) × seconds.
+    compute_binned_metrics : bool
+        Whether to divide the session into fixed-width time bins and write the per-bin mean
+        z-score, mean ΔF/F and transient counts. Defaults to False.
+    binned_metrics_width : int
+        Width of those bins in seconds. Only meaningful when ``compute_binned_metrics`` is
+        ``True``. Defaults to 120.
 
     Raises
     ------
@@ -1009,6 +1017,10 @@ def step4(
 
     # Inject the peak/AUC integration spacing
     input_params["auc_units"] = auc_units
+
+    # Inject the whole-session binned metrics parameters
+    input_params["computeBinnedMetrics"] = compute_binned_metrics
+    input_params["binnedMetricsWidth"] = binned_metrics_width
 
     # Call the underlying Step 4 workers directly, in the order the GUI runs them:
     # transients first, so their timestamps are available as events for the PSTH.

--- a/src/guppy/visualization/binned_metrics.py
+++ b/src/guppy/visualization/binned_metrics.py
@@ -1,0 +1,101 @@
+"""Display-time rendering for whole-session time-binned metrics.
+
+The binned values are drawn as bars spanning the bins they summarize, stacked
+under the trace they were reduced from. Both panels share the ``time (s)``
+dimension, so bokeh links their axes and zooming the bars zooms the trace with
+them -- which is what makes a bin width that is too coarse or too fine visible
+at a glance.
+"""
+
+import logging
+
+import holoviews as hv
+import numpy as np
+
+from .shading import shade_trace
+
+logger = logging.getLogger(__name__)
+
+BAR_COLOR = "#1f77b4"
+
+
+def build_bin_bars(
+    *, bin_starts: np.ndarray, bin_ends: np.ndarray, values: np.ndarray, value_label: str
+) -> hv.Rectangles:
+    """Draw one bar per time bin, spanning that bin's true bounds.
+
+    Bins whose value is NaN -- a stretch of recording lost to artifact removal --
+    are left empty rather than drawn at zero.
+
+    Parameters
+    ----------
+    bin_starts, bin_ends : np.ndarray
+        Bin bounds in seconds. The final pair may be narrower than the rest.
+    values : np.ndarray
+        One value per bin.
+    value_label : str
+        Axis label for the values, e.g. ``"mean z-score"``.
+
+    Returns
+    -------
+    hv.Rectangles
+        Bars from zero to each bin's value. The first key dimension is
+        ``"time (s)"``, so this panel links axes with a trace plotted against the
+        same dimension.
+    """
+    bin_starts = np.asarray(bin_starts, dtype=float)
+    bin_ends = np.asarray(bin_ends, dtype=float)
+    values = np.asarray(values, dtype=float)
+
+    drawable = ~np.isnan(values)
+    bars = list(zip(bin_starts[drawable], np.zeros(np.count_nonzero(drawable)), bin_ends[drawable], values[drawable]))
+
+    return hv.Rectangles(
+        bars,
+        kdims=["time (s)", value_label, "time (s) end", value_label + " end"],
+    )
+
+
+def build_binned_metrics_panel(
+    *,
+    timestamps: np.ndarray,
+    trace: np.ndarray,
+    trace_label: str,
+    bin_starts: np.ndarray,
+    bin_ends: np.ndarray,
+    values: np.ndarray,
+    value_label: str,
+    suptitle: str,
+) -> hv.Layout:
+    """Stack the binned values under the full-session trace they reduce.
+
+    Parameters
+    ----------
+    timestamps : np.ndarray
+        Corrected time axis (s) of the trace.
+    trace : np.ndarray
+        Full-session trace the metric was reduced from.
+    trace_label : str
+        Axis label for the trace, e.g. ``"z-score"``.
+    bin_starts, bin_ends : np.ndarray
+        Bin bounds in seconds.
+    values : np.ndarray
+        One value per bin.
+    value_label : str
+        Axis label for the binned values.
+    suptitle : str
+        Session-level title prefix applied to the trace panel.
+
+    Returns
+    -------
+    hv.Layout
+        The shaded trace above, the per-bin bars below, on a linked time axis.
+    """
+    trace_curve = shade_trace(hv.Curve((timestamps, trace), "time (s)", trace_label)).opts(
+        title=f"{suptitle} — {trace_label}", responsive=True, height=220
+    )
+    bars = build_bin_bars(bin_starts=bin_starts, bin_ends=bin_ends, values=values, value_label=value_label).opts(
+        color=BAR_COLOR, line_color="white", title=value_label, responsive=True, height=220
+    )
+
+    return hv.Layout([trace_curve, bars]).cols(1)

--- a/tests/integration/test_binned_metrics.py
+++ b/tests/integration/test_binned_metrics.py
@@ -1,0 +1,134 @@
+import os
+import shutil
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from guppy.analysis.io_utils import read_hdf5
+from guppy.analysis.standard_io import read_binned_metrics_from_hdf5
+from guppy.testing.api import step1, step2, step3, step4
+from guppy.utils.utils import parse_run_name
+from guppy_test_data import STUBBED_TESTING_DATA
+
+from .integration_helpers import REPRESENTATIVE_SESSIONS, _locate_output_directory
+
+# The stubbed CSV session runs ~411 s, so 100 s bins give four whole bins and a
+# short fifth one -- exercising the ragged final bin end to end.
+BIN_WIDTH = 100
+RECORDING_SITE = "region"
+
+
+@pytest.fixture(scope="module")
+def preprocessed_session(tmp_path_factory):
+    representative_config = REPRESENTATIVE_SESSIONS["csv"]
+    source_session = os.path.join(str(STUBBED_TESTING_DATA), representative_config["session_subdir"])
+    base_directory = tmp_path_factory.mktemp("integration_binned_metrics")
+    session = base_directory / os.path.basename(source_session)
+    # Output directories are gitignored, so a stale one from a previous local run
+    # would otherwise seed this session.
+    shutil.copytree(source_session, session, ignore=shutil.ignore_patterns("*_output_*"))
+
+    step1(
+        base_dir=str(base_directory),
+        selected_folders=[str(session)],
+        store_id_to_store_label=representative_config["store_id_to_store_label"],
+    )
+    output_directory = _locate_output_directory(session_copy=str(session))
+    selected_runs = {str(session): [parse_run_name(output_directory)]}
+
+    step2(base_dir=str(base_directory), selected_folders=[str(session)], selected_runs=selected_runs)
+    step3(base_dir=str(base_directory), selected_folders=[str(session)], selected_runs=selected_runs)
+
+    return {
+        "base_directory": str(base_directory),
+        "session": str(session),
+        "selected_runs": selected_runs,
+        "output_directory": _locate_output_directory(session_copy=str(session)),
+    }
+
+
+@pytest.fixture(scope="module")
+def binned_output(preprocessed_session):
+    step4(
+        base_dir=preprocessed_session["base_directory"],
+        selected_folders=[preprocessed_session["session"]],
+        selected_runs=preprocessed_session["selected_runs"],
+        compute_binned_metrics=True,
+        binned_metrics_width=BIN_WIDTH,
+    )
+    return preprocessed_session["output_directory"]
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+class TestBinnedMetrics:
+    def test_writes_both_formats(self, binned_output):
+        assert os.path.exists(os.path.join(binned_output, f"binned_metrics_{RECORDING_SITE}.h5"))
+        assert os.path.exists(os.path.join(binned_output, f"binned_metrics_{RECORDING_SITE}.csv"))
+
+    def test_schema(self, binned_output):
+        binned = read_binned_metrics_from_hdf5(binned_output, RECORDING_SITE)
+
+        assert binned.index.name == "bin"
+        assert list(binned.columns) == [
+            "bin_start",
+            "bin_end",
+            "n_samples",
+            "mean_zscore",
+            "mean_dff",
+            "transient_count_z_score",
+        ]
+
+    def test_bins_tile_the_recording_without_gaps(self, binned_output):
+        binned = read_binned_metrics_from_hdf5(binned_output, RECORDING_SITE)
+        timestamps = read_hdf5("timeCorrection_" + RECORDING_SITE, binned_output, "timestampNew").ravel()
+
+        # Each bin picks up exactly where the previous one ended, and the tiling
+        # spans the corrected time axis end to end.
+        np.testing.assert_allclose(binned["bin_start"].to_numpy()[1:], binned["bin_end"].to_numpy()[:-1])
+        np.testing.assert_allclose(binned["bin_start"].iloc[0], timestamps[0])
+        np.testing.assert_allclose(binned["bin_end"].iloc[-1], timestamps[-1])
+
+    def test_final_bin_is_kept_and_is_short(self, binned_output):
+        binned = read_binned_metrics_from_hdf5(binned_output, RECORDING_SITE)
+        widths = (binned["bin_end"] - binned["bin_start"]).to_numpy()
+
+        np.testing.assert_allclose(widths[:-1], BIN_WIDTH)
+        assert 0 < widths[-1] < BIN_WIDTH
+
+    def test_means_match_the_traces_on_disk(self, binned_output):
+        binned = read_binned_metrics_from_hdf5(binned_output, RECORDING_SITE)
+        timestamps = read_hdf5("timeCorrection_" + RECORDING_SITE, binned_output, "timestampNew").ravel()
+        z_score = read_hdf5("z_score_" + RECORDING_SITE, binned_output, "data").ravel()
+        dff = read_hdf5("dff_" + RECORDING_SITE, binned_output, "data").ravel()
+
+        for bin_number, row in binned.iterrows():
+            # Half-open, except the final bin which owns its end.
+            if bin_number == binned.index[-1]:
+                mask = (timestamps >= row["bin_start"]) & (timestamps <= row["bin_end"])
+            else:
+                mask = (timestamps >= row["bin_start"]) & (timestamps < row["bin_end"])
+
+            assert row["n_samples"] == np.count_nonzero(~np.isnan(z_score[mask]))
+            assert row["mean_zscore"] == pytest.approx(np.nanmean(z_score[mask]))
+            assert row["mean_dff"] == pytest.approx(np.nanmean(dff[mask]))
+
+    def test_every_sample_lands_in_exactly_one_bin(self, binned_output):
+        binned = read_binned_metrics_from_hdf5(binned_output, RECORDING_SITE)
+        z_score = read_hdf5("z_score_" + RECORDING_SITE, binned_output, "data").ravel()
+
+        assert binned["n_samples"].sum() == np.count_nonzero(~np.isnan(z_score))
+
+    def test_transient_counts_account_for_every_detected_transient(self, binned_output):
+        binned = read_binned_metrics_from_hdf5(binned_output, RECORDING_SITE)
+        occurrences = pd.read_csv(
+            os.path.join(binned_output, f"transientsOccurrences_z_score_{RECORDING_SITE}.csv"), index_col=0
+        )
+
+        assert binned["transient_count_z_score"].sum() == occurrences.shape[0]
+
+    def test_csv_matches_the_hdf5(self, binned_output):
+        from_hdf5 = read_binned_metrics_from_hdf5(binned_output, RECORDING_SITE)
+        from_csv = pd.read_csv(os.path.join(binned_output, f"binned_metrics_{RECORDING_SITE}.csv"), index_col="bin")
+
+        pd.testing.assert_frame_equal(from_csv, from_hdf5, check_dtype=False)

--- a/tests/integration/test_integration_home.py
+++ b/tests/integration/test_integration_home.py
@@ -44,6 +44,8 @@ EXPECTED_JSON_KEYS = {
     "moving_window",
     "highAmpFilt",
     "transientsThresh",
+    "computeBinnedMetrics",
+    "binnedMetricsWidth",
     "visualize_zscore_or_dff",
     "averageForGroup",
 }

--- a/tests/integration/test_integration_save_parameters.py
+++ b/tests/integration/test_integration_save_parameters.py
@@ -43,6 +43,8 @@ def default_parameters():
         "moving_window": 15,
         "highAmpFilt": 2,
         "transientsThresh": 3,
+        "computeBinnedMetrics": False,
+        "binnedMetricsWidth": 120,
         "visualize_zscore_or_dff": "z_score",
         "averageForGroup": False,
     }

--- a/tests/integration/test_integration_step4.py
+++ b/tests/integration/test_integration_step4.py
@@ -1,3 +1,4 @@
+import glob
 import os
 
 import pandas as pd
@@ -119,3 +120,7 @@ def test_step4(step3_fixture_name, expected_recording_site, expected_ttl, reques
     assert os.path.exists(
         transients_occurrences_csv_file_path
     ), f"Missing transients occurrences CSV: {transients_occurrences_csv_file_path}"
+
+    # Binned metrics are opt-in, so a default Step 4 must not produce them.
+    binned_metrics_file_paths = glob.glob(os.path.join(output_directory, "binned_metrics_*"))
+    assert binned_metrics_file_paths == [], f"Unexpected binned metrics outputs: {binned_metrics_file_paths}"

--- a/tests/unit/analysis/test_binned_metrics.py
+++ b/tests/unit/analysis/test_binned_metrics.py
@@ -1,0 +1,154 @@
+import warnings
+
+import numpy as np
+import pytest
+
+from guppy.analysis.binned_metrics import compute_bin_edges, compute_binned_metrics
+
+
+class TestComputeBinEdges:
+    def test_exact_multiple(self):
+        # 10 s at 5 s bins divides evenly into two whole bins.
+        np.testing.assert_allclose(compute_bin_edges(start=0.0, end=10.0, bin_width=5.0), [0.0, 5.0, 10.0])
+
+    def test_ragged_final_bin_is_kept(self):
+        # 10 s at 4 s bins -> bins [0,4), [4,8), and a short [8,10].
+        np.testing.assert_allclose(compute_bin_edges(start=0.0, end=10.0, bin_width=4.0), [0.0, 4.0, 8.0, 10.0])
+
+    def test_bin_width_longer_than_recording_gives_one_bin(self):
+        np.testing.assert_allclose(compute_bin_edges(start=0.0, end=10.0, bin_width=100.0), [0.0, 10.0])
+
+    def test_edges_start_at_the_first_timestamp(self):
+        # Bins are anchored to the recording, not to zero.
+        np.testing.assert_allclose(compute_bin_edges(start=2.0, end=8.0, bin_width=3.0), [2.0, 5.0, 8.0])
+
+    def test_floating_point_sliver_is_absorbed(self):
+        # 0.1 + 0.2 == 0.30000000000000004, so the duration divides into 3 bins
+        # but rounds up to 4, leaving a zero-width final bin that np.histogram
+        # would reject.
+        end = 0.1 + 0.2
+        edges = compute_bin_edges(start=0.0, end=end, bin_width=0.1)
+
+        assert edges.shape[0] == 4
+        assert np.all(np.diff(edges) > 0)
+        assert edges[-1] == end
+
+    def test_non_positive_bin_width_raises(self):
+        with pytest.raises(ValueError, match="must be positive"):
+            compute_bin_edges(start=0.0, end=10.0, bin_width=0.0)
+
+    def test_recording_without_duration_raises(self):
+        with pytest.raises(ValueError, match="no duration to bin"):
+            compute_bin_edges(start=4.0, end=4.0, bin_width=1.0)
+
+
+class TestComputeBinnedMetrics:
+    @pytest.fixture
+    def traces(self):
+        timestamps = np.arange(0, 11, 1, dtype=float)
+        return {
+            "timestamps": timestamps,
+            "z_score": timestamps.copy(),
+            "dff": timestamps / 10,
+        }
+
+    def test_means_over_whole_bins(self, traces):
+        # bin 0 = [0,5) -> samples 0,1,2,3,4 -> z 2.0, dff 0.2
+        # bin 1 = [5,10] -> samples 5..10 (final bin includes its end) -> z 7.5, dff 0.75
+        binned = compute_binned_metrics(**traces, transient_timestamps={}, bin_width=5.0)
+
+        np.testing.assert_allclose(binned["bin_start"].to_numpy(), [0.0, 5.0])
+        np.testing.assert_allclose(binned["bin_end"].to_numpy(), [5.0, 10.0])
+        np.testing.assert_allclose(binned["mean_zscore"].to_numpy(), [2.0, 7.5])
+        np.testing.assert_allclose(binned["mean_dff"].to_numpy(), [0.2, 0.75])
+        np.testing.assert_array_equal(binned["n_samples"].to_numpy(), [5, 6])
+        assert binned.index.name == "bin"
+        np.testing.assert_array_equal(binned.index.to_numpy(), [0, 1])
+
+    def test_ragged_final_bin_reports_its_true_bounds(self, traces):
+        # bin 0 = [0,4) -> 0,1,2,3 -> 1.5;  bin 1 = [4,8) -> 4,5,6,7 -> 5.5
+        # bin 2 = [8,10] -> 8,9,10 -> 9.0, and is only 2 s wide
+        binned = compute_binned_metrics(**traces, transient_timestamps={}, bin_width=4.0)
+
+        np.testing.assert_allclose(binned["bin_start"].to_numpy(), [0.0, 4.0, 8.0])
+        np.testing.assert_allclose(binned["bin_end"].to_numpy(), [4.0, 8.0, 10.0])
+        np.testing.assert_allclose(binned["mean_zscore"].to_numpy(), [1.5, 5.5, 9.0])
+        np.testing.assert_array_equal(binned["n_samples"].to_numpy(), [4, 4, 3])
+
+    def test_transient_counts_follow_the_bin_convention(self, traces):
+        # Edges are [0,4,8,10]. 3.9 falls in bin 0 and 4.0 opens bin 1 (half-open),
+        # while 10.0 lands in the final bin because that one includes its end.
+        occurrences = np.array([0.5, 3.9, 4.0, 9.9, 10.0])
+        binned = compute_binned_metrics(**traces, transient_timestamps={"z_score": occurrences}, bin_width=4.0)
+
+        np.testing.assert_array_equal(binned["transient_count_z_score"].to_numpy(), [2, 1, 2])
+        assert binned["transient_count_z_score"].sum() == occurrences.shape[0]
+
+    def test_one_count_column_per_metric(self, traces):
+        binned = compute_binned_metrics(
+            **traces,
+            transient_timestamps={"z_score": np.array([1.0]), "dff": np.array([6.0, 7.0])},
+            bin_width=5.0,
+        )
+
+        np.testing.assert_array_equal(binned["transient_count_z_score"].to_numpy(), [1, 0])
+        np.testing.assert_array_equal(binned["transient_count_dff"].to_numpy(), [0, 2])
+
+    def test_no_count_columns_when_no_transients_were_detected_on_a_metric(self, traces):
+        binned = compute_binned_metrics(**traces, transient_timestamps={}, bin_width=5.0)
+
+        assert [column for column in binned.columns if column.startswith("transient_count_")] == []
+
+    def test_zero_detected_transients_counts_zero(self, traces):
+        binned = compute_binned_metrics(**traces, transient_timestamps={"z_score": np.array([])}, bin_width=5.0)
+
+        np.testing.assert_array_equal(binned["transient_count_z_score"].to_numpy(), [0, 0])
+
+    def test_bin_lost_to_artifact_removal_is_nan_without_warning(self, traces):
+        # Artifact removal NaNs the samples in place, so a bin can be entirely NaN.
+        traces["z_score"][0:4] = np.nan
+        traces["dff"][0:4] = np.nan
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            binned = compute_binned_metrics(**traces, transient_timestamps={}, bin_width=4.0)
+
+        assert np.isnan(binned["mean_zscore"].iloc[0])
+        assert np.isnan(binned["mean_dff"].iloc[0])
+        assert binned["n_samples"].iloc[0] == 0
+        # The surviving bins are unaffected: [4,8) -> 4,5,6,7 and [8,10] -> 8,9,10.
+        np.testing.assert_allclose(binned["mean_zscore"].to_numpy()[1:], [5.5, 9.0])
+
+    def test_partially_removed_bin_averages_only_the_surviving_samples(self, traces):
+        # Drop samples 0 and 1 from bin [0,4); the mean is then over 2 and 3.
+        traces["z_score"][0:2] = np.nan
+        traces["dff"][0:2] = np.nan
+
+        binned = compute_binned_metrics(**traces, transient_timestamps={}, bin_width=4.0)
+
+        np.testing.assert_allclose(binned["mean_zscore"].iloc[0], 2.5)
+        assert binned["n_samples"].iloc[0] == 2
+
+    def test_bin_width_longer_than_recording_gives_a_single_bin(self, traces):
+        binned = compute_binned_metrics(**traces, transient_timestamps={}, bin_width=100.0)
+
+        assert binned.shape[0] == 1
+        # Mean of 0..10 inclusive.
+        np.testing.assert_allclose(binned["mean_zscore"].iloc[0], 5.0)
+        np.testing.assert_allclose(binned["bin_end"].iloc[0], 10.0)
+
+    def test_column_order(self, traces):
+        binned = compute_binned_metrics(**traces, transient_timestamps={"z_score": np.array([1.0])}, bin_width=5.0)
+
+        assert list(binned.columns) == [
+            "bin_start",
+            "bin_end",
+            "n_samples",
+            "mean_zscore",
+            "mean_dff",
+            "transient_count_z_score",
+        ]
+
+    def test_non_positive_bin_width_raises(self, traces):
+        with pytest.raises(ValueError, match="must be positive"):
+            compute_binned_metrics(**traces, transient_timestamps={}, bin_width=-1.0)

--- a/tests/unit/analysis/test_io_utils.py
+++ b/tests/unit/analysis/test_io_utils.py
@@ -14,6 +14,7 @@ from guppy.analysis.io_utils import (
     is_channel_label,
     make_dir_for_cross_correlation,
     makeAverageDir,
+    metric_from_preprocessed_label,
     read_hdf5,
     recording_site_from_channel_label,
     recording_site_from_channel_path,
@@ -317,6 +318,16 @@ def test_recording_site_from_channel_path_strips_prefix_and_extension():
 def test_recording_site_from_preprocessed_label_strips_zscore_or_dff_prefix():
     assert recording_site_from_preprocessed_label("z_score_left_hemisphere") == "left_hemisphere"
     assert recording_site_from_preprocessed_label("dff_d_ms") == "d_ms"
+
+
+def test_metric_from_preprocessed_label_returns_the_prefix():
+    assert metric_from_preprocessed_label("z_score_left_hemisphere") == "z_score"
+    assert metric_from_preprocessed_label("dff_d_ms") == "dff"
+
+
+def test_metric_from_preprocessed_label_without_a_known_prefix_raises():
+    with pytest.raises(ValueError, match="starts with neither"):
+        metric_from_preprocessed_label("control_dms")
 
 
 # ── make_dir_for_cross_correlation ────────────────────────────────────────────

--- a/tests/unit/analysis/test_standard_io.py
+++ b/tests/unit/analysis/test_standard_io.py
@@ -5,6 +5,7 @@ import pytest
 
 from guppy.analysis.io_utils import write_hdf5
 from guppy.analysis.standard_io import (
+    read_binned_metrics_from_hdf5,
     read_control_and_signal,
     read_coords_pairwise,
     read_corrected_data,
@@ -19,6 +20,8 @@ from guppy.analysis.standard_io import (
     read_ttl_timestamps_for_combining_data,
     write_artifact_corrected_timestamps,
     write_artifact_removal,
+    write_binned_metrics_to_csv,
+    write_binned_metrics_to_hdf5,
     write_combined_data,
     write_corrected_data,
     write_corrected_timestamps,
@@ -469,3 +472,37 @@ def test_read_ttl_timestamps_for_combining_data_mismatched_recording_sites_raise
     store_array = np.array([["ctrl0", "sig0", "ttl0"], ["control_dms", "signal_vms", "TTL1"]])
     with pytest.raises(ValueError, match="Mismatched control/signal files"):
         read_ttl_timestamps_for_combining_data([str(session)], store_array)
+
+
+# ── write_binned_metrics_to_hdf5 / _to_csv / read_binned_metrics_from_hdf5 ────
+
+
+@pytest.fixture
+def binned_metrics():
+    return pd.DataFrame(
+        {
+            "bin_start": [0.0, 5.0],
+            "bin_end": [5.0, 10.0],
+            "n_samples": [5, 6],
+            "mean_zscore": [2.0, 7.5],
+            "mean_dff": [0.2, 0.75],
+            "transient_count_z_score": [1, 3],
+        },
+        index=pd.RangeIndex(2, name="bin"),
+    )
+
+
+def test_write_and_read_binned_metrics_roundtrip(tmp_path, binned_metrics):
+    write_binned_metrics_to_hdf5(str(tmp_path), binned_metrics, "dms")
+    result = read_binned_metrics_from_hdf5(str(tmp_path), "dms")
+
+    pd.testing.assert_frame_equal(result, binned_metrics)
+
+
+def test_write_binned_metrics_to_csv_preserves_the_bin_index(tmp_path, binned_metrics):
+    write_binned_metrics_to_csv(str(tmp_path), binned_metrics, "dms")
+    result = pd.read_csv(tmp_path / "binned_metrics_dms.csv", index_col="bin")
+
+    np.testing.assert_allclose(result["mean_zscore"].to_numpy(), [2.0, 7.5])
+    np.testing.assert_allclose(result["bin_end"].to_numpy(), [5.0, 10.0])
+    np.testing.assert_array_equal(result["transient_count_z_score"].to_numpy(), [1, 3])

--- a/tests/unit/frontend/test_binned_metrics_view.py
+++ b/tests/unit/frontend/test_binned_metrics_view.py
@@ -1,0 +1,145 @@
+import numpy as np
+import pandas as pd
+import panel as pn
+import pytest
+
+from guppy.analysis.io_utils import write_hdf5
+from guppy.analysis.standard_io import write_binned_metrics_to_hdf5
+from guppy.frontend.binned_metrics_view import (
+    BinnedMetricsView,
+    binned_metrics_sites,
+    build_binned_metrics_view,
+)
+
+
+def write_site_outputs(filepath, site, count_columns=("transient_count_z_score",)):
+    """Write the Step-3 traces and the Step-4 binned table one site needs."""
+    timestamps = np.arange(0, 11, 1, dtype=float)
+    write_hdf5(timestamps, "timeCorrection_" + site, filepath, "timestampNew")
+    write_hdf5(timestamps.copy(), "z_score_" + site, filepath, "data")
+    write_hdf5(timestamps / 10, "dff_" + site, filepath, "data")
+
+    binned_metrics = pd.DataFrame(
+        {
+            "bin_start": [0.0, 5.0],
+            "bin_end": [5.0, 10.0],
+            "n_samples": [5, 6],
+            "mean_zscore": [2.0, 7.5],
+            "mean_dff": [0.2, 0.75],
+        },
+        index=pd.RangeIndex(2, name="bin"),
+    )
+    for column in count_columns:
+        binned_metrics[column] = [1, 3]
+    write_binned_metrics_to_hdf5(filepath, binned_metrics, site)
+
+
+@pytest.fixture
+def session(tmp_path, panel_extension):
+    write_site_outputs(str(tmp_path), "dms")
+    write_site_outputs(str(tmp_path), "nac")
+    return str(tmp_path)
+
+
+@pytest.fixture
+def view(session):
+    binned_metrics_view = BinnedMetricsView(session)
+    # Pin the site so tests do not depend on glob ordering.
+    binned_metrics_view.site_select.value = "dms"
+    return binned_metrics_view
+
+
+class TestBinnedMetricsSites:
+    def test_lists_sites_sorted(self, session):
+        assert binned_metrics_sites(session) == ["dms", "nac"]
+
+    def test_empty_when_the_session_has_no_binned_metrics(self, tmp_path):
+        assert binned_metrics_sites(str(tmp_path)) == []
+
+    def test_recording_sites_with_underscores_survive(self, tmp_path, panel_extension):
+        write_site_outputs(str(tmp_path), "left_hemisphere")
+
+        assert binned_metrics_sites(str(tmp_path)) == ["left_hemisphere"]
+
+
+class TestBinnedMetricsView:
+    def test_offers_every_site(self, view):
+        assert view.site_select.options == ["dms", "nac"]
+
+    def test_metric_menu_covers_the_columns_present(self, view):
+        assert view.metric_select.options == {
+            "Mean z-score": "mean_zscore",
+            "Mean ΔF/F": "mean_dff",
+            "Transient count (z-score)": "transient_count_z_score",
+        }
+
+    def test_metric_menu_omits_counts_the_detector_did_not_produce(self, tmp_path, panel_extension):
+        # Only z-score transients were computed, so there is no ΔF/F count column.
+        write_site_outputs(str(tmp_path), "dms", count_columns=())
+        binned_metrics_view = BinnedMetricsView(str(tmp_path))
+
+        assert "Transient count (z-score)" not in binned_metrics_view.metric_select.options
+        assert "Mean z-score" in binned_metrics_view.metric_select.options
+
+    def test_metric_menu_covers_both_counts_when_both_were_computed(self, tmp_path, panel_extension):
+        write_site_outputs(str(tmp_path), "dms", count_columns=("transient_count_z_score", "transient_count_dff"))
+        binned_metrics_view = BinnedMetricsView(str(tmp_path))
+
+        assert "Transient count (z-score)" in binned_metrics_view.metric_select.options
+        assert "Transient count (ΔF/F)" in binned_metrics_view.metric_select.options
+
+    def test_plots_the_selected_metric_values(self, view):
+        view.metric_select.value = "mean_zscore"
+
+        bars = list(view.plot_pane.object)[1].array()
+        np.testing.assert_allclose(bars[:, 3], [2.0, 7.5])
+
+    def test_switching_metric_redraws_with_the_new_values(self, view):
+        view.metric_select.value = "mean_dff"
+
+        bars = list(view.plot_pane.object)[1].array()
+        np.testing.assert_allclose(bars[:, 3], [0.2, 0.75])
+
+    def test_transient_count_metric_plots_the_counts(self, view):
+        view.metric_select.value = "transient_count_z_score"
+
+        bars = list(view.plot_pane.object)[1].array()
+        np.testing.assert_allclose(bars[:, 3], [1, 3])
+
+    def test_switching_site_redraws(self, view, session):
+        # Give the second site distinguishable values so the redraw is observable.
+        binned_metrics = pd.DataFrame(
+            {
+                "bin_start": [0.0, 5.0],
+                "bin_end": [5.0, 10.0],
+                "n_samples": [5, 6],
+                "mean_zscore": [-1.0, -4.0],
+                "mean_dff": [0.1, 0.2],
+                "transient_count_z_score": [0, 1],
+            },
+            index=pd.RangeIndex(2, name="bin"),
+        )
+        write_binned_metrics_to_hdf5(session, binned_metrics, "nac")
+
+        view.metric_select.value = "mean_zscore"
+        view.site_select.value = "nac"
+
+        bars = list(view.plot_pane.object)[1].array()
+        np.testing.assert_allclose(bars[:, 3], [-1.0, -4.0])
+
+    def test_widget_composes_selectors_and_plot(self, view):
+        assert isinstance(view.widget, pn.Column)
+
+
+class TestBuildBinnedMetricsView:
+    def test_returns_the_view_when_results_exist(self, session):
+        result = build_binned_metrics_view(session)
+
+        assert isinstance(result, pn.Column)
+        assert not isinstance(result[0], pn.pane.Markdown)
+
+    def test_returns_an_empty_state_note_when_there_are_no_results(self, tmp_path, panel_extension):
+        result = build_binned_metrics_view(str(tmp_path))
+
+        assert isinstance(result[0], pn.pane.Markdown)
+        assert "No binned metrics" in result[0].object

--- a/tests/unit/frontend/test_input_parameters.py
+++ b/tests/unit/frontend/test_input_parameters.py
@@ -124,6 +124,12 @@ class TestParameterForm:
     def test_transients_thresh_default(self, parameter_form):
         assert parameter_form.transientsThresh.value == 3
 
+    def test_compute_binned_metrics_default(self, parameter_form):
+        assert parameter_form.computeBinnedMetrics.value is False
+
+    def test_binned_metrics_width_default(self, parameter_form):
+        assert parameter_form.binnedMetricsWidth.value == 120
+
     def test_no_channels_np_default(self, parameter_form):
         assert parameter_form.no_channels_np.value == 2
 
@@ -321,6 +327,11 @@ class TestNumericParameterValidation:
     def test_negative_transients_thresh_raises(self, parameter_form):
         parameter_form.transientsThresh.value = -3
         with pytest.raises(ValueError, match="transientsThresh=-3 must be greater than 0"):
+            parameter_form.getInputParameters()
+
+    def test_zero_binned_metrics_width_raises(self, parameter_form):
+        parameter_form.binnedMetricsWidth.value = 0
+        with pytest.raises(ValueError, match="binnedMetricsWidth=0 must be greater than 0"):
             parameter_form.getInputParameters()
 
     def test_nsecprev_equal_to_nsecpost_raises(self, parameter_form):
@@ -626,6 +637,8 @@ SAVED_PARAMETERS = {
     "moving_window": 12,
     "highAmpFilt": 5,
     "transientsThresh": 6,
+    "computeBinnedMetrics": True,
+    "binnedMetricsWidth": 60,
     "visualize_zscore_or_dff": "dff",
     "averageForGroup": True,
 }

--- a/tests/unit/orchestration/conftest.py
+++ b/tests/unit/orchestration/conftest.py
@@ -42,4 +42,6 @@ def base_input_parameters() -> dict[str, object]:
         "moving_window": 15,
         "highAmpFilt": 3.0,
         "transientsThresh": 2.0,
+        "computeBinnedMetrics": False,
+        "binnedMetricsWidth": 120,
     }

--- a/tests/unit/orchestration/test_read_raw_data.py
+++ b/tests/unit/orchestration/test_read_raw_data.py
@@ -44,6 +44,8 @@ DEFAULT_ANALYSIS_PARAMETERS = {
     "moving_window": 15,
     "highAmpFilt": 2,
     "transientsThresh": 3,
+    "computeBinnedMetrics": False,
+    "binnedMetricsWidth": 120,
     "visualize_zscore_or_dff": "z_score",
     "averageForGroup": False,
 }

--- a/tests/unit/orchestration/test_save_parameters.py
+++ b/tests/unit/orchestration/test_save_parameters.py
@@ -46,6 +46,8 @@ PARAMETER_KEYS = {
     "moving_window",
     "highAmpFilt",
     "transientsThresh",
+    "computeBinnedMetrics",
+    "binnedMetricsWidth",
     "visualize_zscore_or_dff",
     "averageForGroup",
 }
@@ -101,6 +103,8 @@ def base_input_parameters(tmp_path):
         "moving_window": 15,
         "highAmpFilt": 3.0,
         "transientsThresh": 2.0,
+        "computeBinnedMetrics": False,
+        "binnedMetricsWidth": 120,
         "visualize_zscore_or_dff": "z_score",
         "averageForGroup": False,
         # orchestration-only keys that should not be saved
@@ -202,6 +206,8 @@ def test_save_parameters_single_folder(tmp_path):
         "moving_window": 20,
         "highAmpFilt": 5.0,
         "transientsThresh": 3.0,
+        "computeBinnedMetrics": False,
+        "binnedMetricsWidth": 120,
         "visualize_zscore_or_dff": "dff",
         "averageForGroup": True,
     }

--- a/tests/unit/orchestration/test_transients.py
+++ b/tests/unit/orchestration/test_transients.py
@@ -1,8 +1,14 @@
+import os
+
+import numpy as np
 import pytest
 
+from guppy.analysis.io_utils import write_hdf5
+from guppy.analysis.standard_io import read_binned_metrics_from_hdf5
 from guppy.orchestration.transients import (
     execute_average_for_group,
     executeFindFreqAndAmp,
+    findBinnedMetrics,
 )
 
 
@@ -60,3 +66,47 @@ class TestExecuteFindFreqAndAmpDispatch:
 def test_execute_average_for_group_raises_for_empty_folders(base_input_parameters):
     with pytest.raises(ValueError, match="No folders selected for group averaging"):
         execute_average_for_group(base_input_parameters, [])
+
+
+class TestFindBinnedMetrics:
+    @pytest.fixture
+    def run_folder(self, tmp_path):
+        # 0..10 s at 1 Hz, with z-score equal to time so bin means are obvious.
+        timestamps = np.arange(0, 11, 1, dtype=float)
+        write_hdf5(timestamps, "timeCorrection_dms", str(tmp_path), "timestampNew")
+        write_hdf5(timestamps.copy(), "z_score_dms", str(tmp_path), "data")
+        write_hdf5(timestamps / 10, "dff_dms", str(tmp_path), "data")
+        return str(tmp_path)
+
+    def test_writes_one_table_per_recording_site(self, run_folder, base_input_parameters):
+        base_input_parameters["binnedMetricsWidth"] = 5
+        findBinnedMetrics(run_folder, base_input_parameters, {"dms": {"z_score": np.array([1.0, 6.0, 7.0])}})
+
+        binned = read_binned_metrics_from_hdf5(run_folder, "dms")
+        # bin 0 = [0,5) -> 0..4 -> 2.0;  bin 1 = [5,10] -> 5..10 -> 7.5
+        np.testing.assert_allclose(binned["mean_zscore"].to_numpy(), [2.0, 7.5])
+        np.testing.assert_allclose(binned["mean_dff"].to_numpy(), [0.2, 0.75])
+        np.testing.assert_array_equal(binned["transient_count_z_score"].to_numpy(), [1, 2])
+        assert os.path.exists(os.path.join(run_folder, "binned_metrics_dms.csv"))
+
+    def test_bins_span_the_uncompressed_time_axis(self, run_folder, base_input_parameters):
+        # Regression guard: binning must use timestampNew, not the NaN-stripped
+        # time axis the transient detector works on.
+        base_input_parameters["binnedMetricsWidth"] = 5
+        findBinnedMetrics(run_folder, base_input_parameters, {"dms": {"z_score": np.array([])}})
+
+        binned = read_binned_metrics_from_hdf5(run_folder, "dms")
+        np.testing.assert_allclose(binned["bin_start"].iloc[0], 0.0)
+        np.testing.assert_allclose(binned["bin_end"].iloc[-1], 10.0)
+
+    def test_both_metrics_produce_two_count_columns(self, run_folder, base_input_parameters):
+        base_input_parameters["binnedMetricsWidth"] = 5
+        findBinnedMetrics(
+            run_folder,
+            base_input_parameters,
+            {"dms": {"z_score": np.array([1.0]), "dff": np.array([6.0, 7.0])}},
+        )
+
+        binned = read_binned_metrics_from_hdf5(run_folder, "dms")
+        np.testing.assert_array_equal(binned["transient_count_z_score"].to_numpy(), [1, 0])
+        np.testing.assert_array_equal(binned["transient_count_dff"].to_numpy(), [0, 2])

--- a/tests/unit/visualization/test_binned_metrics.py
+++ b/tests/unit/visualization/test_binned_metrics.py
@@ -1,0 +1,93 @@
+import holoviews as hv
+import numpy as np
+import pytest
+
+from guppy.visualization.binned_metrics import (
+    build_bin_bars,
+    build_binned_metrics_panel,
+)
+
+
+@pytest.fixture
+def bins():
+    # Two whole bins and a short third one, as a ragged final bin produces.
+    return {
+        "bin_starts": np.array([0.0, 4.0, 8.0]),
+        "bin_ends": np.array([4.0, 8.0, 10.0]),
+    }
+
+
+class TestBuildBinBars:
+    def test_one_bar_per_bin_spanning_its_bounds(self, bins, panel_extension):
+        bars = build_bin_bars(**bins, values=np.array([1.5, 5.5, 9.0]), value_label="mean z-score")
+
+        data = bars.array()
+        assert data.shape[0] == 3
+        # Each bar runs from its bin start to its bin end, and from zero to the value.
+        np.testing.assert_allclose(data[:, 0], [0.0, 4.0, 8.0])
+        np.testing.assert_allclose(data[:, 1], [0.0, 0.0, 0.0])
+        np.testing.assert_allclose(data[:, 2], [4.0, 8.0, 10.0])
+        np.testing.assert_allclose(data[:, 3], [1.5, 5.5, 9.0])
+
+    def test_final_bar_is_narrower_when_the_final_bin_is_ragged(self, bins, panel_extension):
+        bars = build_bin_bars(**bins, values=np.array([1.5, 5.5, 9.0]), value_label="mean z-score")
+
+        data = bars.array()
+        widths = data[:, 2] - data[:, 0]
+        np.testing.assert_allclose(widths, [4.0, 4.0, 2.0])
+
+    def test_nan_bins_are_not_drawn(self, bins, panel_extension):
+        bars = build_bin_bars(**bins, values=np.array([1.5, np.nan, 9.0]), value_label="mean z-score")
+
+        data = bars.array()
+        assert data.shape[0] == 2
+        np.testing.assert_allclose(data[:, 0], [0.0, 8.0])
+
+    def test_negative_values_bar_down_from_zero(self, bins, panel_extension):
+        bars = build_bin_bars(**bins, values=np.array([-1.5, 5.5, 9.0]), value_label="mean z-score")
+
+        data = bars.array()
+        np.testing.assert_allclose(data[0, 1], 0.0)
+        np.testing.assert_allclose(data[0, 3], -1.5)
+
+    def test_time_is_the_first_key_dimension(self, bins, panel_extension):
+        # The trace panel plots against "time (s)"; matching that name is what
+        # makes bokeh link the two axes in the stacked layout.
+        bars = build_bin_bars(**bins, values=np.array([1.5, 5.5, 9.0]), value_label="mean z-score")
+
+        assert [dimension.name for dimension in bars.kdims][:2] == ["time (s)", "mean z-score"]
+
+
+class TestBuildBinnedMetricsPanel:
+    def test_stacks_the_trace_over_the_bars(self, bins, panel_extension):
+        timestamps = np.arange(0, 11, 1, dtype=float)
+        layout = build_binned_metrics_panel(
+            timestamps=timestamps,
+            trace=timestamps.copy(),
+            trace_label="z-score",
+            **bins,
+            values=np.array([1.5, 5.5, 9.0]),
+            value_label="mean z-score",
+            suptitle="dms",
+        )
+
+        assert len(layout) == 2
+
+    def test_both_panels_share_one_time_axis(self, bins, panel_extension):
+        # Naming both panels' x dimension "time (s)" is what makes bokeh give them
+        # a single shared x_range, so zooming the bars zooms the trace with them.
+        timestamps = np.arange(0, 11, 1, dtype=float)
+        layout = build_binned_metrics_panel(
+            timestamps=timestamps,
+            trace=timestamps.copy(),
+            trace_label="z-score",
+            **bins,
+            values=np.array([1.5, 5.5, 9.0]),
+            value_label="mean z-score",
+            suptitle="dms",
+        )
+
+        plot = hv.renderer("bokeh").get_plot(layout)
+        trace_subplot, bars_subplot = list(plot.subplots.values())
+
+        assert trace_subplot.subplots["main"].handles["x_range"] is bars_subplot.subplots["main"].handles["x_range"]


### PR DESCRIPTION
Fixes #419 

Since this work creates a brand new type of GuPPy output that will need to be represented in ndx-guppy and the GuppyConverter, I'm holding off on merging this feature until https://github.com/LernerLab/GuPPy/pull/357 is in and released.

Follow-ups

- https://github.com/catalystneuro/ndx-guppy/pull/5
- https://github.com/catalystneuro/neuroconv/pull/1975


<details>
<summary>Details (AI-generated)</summary>

Closes #419.

Adds a **Compute Binned Metrics?** parameter (off by default) and a **Bin Width (s)**. When enabled, Step 4 divides each session into fixed-width bins and writes `binned_metrics_<site>.h5` and `.csv`: one row per bin with `bin_start`, `bin_end`, `n_samples`, `mean_zscore`, `mean_dff`, and a `transient_count_*` column per metric the detector ran on. The final bin is kept even when the session does not divide evenly, with its true bounds reported.

It hooks into `findFreqAndAmp`, where the transient occurrence times already exist — group mode is out of scope, since cross-session roll-up is an open question on the issue. Step 5 gains a **Binned** tab showing the selected metric as bars under the trace it was reduced from, on a linked time axis, with recording-site and metric selectors.

Verification: 117 unit tests across the new modules, plus `tests/integration/test_binned_metrics.py`, which cross-checks every per-bin mean against independently re-read traces. The full `test_integration_step4.py` suite passes across all five modalities and now asserts the outputs are absent by default. `pre-commit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>
