### PR TITLE
Rework the docs home page into a graphical launch point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Fixes
 
 ## Improvements
+- Reworked the documentation home page into a card-grid launch point over the Diátaxis sections, moved the installation walkthrough from the README onto its own [installation page](https://guppy.readthedocs.io/en/latest/installation.html), and trimmed the README to a quick start plus pointers to the docs. [PR #444](https://github.com/LernerLab/GuPPy/pull/444)
 - Added a [how-to guide for group analysis](https://guppy.readthedocs.io/en/latest/how-to/group-analysis.html): running Step 4's cross-session averaging and Step 5's averaged-results visualization. [PR #435](https://github.com/LernerLab/GuPPy/pull/435)
 
 ## Deprecations and Removals

--- a/README.md
+++ b/README.md
@@ -20,22 +20,7 @@ Then launch the user interface:
 guppy
 ```
 
-See the [installation guide](https://guppy.readthedocs.io/en/latest/installation.html) for the full walkthrough, including installing conda and installing from source.
-
-## Version status
-
-**GuPPy 2.0 is in beta.** No 2.0 stable release has been published yet, so the command above installs the latest beta.
-
-If you need a stable version, use **[GuPPy v1.3.0](https://github.com/LernerLab/GuPPy/releases/tag/v1.3.0)**. It predates the 2.0 rewrite and is not installable with `pip`: download the source from that release, then from inside the unpacked folder run
-
-```bash
-# Substitute spec_file_windows10.txt or spec_file_linux.txt for your OS.
-conda create --name guppy --file spec_file_mac.txt
-conda activate guppy
-panel serve --show GuPPy/savingInputParameters.ipynb
-```
-
-v1.3.0 has a different interface and different parameters, so the documentation below does not apply to it. Use the [GitHub Wiki](https://github.com/LernerLab/GuPPy/wiki) instead.
+See the [installation guide](https://guppy.readthedocs.io/en/latest/installation.html) for the full walkthrough, including installing conda and installing from source. This installs the GuPPy 2.0 beta — see [Older versions](#older-versions) if you need the stable v1.3.0.
 
 ## Documentation
 
@@ -55,3 +40,18 @@ The GuPPy documentation lives at [guppy.readthedocs.io](https://guppy.readthedoc
 - [Gabriela Lopez](https://github.com/glopez924)
 - [Talia Lerner](https://github.com/talialerner)
 - [Paul Adkisson-Floro](https://github.com/pauladkisson)
+
+## Older versions
+
+**GuPPy 2.0 is in beta.** No 2.0 stable release has been published yet, so `pip install guppy-neuro` installs the latest beta.
+
+If you need a stable version, use **[GuPPy v1.3.0](https://github.com/LernerLab/GuPPy/releases/tag/v1.3.0)**. It predates the 2.0 rewrite and is not installable with `pip`: download the source from that release, then from inside the unpacked folder run
+
+```bash
+# Substitute spec_file_windows10.txt or spec_file_linux.txt for your OS.
+conda create --name guppy --file spec_file_mac.txt
+conda activate guppy
+panel serve --show GuPPy/savingInputParameters.ipynb
+```
+
+v1.3.0 has a different interface and different parameters, so the documentation at guppy.readthedocs.io does not apply to it. Use the [GitHub Wiki](https://github.com/LernerLab/GuPPy/wiki) instead.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Guided Photometry Analysis in Python, a free and open-source fiber photometry data analysis tool.
 
+> **GuPPy 2.0 is in beta.** `pip install guppy-neuro` installs a pre-release. If you need a stable version, see [Older versions](#older-versions).
+
 ## Quick start
 
 Requires Python 3.10 or greater. We recommend installing into a conda environment:
@@ -20,7 +22,7 @@ Then launch the user interface:
 guppy
 ```
 
-See the [installation guide](https://guppy.readthedocs.io/en/latest/installation.html) for the full walkthrough, including installing conda and installing from source. This installs the GuPPy 2.0 beta — see [Older versions](#older-versions) if you need the stable v1.3.0.
+See the [installation guide](https://guppy.readthedocs.io/en/latest/installation.html) for the full walkthrough, including installing conda and installing from source.
 
 ## Documentation
 
@@ -43,9 +45,7 @@ The GuPPy documentation lives at [guppy.readthedocs.io](https://guppy.readthedoc
 
 ## Older versions
 
-**GuPPy 2.0 is in beta.** No 2.0 stable release has been published yet, so `pip install guppy-neuro` installs the latest beta.
-
-If you need a stable version, use **[GuPPy v1.3.0](https://github.com/LernerLab/GuPPy/releases/tag/v1.3.0)**. It predates the 2.0 rewrite and is not installable with `pip`: download the source from that release, then from inside the unpacked folder run
+No GuPPy 2.0 stable release has been published yet. If you need a stable version, use **[GuPPy v1.3.0](https://github.com/LernerLab/GuPPy/releases/tag/v1.3.0)**. It predates the 2.0 rewrite and is not installable with `pip`: download the source from that release, then from inside the unpacked folder run
 
 ```bash
 # Substitute spec_file_windows10.txt or spec_file_linux.txt for your OS.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,21 @@ guppy
 
 See the [installation guide](https://guppy.readthedocs.io/en/latest/installation.html) for the full walkthrough, including installing conda and installing from source.
 
+## Version status
+
+**GuPPy 2.0 is in beta.** No 2.0 stable release has been published yet, so the command above installs the latest beta.
+
+If you need a stable version, use **[GuPPy v1.3.0](https://github.com/LernerLab/GuPPy/releases/tag/v1.3.0)**. It predates the 2.0 rewrite and is not installable with `pip`: download the source from that release, then from inside the unpacked folder run
+
+```bash
+# Substitute spec_file_windows10.txt or spec_file_linux.txt for your OS.
+conda create --name guppy --file spec_file_mac.txt
+conda activate guppy
+panel serve --show GuPPy/savingInputParameters.ipynb
+```
+
+v1.3.0 has a different interface and different parameters, so the documentation below does not apply to it. Use the [GitHub Wiki](https://github.com/LernerLab/GuPPy/wiki) instead.
+
 ## Documentation
 
 The GuPPy documentation lives at [guppy.readthedocs.io](https://guppy.readthedocs.io/): a [tutorial](https://guppy.readthedocs.io/en/latest/tutorials/index.html) walking through a first analysis end to end, [how-to guides](https://guppy.readthedocs.io/en/latest/how-to/index.html) for individual tasks, [explanations](https://guppy.readthedocs.io/en/latest/explanation/index.html) of how the analysis works, and a [reference](https://guppy.readthedocs.io/en/latest/reference/index.html) for every input parameter and output file.

--- a/README.md
+++ b/README.md
@@ -2,112 +2,29 @@
 
 <img src="assets/GuppyLogo.png" alt="GuPPy Logo" width="300">
 
+Guided Photometry Analysis in Python, a free and open-source fiber photometry data analysis tool.
 
-## Installation
+## Quick start
 
-GuPPy can be run on Windows, Mac or Linux. It requires **Python 3.10 or greater**.
-
-### Step 1: Install Conda
-
-We recommend installing GuPPy inside a conda virtual environment to avoid conflicts with other Python packages on your system.
-
-1. Download the **Miniconda** installer for your operating system from the [official Miniconda page](https://docs.conda.io/en/latest/miniconda.html).
-   - **Windows**: Download the `.exe` installer and run it, following the on-screen prompts.
-   - **macOS**: Download the `.pkg` installer (or the `.sh` script) and follow the on-screen prompts. Alternatively, run the shell script in a terminal:
-     ```bash
-     bash Miniconda3-latest-MacOSX-x86_64.sh
-     ```
-   - **Linux**: Download the `.sh` installer and run it in a terminal:
-     ```bash
-     bash Miniconda3-latest-Linux-x86_64.sh
-     ```
-
-2. After installation, open a new terminal (or Command Prompt / Anaconda Prompt on Windows) and verify conda is available:
-   ```bash
-   conda --version
-   ```
-
-### Step 2: Create and Activate a Conda Environment
-
-1. Create a new conda environment named `guppy_env` with Python 3.12:
-   ```bash
-   conda create -n guppy_env python=3.12
-   ```
-
-2. Activate the environment:
-   ```bash
-   conda activate guppy_env
-   ```
-   Your terminal prompt should now show `(guppy_env)` to indicate the environment is active. You will need to activate this environment each time you open a new terminal before using GuPPy.
-
-### Step 3: Install GuPPy
-
-With the `guppy_env` environment active, install GuPPy using one of the two methods below.
-
-#### Option A: Install via PyPI (Recommended)
-
-Install the latest stable release directly from PyPI:
+Requires Python 3.10 or greater. We recommend installing into a conda environment:
 
 ```bash
+conda create -n guppy_env python=3.12
+conda activate guppy_env
 pip install guppy-neuro
 ```
 
-#### Option B: Install from GitHub (Latest Development Version)
-
-This option gives you access to the latest features and bug fixes that may not yet be in the stable release.
-You will need `git` installed ([installation instructions](https://github.com/git-guides/install-git)).
-
-1. Clone the repository:
-   ```bash
-   git clone https://github.com/LernerLab/GuPPy.git
-   ```
-
-2. Navigate into the cloned directory:
-   ```bash
-   cd GuPPy
-   ```
-
-3. Install the package in [editable mode](https://pip.pypa.io/en/stable/cli/pip_install/#editable-installs):
-   ```bash
-   pip install -e .
-   ```
-
-## Usage
-
-In a terminal or command prompt, you can start using GuPPy by running the following command:
+Then launch the user interface:
 
 ```bash
 guppy
 ```
 
-This will launch the GuPPy user interface, where you can begin analyzing your fiber photometry data.
+See the [installation guide](https://guppy.readthedocs.io/en/latest/installation.html) for the full walkthrough, including installing conda and installing from source.
 
 ## Documentation
 
 The GuPPy documentation lives at [guppy.readthedocs.io](https://guppy.readthedocs.io/): a [tutorial](https://guppy.readthedocs.io/en/latest/tutorials/index.html) walking through a first analysis end to end, [how-to guides](https://guppy.readthedocs.io/en/latest/how-to/index.html) for individual tasks, [explanations](https://guppy.readthedocs.io/en/latest/explanation/index.html) of how the analysis works, and a [reference](https://guppy.readthedocs.io/en/latest/reference/index.html) for every input parameter and output file.
-
-> **Note:** The Wiki and video tutorials below refer to GuPPy v1.3.0 and earlier.
-
-### Wiki
-- The full instructions along with detailed descriptions of each step to run the GuPPy tool is on [Github Wiki Page](https://github.com/LernerLab/GuPPy/wiki).
-
-### Tutorial Videos
-
-- [Installation steps](https://youtu.be/7qfU8xvj2nc)
-- [Explaining Input Parameters GUI](https://youtu.be/aO7_QqbYZ84)
-- [Individual Analysis steps](https://youtu.be/6IollIr9q6Y)
-- [Artifacts Removal](https://youtu.be/KXh3vkkZxuo)
-- [Group Analysis steps](https://youtu.be/lntf-SER_so)
-- [Use of csv file as an input](https://youtu.be/Yrhartn5Hwk)
-- [Use of Neurophotometrics data as an input](https://youtu.be/n1HSGRnBYPQ)
-
-## Sample Data
-
-- [Sample data](https://drive.google.com/drive/folders/1qO8ynfqRoEpWuJ0P1tYVHtLljJXoxufl?usp=sharing) for the user to go through the tool in the start. This folder of sample data has two types of sample data recorded with a TDT system : 1) Clean Data 2) Data with artifacts (to practice removing them) 3) Neurophotometrics data 4) Doric system data. Finally, it has a control channel, signal channel and event timestamps file in a 'csv' format to get an idea of how to structure other data in the 'csv' file format accepted by GuPPy.
-
-## Discussions
-
-- GuPPy was initially developed keeping our data (FP data recorded using TDT systems) in mind. GuPPy now supports data collected using Neurophotometrics, Doric system and also other data types/formats using 'csv' files as input, but these are less extensively tested because of lack of sample data. If you have any issues, please get in touch on the [chat room](https://gitter.im/LernerLab/GuPPy?utm_source=share-link&utm_medium=link&utm_campaign=share-link) or by [raising an issue](https://github.com/LernerLab/GuPPy/issues), so that we can continue to improve this tool.
 
 ## Citation
 

--- a/docs/citing.md
+++ b/docs/citing.md
@@ -1,0 +1,5 @@
+# Citing GuPPy
+
+If you use GuPPy in your research, please cite:
+
+> Venus N. Sherathiya, Michael D. Schaid, Jillian L. Seiler, Gabriela C. Lopez, and Talia N. Lerner. [GuPPy, a Python toolbox for the analysis of fiber photometry data](https://www.nature.com/articles/s41598-021-03626-9). Sci Rep 11, 24212 (2021). <https://doi.org/10.1038/s41598-021-03626-9>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,6 +8,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.intersphinx",
     "sphinx_autodoc_typehints",
+    "sphinx_design",
 ]
 
 html_theme = "pydata_sphinx_theme"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,6 +22,19 @@ html_logo = "../assets/GuppyLogo.png"
 
 html_theme_options = {
     "github_url": "https://github.com/LernerLab/GuPPy",
+    "header_links_before_dropdown": 7,
+    "icon_links": [
+        {
+            "name": "PyPI",
+            "url": "https://pypi.org/project/guppy-neuro/",
+            "icon": "fa-brands fa-python",
+        },
+        {
+            "name": "Issue tracker",
+            "url": "https://github.com/LernerLab/GuPPy/issues",
+            "icon": "fa-solid fa-circle-dot",
+        },
+    ],
     "logo": {
         "image_light": "../assets/GuppyLogo.png",
         "image_dark": "../assets/GuppyLogo.png",

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -1,6 +1,6 @@
 # How-to Guides
 
-How-to guides are task-oriented references for readers who know what they want to accomplish. Updated guides for GuPPy v2 are in progress. In the meantime, the [GitHub Wiki](https://github.com/LernerLab/GuPPy/wiki) covers the v1 workflow and remains a useful reference for most steps.
+How-to guides are task-oriented references for readers who know what they want to accomplish.
 
 ```{toctree}
 :maxdepth: 1
@@ -14,3 +14,17 @@ group-analysis
 export-to-nwb
 correlate-behavioral-covariates
 ```
+
+## Legacy v1 resources
+
+The materials below were written for GuPPy v1.3.0 and earlier. They still describe most steps usefully, but the interface and some parameters have changed in v2.
+
+- The [GitHub Wiki](https://github.com/LernerLab/GuPPy/wiki) covers the v1 workflow step by step.
+- Tutorial videos:
+  - [Installation steps](https://youtu.be/7qfU8xvj2nc)
+  - [Explaining Input Parameters GUI](https://youtu.be/aO7_QqbYZ84)
+  - [Individual analysis steps](https://youtu.be/6IollIr9q6Y)
+  - [Artifacts removal](https://youtu.be/KXh3vkkZxuo)
+  - [Group analysis steps](https://youtu.be/lntf-SER_so)
+  - [Use of csv file as an input](https://youtu.be/Yrhartn5Hwk)
+  - [Use of Neurophotometrics data as an input](https://youtu.be/n1HSGRnBYPQ)

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -14,17 +14,3 @@ group-analysis
 export-to-nwb
 correlate-behavioral-covariates
 ```
-
-## Legacy v1 resources
-
-The materials below were written for GuPPy v1.3.0 and earlier. They still describe most steps usefully, but the interface and some parameters have changed in v2.
-
-- The [GitHub Wiki](https://github.com/LernerLab/GuPPy/wiki) covers the v1 workflow step by step.
-- Tutorial videos:
-  - [Installation steps](https://youtu.be/7qfU8xvj2nc)
-  - [Explaining Input Parameters GUI](https://youtu.be/aO7_QqbYZ84)
-  - [Individual analysis steps](https://youtu.be/6IollIr9q6Y)
-  - [Artifacts removal](https://youtu.be/KXh3vkkZxuo)
-  - [Group analysis steps](https://youtu.be/lntf-SER_so)
-  - [Use of csv file as an input](https://youtu.be/Yrhartn5Hwk)
-  - [Use of Neurophotometrics data as an input](https://youtu.be/n1HSGRnBYPQ)

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@
 :align: center
 ```
 
-**Guided Photometry Analysis in Python** is an open-source tool for processing and analyzing fiber photometry recordings. It provides a GUI-based pipeline covering raw data ingestion, signal preprocessing, PSTH computation, transient detection, visualization, and export to NWB. Data formats supported include TDT, Doric, Neurophotometrics (NPM), and generic CSV.
+**Guided Photometry Analysis in Python** is an open-source tool for processing and analyzing fiber photometry recordings. It provides a GUI-based pipeline covering raw data ingestion, signal preprocessing, PSTH computation, transient detection, visualization, and export to NWB. Data formats supported include TDT, Doric, Neurophotometrics (NPM), NWB, and generic CSV.
 
 ::::{grid} 1 1 2 2
 :gutter: 3
@@ -55,22 +55,6 @@ Get oriented in the codebase: pipeline architecture, the test suite, and how to 
 
 ::::
 
-## Getting help
-
-GuPPy was initially developed with TDT recordings in mind. It now also supports Neurophotometrics, Doric, NWB and generic CSV inputs, but these are less extensively tested because of the limited sample data available for them. If you run into problems, get in touch on the [chat room](https://gitter.im/LernerLab/GuPPy?utm_source=share-link&utm_medium=link&utm_campaign=share-link) or by [raising an issue](https://github.com/LernerLab/GuPPy/issues), so that we can continue to improve the tool.
-
-## Citing GuPPy
-
-If you use GuPPy in your research, please cite:
-
-> Venus N. Sherathiya, Michael D. Schaid, Jillian L. Seiler, Gabriela C. Lopez, and Talia N. Lerner. [GuPPy, a Python toolbox for the analysis of fiber photometry data](https://www.nature.com/articles/s41598-021-03626-9). Sci Rep 11, 24212 (2021). <https://doi.org/10.1038/s41598-021-03626-9>
-
-## Links
-
-- [Source code](https://github.com/LernerLab/GuPPy)
-- [PyPI package](https://pypi.org/project/guppy-neuro/)
-- [Issue tracker](https://github.com/LernerLab/GuPPy/issues)
-
 ```{toctree}
 :maxdepth: 1
 :hidden:
@@ -80,5 +64,6 @@ tutorials/index
 how-to/index
 explanation/index
 reference/index
-contributing/index
+Contributing <contributing/index>
+Cite <citing>
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,32 +8,77 @@
 
 **Guided Photometry Analysis in Python** is an open-source tool for processing and analyzing fiber photometry recordings. It provides a GUI-based pipeline covering raw data ingestion, signal preprocessing, PSTH computation, transient detection, visualization, and export to NWB. Data formats supported include TDT, Doric, Neurophotometrics (NPM), and generic CSV.
 
-## Installation
+::::{grid} 1 1 2 2
+:gutter: 3
 
-```bash
-pip install guppy-neuro
-```
+:::{grid-item-card} {octicon}`download;1.5em;sd-mr-1` Installation
+:link: installation
+:link-type: doc
 
-Then launch the GUI:
+Set up a conda environment and install GuPPy from PyPI or from source.
+:::
 
-```bash
-guppy
-```
+:::{grid-item-card} {octicon}`rocket;1.5em;sd-mr-1` Tutorials
+:link: tutorials/index
+:link-type: doc
 
-```{toctree}
-:maxdepth: 1
-:caption: Contents
+Learning-oriented guides that walk you through a complete workflow from start to finish. Start here if you are new to GuPPy.
+:::
 
-tutorials/index
-how-to/index
-explanation/index
-reference/index
-contributing/index
-```
+:::{grid-item-card} {octicon}`checklist;1.5em;sd-mr-1` How-to Guides
+:link: how-to/index
+:link-type: doc
+
+Task-oriented recipes for readers who already know what they want to accomplish.
+:::
+
+:::{grid-item-card} {octicon}`light-bulb;1.5em;sd-mr-1` Explanation
+:link: explanation/index
+:link-type: doc
+
+Background and context: the science behind fiber photometry, the design of the GuPPy pipeline, and the reasoning behind key parameter choices.
+:::
+
+:::{grid-item-card} {octicon}`book;1.5em;sd-mr-1` Reference
+:link: reference/index
+:link-type: doc
+
+Lookup material: every input parameter the GUI exposes, every file GuPPy writes, and the vocabulary GuPPy uses for its data entities.
+:::
+
+:::{grid-item-card} {octicon}`git-pull-request;1.5em;sd-mr-1` Contributor's Guide
+:link: contributing/index
+:link-type: doc
+
+Get oriented in the codebase: pipeline architecture, the test suite, and how to add support for a new recording format.
+:::
+
+::::
+
+## Getting help
+
+GuPPy was initially developed with TDT recordings in mind. It now also supports Neurophotometrics, Doric, NWB and generic CSV inputs, but these are less extensively tested because of the limited sample data available for them. If you run into problems, get in touch on the [chat room](https://gitter.im/LernerLab/GuPPy?utm_source=share-link&utm_medium=link&utm_campaign=share-link) or by [raising an issue](https://github.com/LernerLab/GuPPy/issues), so that we can continue to improve the tool.
+
+## Citing GuPPy
+
+If you use GuPPy in your research, please cite:
+
+> Venus N. Sherathiya, Michael D. Schaid, Jillian L. Seiler, Gabriela C. Lopez, and Talia N. Lerner. [GuPPy, a Python toolbox for the analysis of fiber photometry data](https://www.nature.com/articles/s41598-021-03626-9). Sci Rep 11, 24212 (2021). <https://doi.org/10.1038/s41598-021-03626-9>
 
 ## Links
 
 - [Source code](https://github.com/LernerLab/GuPPy)
 - [PyPI package](https://pypi.org/project/guppy-neuro/)
 - [Issue tracker](https://github.com/LernerLab/GuPPy/issues)
-- [GitHub Wiki](https://github.com/LernerLab/GuPPy/wiki) (covers v1.3.0 and earlier; updated guides for v2 are being added here)
+
+```{toctree}
+:maxdepth: 1
+:hidden:
+
+installation
+tutorials/index
+how-to/index
+explanation/index
+reference/index
+contributing/index
+```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -96,8 +96,6 @@ git lfs install
 git lfs pull --include="stubbed_testing_data/csv/sample_data_csv_1/*"
 ```
 
-Larger practice recordings for every supported acquisition format are listed under [sample data](tutorials/index.md#sample-data).
-
 ## Setting up a development environment
 
 Contributors who need the test, docs or linting dependencies should follow the [development environment guide](contributing/development_environment.md), which covers GuPPy's [PEP 735](https://peps.python.org/pep-0735/) dependency groups.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -49,10 +49,14 @@ With the `guppy_env` environment active, install GuPPy using one of the two meth
 
 ### Option A: Install from PyPI (recommended)
 
-Install the latest stable release:
-
 ```bash
 pip install guppy-neuro
+```
+
+```{note}
+GuPPy 2.0 is in beta. No 2.0 stable release has been published yet, so this installs the latest
+beta. If you need a stable version, see the [v1.3.0 release](https://github.com/LernerLab/GuPPy/releases/tag/v1.3.0),
+which predates the 2.0 rewrite and is documented on the [GitHub Wiki](https://github.com/LernerLab/GuPPy/wiki).
 ```
 
 ### Option B: Install from GitHub (latest development version)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,103 @@
+# Installation
+
+GuPPy runs on Windows, macOS and Linux, and requires **Python 3.10 or greater**.
+
+## Step 1: Install Conda
+
+We recommend installing GuPPy inside a conda virtual environment to avoid conflicts with other Python packages on your system.
+
+1. Download the **Miniconda** installer for your operating system from the [official Miniconda page](https://docs.conda.io/en/latest/miniconda.html).
+
+   - **Windows**: download the `.exe` installer and run it, following the on-screen prompts.
+   - **macOS**: download the `.pkg` installer (or the `.sh` script) and follow the on-screen prompts. Alternatively, run the shell script in a terminal:
+
+     ```bash
+     bash Miniconda3-latest-MacOSX-x86_64.sh
+     ```
+
+   - **Linux**: download the `.sh` installer and run it in a terminal:
+
+     ```bash
+     bash Miniconda3-latest-Linux-x86_64.sh
+     ```
+
+2. After installation, open a new terminal (or Command Prompt / Anaconda Prompt on Windows) and verify conda is available:
+
+   ```bash
+   conda --version
+   ```
+
+## Step 2: Create and activate a conda environment
+
+1. Create a new conda environment named `guppy_env` with Python 3.12:
+
+   ```bash
+   conda create -n guppy_env python=3.12
+   ```
+
+2. Activate the environment:
+
+   ```bash
+   conda activate guppy_env
+   ```
+
+   Your terminal prompt should now show `(guppy_env)` to indicate the environment is active. You will need to activate this environment each time you open a new terminal before using GuPPy.
+
+## Step 3: Install GuPPy
+
+With the `guppy_env` environment active, install GuPPy using one of the two methods below.
+
+### Option A: Install from PyPI (recommended)
+
+Install the latest stable release:
+
+```bash
+pip install guppy-neuro
+```
+
+### Option B: Install from GitHub (latest development version)
+
+This option gives you access to the latest features and bug fixes that may not yet be in the stable release. You will need `git` installed ([installation instructions](https://github.com/git-guides/install-git)).
+
+1. Clone the repository:
+
+   ```bash
+   git clone https://github.com/LernerLab/GuPPy.git
+   ```
+
+2. Navigate into the cloned directory:
+
+   ```bash
+   cd GuPPy
+   ```
+
+3. Install the package in [editable mode](https://pip.pypa.io/en/stable/cli/pip_install/#editable-installs):
+
+   ```bash
+   pip install -e .
+   ```
+
+## Launching GuPPy
+
+In a terminal with `guppy_env` active, run:
+
+```bash
+guppy
+```
+
+This launches the GuPPy user interface, where you can begin analyzing your fiber photometry data. The [first analysis tutorial](tutorials/first_analysis.md) walks through a complete session from there.
+
+## Sample data included in the repository
+
+The first tutorial analyzes a small CSV session stored in the repository under `stubbed_testing_data/`. Those files are tracked with [Git LFS](https://git-lfs.com), so a plain clone leaves you with pointer files rather than the recordings themselves. If you installed from source and want the sample session, install Git LFS once per machine and fetch the files:
+
+```bash
+git lfs install
+git lfs pull --include="stubbed_testing_data/csv/sample_data_csv_1/*"
+```
+
+Larger practice recordings for every supported acquisition format are listed under [sample data](tutorials/index.md#sample-data).
+
+## Setting up a development environment
+
+Contributors who need the test, docs or linting dependencies should follow the [development environment guide](contributing/development_environment.md), which covers GuPPy's [PEP 735](https://peps.python.org/pep-0735/) dependency groups.

--- a/docs/tutorials/first_analysis.md
+++ b/docs/tutorials/first_analysis.md
@@ -26,7 +26,7 @@ By the end you will have:
   pip install -e .
   ```
 
-  See the [README](https://github.com/LernerLab/GuPPy#installation) for the full installation guide, including how to set up a conda environment first. The plain `pip install guppy-neuro` path also works for installing the GUI itself, but you would still need to clone the repo (with Git LFS) separately to access the sample data.
+  See [installation](../installation.md) for the full installation guide, including how to set up a conda environment first. The plain `pip install guppy-neuro` path also works for installing the GUI itself, but you would still need to clone the repo (with Git LFS) separately to access the sample data.
 
 - The sample data lives at `stubbed_testing_data/csv/sample_data_csv_1/` inside the cloned repository. It contains three CSV files:
 

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -9,3 +9,9 @@ first_analysis
 custom_plots
 compare_parameters
 ```
+
+## Sample data
+
+The [first analysis tutorial](first_analysis.md) uses a small CSV session that ships with the repository under `stubbed_testing_data/`, so you can follow along without downloading anything extra. See [installation](../installation.md#sample-data-included-in-the-repository) for how to fetch it with Git LFS.
+
+For longer recordings covering every supported acquisition format, a [sample data folder](https://drive.google.com/drive/folders/1qO8ynfqRoEpWuJ0P1tYVHtLljJXoxufl?usp=sharing) is available on Google Drive. It contains two TDT sessions — one clean and one with artifacts, for practicing artifact removal — plus Neurophotometrics and Doric sessions, and a control channel, signal channel and event timestamps file in GuPPy's CSV format to illustrate how to structure other data for CSV input.

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -9,9 +9,3 @@ first_analysis
 custom_plots
 compare_parameters
 ```
-
-## Sample data
-
-The [first analysis tutorial](first_analysis.md) uses a small CSV session that ships with the repository under `stubbed_testing_data/`, so you can follow along without downloading anything extra. See [installation](../installation.md#sample-data-included-in-the-repository) for how to fetch it with Git LFS.
-
-For longer recordings covering every supported acquisition format, a [sample data folder](https://drive.google.com/drive/folders/1qO8ynfqRoEpWuJ0P1tYVHtLljJXoxufl?usp=sharing) is available on Google Drive. It contains two TDT sessions — one clean and one with artifacts, for practicing artifact removal — plus Neurophotometrics and Doric sessions, and a control channel, signal channel and event timestamps file in GuPPy's CSV format to illustrate how to structure other data for CSV input.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ docs = [
     "pydata-sphinx-theme",
     "myst-parser",
     "sphinx-autodoc-typehints",
+    "sphinx-design",
 ]
 
 test = [


### PR DESCRIPTION

<details>
<summary>Details (AI-generated)</summary>

Addresses three of the four **Homepage** boxes in #136: the home page carrying the README's information, the README pointing at the docs, and the NumPy-style graphical launch point. The fourth box, *Update branding*, is deliberately left alone for a separate PR — no logo, theme or CSS changes here.

The installation walkthrough moves from the README to a new `docs/installation.md`, and `docs/index.md` becomes a `sphinx-design` card grid over the five Diátaxis sections plus installation, with the root toctree hidden so the navbar carries the nav. Two README sections that aren't installation are rehomed rather than dropped: the Google Drive sample data to `docs/tutorials/index.md`, and the wiki and v1.3.0 tutorial videos to a "Legacy v1 resources" section in `docs/how-to/index.md`. The README keeps a three-command quick start, the documentation links, citation and contributors. `sphinx-design` is added to the `docs` dependency group.

Verification: `sphinx-build -W` builds clean; a crawl of the built site found 0 broken internal links or anchors; `pre-commit` passes on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>