### PR TITLE
Remove the dead progress_bar pytest marker

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -75,7 +75,7 @@ jobs:
           rclone-config: ${{ secrets.RCLONE_CONFIG }}
 
       - name: Run tests
-        run: pytest tests -vv -rsx -n auto --dist worksteal -m "not parallel and not ui and not dandi_live${{ inputs.skip-full-data-tests && ' and not full_data' || '' }}${{ runner.os == 'Windows' && ' and not progress_bar' || '' }}" --cov=guppy --cov-branch --cov-report=xml
+        run: pytest tests -vv -rsx -n auto --dist worksteal -m "not parallel and not ui and not dandi_live${{ inputs.skip-full-data-tests && ' and not full_data' || '' }}" --cov=guppy --cov-branch --cov-report=xml
       - name: Run parallel tests
         run: pytest tests -vv -rsx -m "parallel and not full_data and not dandi_live" --cov=guppy --cov-append --cov-report=xml
       # UI tests run serially in their own process so the threaded live Panel server never shares

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Refreshed the GuPPy branding: a new logo across the README and the documentation site, a fish-only mark in the docs header that stays legible in both light and dark mode, and a favicon for the documentation site, which previously had none. [PR #445](https://github.com/LernerLab/GuPPy/pull/445)
 - Reworked the documentation home page into a card-grid launch point over the Diátaxis sections, moved the installation walkthrough from the README onto its own [installation page](https://guppy.readthedocs.io/en/latest/installation.html), and trimmed the README to a quick start plus pointers to the docs. [PR #444](https://github.com/LernerLab/GuPPy/pull/444)
 - Added a [how-to guide for group analysis](https://guppy.readthedocs.io/en/latest/how-to/group-analysis.html): running Step 4's cross-session averaging and Step 5's averaged-results visualization. [PR #435](https://github.com/LernerLab/GuPPy/pull/435)
+- Removed the `progress_bar` pytest marker, which was applied to no tests and made every Windows CI run deselect nothing. [PR #449](https://github.com/LernerLab/GuPPy/pull/449)
 
 ## Deprecations and Removals
 

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -20,8 +20,7 @@ command to run while iterating on it — saves you from waiting on the slow ones
 
 ## Markers
 
-Four of the five registered markers gate tests that need something beyond a plain `pytest`
-invocation:
+The registered markers gate tests that need something beyond a plain `pytest` invocation:
 
 - **`full_data`** — needs the full `testing_data/` download, not present in a normal checkout.
   Deselect with `-m "not full_data"`.
@@ -31,8 +30,6 @@ invocation:
   `-m "not ui"`.
 - **`dandi_live`** — streams from the real DANDI Archive over the network. Opt in explicitly with
   `-m dandi_live`; never run it as part of a broader selection.
-- **`progress_bar`** — exercises the progress-bar file-locking loop. Currently applied to no tests,
-  and skipped on Windows in CI when it is.
 
 Markers are declared in
 [`pyproject.toml`](https://github.com/LernerLab/GuPPy/blob/main/pyproject.toml) under

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,5 +182,4 @@ markers = [
     "parallel: marks tests that verify GuPPy multiprocessing behavior (run separately from the main suite)",
     "ui: marks tests that require a live Panel server and browser (deselect with '-m not ui')",
     "dandi_live: marks tests that stream from the real DANDI Archive (deselect with '-m not dandi_live'; skipped in CI, for local use only)",
-    "progress_bar: marks tests that exercise the progress-bar file-locking loop (skipped on Windows in CI due to threading/file-lock issues; see issue #286)",
 ]


### PR DESCRIPTION

<details>
<summary>Details (AI-generated)</summary>

Closes #442.

Removes the `progress_bar` marker declaration from `pyproject.toml`, the Windows-only
`and not progress_bar` conditional from the test invocation in `.github/workflows/run-tests.yml`,
and the marker's bullet from `docs/contributing/testing.md` (with the "Four of the five registered
markers" sentence above it reworded, since it only read that way because of this marker).

Verified `pytest --markers` now lists only the four remaining GuPPy markers, the workflow file still
parses as YAML, and `pre-commit run --files` is clean on the three changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>