### PR TITLE
Drop the /en/latest/ prefix from readthedocs links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Features
 
 ## Fixes
+- Fixed the README's documentation links, which all carried an `/en/latest/` path prefix that 404s on the single-version Read the Docs project. [PR #469](https://github.com/LernerLab/GuPPy/pull/469)
 
 ## Improvements
 - The documentation now explains why `.h5` and `.hdf5` outputs need different readers, rather than only warning that they do: `.h5` files are written by pandas in its fixed format, so reading one with h5py shows the table decomposed into its storage blocks instead of its columns. [PR #470](https://github.com/LernerLab/GuPPy/pull/470)

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ Then launch the user interface:
 guppy
 ```
 
-See the [installation guide](https://guppy.readthedocs.io/en/latest/installation.html) for the full walkthrough, including installing conda and installing from source.
+See the [installation guide](https://guppy.readthedocs.io/installation.html) for the full walkthrough, including installing conda and installing from source.
 
 ## Documentation
 
-The GuPPy documentation lives at [guppy.readthedocs.io](https://guppy.readthedocs.io/): a [tutorial](https://guppy.readthedocs.io/en/latest/tutorials/index.html) walking through a first analysis end to end, [how-to guides](https://guppy.readthedocs.io/en/latest/how-to/index.html) for individual tasks, [explanations](https://guppy.readthedocs.io/en/latest/explanation/index.html) of how the analysis works, and a [reference](https://guppy.readthedocs.io/en/latest/reference/index.html) for every input parameter and output file.
+The GuPPy documentation lives at [guppy.readthedocs.io](https://guppy.readthedocs.io/): a [tutorial](https://guppy.readthedocs.io/tutorials/index.html) walking through a first analysis end to end, [how-to guides](https://guppy.readthedocs.io/how-to/index.html) for individual tasks, [explanations](https://guppy.readthedocs.io/explanation/index.html) of how the analysis works, and a [reference](https://guppy.readthedocs.io/reference/index.html) for every input parameter and output file.
 
 ## Citation
 


### PR DESCRIPTION

<details>
<summary>Details (AI-generated)</summary>

Closes #460.

Rewrites the 2 `guppy.readthedocs.io/en/latest/...` links in `README.md` to `guppy.readthedocs.io/...`, and verifies all 5 doc URLs in the file now return 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>