### PR TITLE
Make count_samples part of the BaseRecordingExtractor contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Fixes
 
 ## Improvements
+- Made `count_samples()` a required method of the recording extractor contract, so a new acquisition format that omits it fails immediately instead of quietly mis-sizing the Read Raw Data progress bar. [PR #450](https://github.com/LernerLab/GuPPy/pull/450)
 - Refreshed the GuPPy branding: a new logo across the README and the documentation site, a fish-only mark in the docs header that stays legible in both light and dark mode, and a favicon for the documentation site, which previously had none. [PR #445](https://github.com/LernerLab/GuPPy/pull/445)
 - Reworked the documentation home page into a card-grid launch point over the Diátaxis sections, moved the installation walkthrough from the README onto its own [installation page](https://guppy.readthedocs.io/en/latest/installation.html), and trimmed the README to a quick start plus pointers to the docs. [PR #444](https://github.com/LernerLab/GuPPy/pull/444)
 - Added a [how-to guide for group analysis](https://guppy.readthedocs.io/en/latest/how-to/group-analysis.html): running Step 4's cross-session averaging and Step 5's averaged-results visualization. [PR #435](https://github.com/LernerLab/GuPPy/pull/435)

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -42,9 +42,8 @@ means a user sees the error before a progress bar starts moving.
 ### `extractors/`
 
 Reads raw acquisition data. Every reader subclasses `BaseRecordingExtractor` and implements the same
-four required methods — `discover_events_and_flags()`, `read()`, `save()`, and `stub()` — plus
-`count_samples()` for progress reporting, so the rest of the codebase never branches on acquisition
-format.
+five required methods — `discover_events_and_flags()`, `read()`, `save()`, `count_samples()`, and
+`stub()` — so the rest of the codebase never branches on acquisition format.
 
 Supported formats: `TdtRecordingExtractor`, `DoricRecordingExtractor`, `NpmRecordingExtractor`,
 `CsvRecordingExtractor`, `NwbRecordingExtractor`, and `DandiNwbRecordingExtractor` for streaming

--- a/docs/contributing/new_recording_format.md
+++ b/docs/contributing/new_recording_format.md
@@ -8,11 +8,12 @@ a different concern. This page is the full recipe; [Architecture](architecture.m
 
 Every reader subclasses
 [`BaseRecordingExtractor`](https://github.com/LernerLab/GuPPy/blob/main/src/guppy/extractors/base_recording_extractor.py)
-and implements four `@abstractmethod`s:
+and implements five `@abstractmethod`s:
 
 - `discover_events_and_flags(cls) -> tuple[list[str], list[str]]`
 - `read(self, *, events: list[str], outputPath: str) -> list[dict[str, Any]]`
 - `save(self, *, output_dicts: list[dict[str, Any]], outputPath: str) -> None`
+- `count_samples(self, *, event: str) -> int`
 - `stub(self, *, folder_path: str | Path, duration_in_seconds: float = 1.0) -> None`
 
 `discover_events_and_flags` is declared on the base class with no parameters beyond `cls` — an
@@ -23,22 +24,17 @@ demultiplexing its interleaved channels needs the channel count and, optionally,
 settings chosen in the Label Stores GUI.
 
 `read()` returns one dict per event with keys such as `store_id`, `timestamps`, `data`, and
-`sampling_rate`; `save()` writes those dicts to HDF5; `stub()` copies the source folder and truncates
-it to a short duration for the test suite.
+`sampling_rate`; `save()` writes those dicts to HDF5; `count_samples()` reports an event's total
+sample count, which `orchestrate_read_raw_data` sums to size the step-2 progress bar before any data
+is read — so answer it from metadata rather than by reading the samples; `stub()` copies the source
+folder and truncates it to a short duration for the test suite.
 
-### `count_samples` and `committed_samples_for_event`
-
-Every concrete extractor also implements `count_samples(self, *, event: str) -> int`, even though it
-is not one of the four `@abstractmethod`s. `orchestrate_read_raw_data` in
-[`orchestration/read_raw_data.py`](https://github.com/LernerLab/GuPPy/blob/main/src/guppy/orchestration/read_raw_data.py)
-calls it via `hasattr(extractor, "count_samples")`, defaulting to `0` when absent, so it is
-duck-typed rather than enforced by the base class — but every extractor needs it to size the
-step-2 progress bar, so treat it as a fifth required method.
+### `committed_samples_for_event`
 
 `committed_samples_for_event(self, event) -> int` is an optional hook for extractors that report
-progress incrementally during `read()` itself, ahead of the event finishing. Only
-`DandiNwbRecordingExtractor` implements it, to convert the bytes its streaming reader has already
-pulled off the wire into a samples estimate. Most new extractors will not need it.
+progress incrementally during `read()` itself, ahead of the event finishing. The base class returns
+`0`; only `DandiNwbRecordingExtractor` overrides it, to convert the bytes its streaming reader has
+already pulled off the wire into a samples estimate. Most new extractors will not need it.
 
 ## Start from the mock extractor
 

--- a/src/guppy/extractors/base_recording_extractor.py
+++ b/src/guppy/extractors/base_recording_extractor.py
@@ -98,6 +98,47 @@ class BaseRecordingExtractor(ABC):
         pass
 
     @abstractmethod
+    def count_samples(self, *, event: str) -> int:
+        """
+        Return the total number of samples recorded for one event.
+
+        Used to size the denominator of the step-2 progress bar before any data
+        is read, so it should be answered from metadata rather than by reading
+        the event's samples.
+
+        Parameters
+        ----------
+        event : str
+            Name of the event/store to count.
+
+        Returns
+        -------
+        int
+            Total number of samples for the event.
+        """
+        pass
+
+    def committed_samples_for_event(self, event: str) -> int:
+        """
+        Return the number of samples already reported to the progress counter.
+
+        Extractors that advance the shared progress counter incrementally during
+        read() override this so the residual added once the event completes does
+        not double-count. The default reports nothing committed mid-read.
+
+        Parameters
+        ----------
+        event : str
+            Name of the event/store to report on.
+
+        Returns
+        -------
+        int
+            Number of samples already committed for the event.
+        """
+        return 0
+
+    @abstractmethod
     def stub(self, *, folder_path: str | Path, duration_in_seconds: float = 1.0) -> None:
         """
         Create a stubbed copy of the data folder truncated to a short duration.
@@ -149,10 +190,9 @@ def read_and_save_events_for_extractor(
     output_dicts = extractor.read(events=normalized_events, outputPath=outputPath)
     extractor.save(output_dicts=output_dicts, outputPath=outputPath)
     # Extractors that report progress incrementally during read (e.g. DANDI's
-    # passive byte counter) expose ``committed_samples_for_event``. Subtract
+    # passive byte counter) override ``committed_samples_for_event``. Subtract
     # what they already committed so we only add the residual at event end.
-    has_passive_counter = hasattr(extractor, "committed_samples_for_event")
     for event in normalized_events:
-        already_committed = int(extractor.committed_samples_for_event(event)) if has_passive_counter else 0
+        already_committed = int(extractor.committed_samples_for_event(event))
         add_samples_done(int(event_total_samples.get(event, 0)) - already_committed)
         logger.info("Data for event {} fetched and stored.".format(event))

--- a/src/guppy/orchestration/read_raw_data.py
+++ b/src/guppy/orchestration/read_raw_data.py
@@ -174,9 +174,7 @@ def orchestrate_read_raw_data(inputParameters: dict[str, object]) -> None:
                         f"Event '{event}' not found in any extractor for folder {filepath}. "
                         f"Available events: {available}."
                     )
-                event_total_samples[event] = (
-                    int(extractor.count_samples(event=event)) if hasattr(extractor, "count_samples") else 0
-                )
+                event_total_samples[event] = int(extractor.count_samples(event=event))
                 total_samples += event_total_samples[event]
 
             # Group events by extractor instance identity so each task is one

--- a/tests/unit/extractors/test_base_recording_extractor.py
+++ b/tests/unit/extractors/test_base_recording_extractor.py
@@ -4,7 +4,10 @@ import h5py
 import numpy as np
 import pytest
 
-from guppy.extractors.base_recording_extractor import read_and_save_events_for_extractor
+from guppy.extractors.base_recording_extractor import (
+    BaseRecordingExtractor,
+    read_and_save_events_for_extractor,
+)
 from guppy.testing.mock_recording_extractor import (
     _MOCK_DURATION_IN_SECONDS,
     _MOCK_SAMPLING_RATE,
@@ -66,6 +69,38 @@ def test_batched_events_with_u34_store_id_normalizes_dtype(tmp_path):
     assert (tmp_path / "fiber_photometry_response_series_0.hdf5").exists()
     with h5py.File(tmp_path / "fiber_photometry_response_series_0.hdf5", "r") as file:
         assert "timestamps" in file
+
+
+# ---------------------------------------------------------------------------
+# Abstract-method contract
+# ---------------------------------------------------------------------------
+
+
+def test_subclass_without_count_samples_cannot_be_instantiated():
+    """A subclass that forgets count_samples fails loudly at instantiation."""
+
+    class _MissingCountSamples(BaseRecordingExtractor):
+        @classmethod
+        def discover_events_and_flags(cls):
+            return [], []
+
+        def read(self, *, events, outputPath):
+            return []
+
+        def save(self, *, output_dicts, outputPath):
+            return None
+
+        def stub(self, *, folder_path, duration_in_seconds=1.0):
+            return None
+
+    with pytest.raises(TypeError, match="count_samples"):
+        _MissingCountSamples()
+
+
+def test_committed_samples_for_event_defaults_to_zero():
+    extractor = MockRecordingExtractor("mock_folder")
+
+    assert extractor.committed_samples_for_event("mock_signal") == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/orchestration/test_read_raw_data.py
+++ b/tests/unit/orchestration/test_read_raw_data.py
@@ -5,6 +5,7 @@ import time
 
 import pytest
 
+from guppy.extractors.base_recording_extractor import BaseRecordingExtractor
 from guppy.orchestration.read_raw_data import orchestrate_read_raw_data
 from guppy.utils.progress import StepProgress, _current_step
 from guppy_test_data import STUBBED_TESTING_DATA
@@ -117,10 +118,14 @@ class TestProgressAccountingEndToEnd:
         # read+save are no-ops on disk.
         observed_during_read = []
 
-        class _ObservingExtractor:
+        class _ObservingExtractor(BaseRecordingExtractor):
             def __init__(self, event, sample_count):
                 self.event = event
                 self.sample_count = sample_count
+
+            @classmethod
+            def discover_events_and_flags(cls):
+                raise NotImplementedError
 
             def count_samples(self, *, event):
                 return self.sample_count
@@ -132,6 +137,9 @@ class TestProgressAccountingEndToEnd:
 
             def save(self, *, output_dicts, outputPath):
                 return None
+
+            def stub(self, *, folder_path, duration_in_seconds=1.0):
+                raise NotImplementedError
 
         def fake_build_event_to_extractor(*, folder_path, store_array, inputParameters):
             return {


### PR DESCRIPTION

<details>
<summary>Details (AI-generated)</summary>

Closes #443.

`count_samples(self, *, event: str) -> int` is now an `@abstractmethod` on `BaseRecordingExtractor`,
and `committed_samples_for_event(self, event) -> int` has a concrete base implementation returning
`0`. Both `hasattr` guards — in `orchestrate_read_raw_data` and in
`read_and_save_events_for_extractor` — are gone. The `extractors/` section of
`docs/contributing/architecture.md` and the contract section of
`docs/contributing/new_recording_format.md` now describe five abstract methods instead of four plus
a duck-typed fifth.

No behavior change for any existing extractor; all seven already implement `count_samples`. The one
duck-typed test double in `tests/unit/orchestration/test_read_raw_data.py` now subclasses
`BaseRecordingExtractor`, and two tests were added covering the new contract.

Verified: `pytest tests/unit/extractors tests/unit/orchestration/test_read_raw_data.py
tests/integration/test_integration_step2.py -m "not dandi_live"` — 744 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>