### PR TITLE
Read TDT .tev stores in large sequential chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed the README's documentation links, which all carried an `/en/latest/` path prefix that 404s on the single-version Read the Docs project. [PR #469](https://github.com/LernerLab/GuPPy/pull/469)
 
 ## Improvements
+- Reading TDT tanks is much faster on a network share: each continuous store's `.tev` data is now fetched in large sequential chunks instead of one small read per data block, so Read Raw Data no longer pays a network round trip for every block. [PR #473](https://github.com/LernerLab/GuPPy/pull/473)
 - GuPPy now reports its own version: `guppy --version` prints it, the user interface header shows it, and the [installation page](https://guppy.readthedocs.io/en/latest/installation.html) covers how to check it and how to upgrade an existing install. [PR #471](https://github.com/LernerLab/GuPPy/pull/471)
 - The documentation now explains why `.h5` and `.hdf5` outputs need different readers, rather than only warning that they do: `.h5` files are written by pandas in its fixed format, so reading one with h5py shows the table decomposed into its storage blocks instead of its columns. [PR #470](https://github.com/LernerLab/GuPPy/pull/470)
 

--- a/src/guppy/extractors/tdt_recording_extractor.py
+++ b/src/guppy/extractors/tdt_recording_extractor.py
@@ -15,6 +15,10 @@ from guppy.utils._hdf5_io import write_hdf5
 
 logger = logging.getLogger(__name__)
 
+# Bytes fetched per read of the .tev file. Large sequential reads keep the number of
+# round trips small when the tank lives on a network share.
+TEV_CHUNK_BYTES = 32 * 1024 * 1024
+
 
 class TdtRecordingExtractor(BaseRecordingExtractor):
     """
@@ -109,7 +113,67 @@ class TdtRecordingExtractor(BaseRecordingExtractor):
         logger.info("Data from tsq file fetched.")
         return df, flag
 
-    def _readtev(self, event: str) -> dict[str, object]:
+    @staticmethod
+    def _read_tev_blocks(
+        tev_file_path: str,
+        *,
+        block_offsets: np.ndarray,
+        samples_per_block: int,
+        dtype: type,
+        chunk_bytes: int,
+    ) -> np.ndarray:
+        """
+        Read fixed-size data blocks from a ``.tev`` file into a 2-D float64 array.
+
+        Every read starts at the next unread block and covers all of the following blocks
+        that fit in ``chunk_bytes``, so a store whose blocks are spread through the file
+        costs a handful of reads rather than one per block. Block offsets must be
+        increasing, as they are in ``.tsq`` header order.
+
+        Parameters
+        ----------
+        tev_file_path : str
+            Path to the ``.tev`` file.
+        block_offsets : np.ndarray
+            Byte offset of each block, in increasing order.
+        samples_per_block : int
+            Number of samples in every block.
+        dtype : type
+            NumPy scalar type of the samples on disk.
+        chunk_bytes : int
+            Number of bytes fetched per read.
+
+        Returns
+        -------
+        np.ndarray
+            Array of shape ``(len(block_offsets), samples_per_block)``, one row per block.
+        """
+        block_bytes = samples_per_block * np.dtype(dtype).itemsize
+        data = np.zeros((len(block_offsets), samples_per_block))
+        with open(tev_file_path, "rb") as tev_file:
+            block_index = 0
+            while block_index < len(block_offsets):
+                chunk_start = int(block_offsets[block_index])
+                tev_file.seek(chunk_start, os.SEEK_SET)
+                chunk = tev_file.read(chunk_bytes)
+                chunk_end = chunk_start + len(chunk)
+                if chunk_start + block_bytes > chunk_end:
+                    raise ValueError(
+                        f"Block {block_index} at byte {chunk_start} of '{tev_file_path}' needs {block_bytes} bytes "
+                        f"but only {len(chunk)} could be read (chunk size {chunk_bytes}); the .tev file is truncated "
+                        "or the chunk size is smaller than one block."
+                    )
+                while block_index < len(block_offsets) and int(block_offsets[block_index]) + block_bytes <= chunk_end:
+                    data[block_index, :] = np.frombuffer(
+                        chunk,
+                        dtype=dtype,
+                        count=samples_per_block,
+                        offset=int(block_offsets[block_index]) - chunk_start,
+                    )
+                    block_index += 1
+        return data
+
+    def _readtev(self, event: str, *, chunk_bytes: int = TEV_CHUNK_BYTES) -> dict[str, object]:
         header_df = self._header_df.copy()
         folder_path = self.folder_path
 
@@ -175,14 +239,13 @@ class TdtRecordingExtractor(BaseRecordingExtractor):
 
         if formatNew != 5:
             nsample = (data_size[first_row,] - 10) * int(table[formatNew, 2])
-            event_dict["data"] = np.zeros((len(fp_loc), nsample))
-            for i in range(0, len(fp_loc)):
-                with open(tevfilepath, "rb") as tev_file:
-                    tev_file.seek(fp_loc[i], os.SEEK_SET)
-                    event_dict["data"][i, :] = np.fromfile(tev_file, dtype=table[formatNew, 3], count=nsample).reshape(
-                        1, nsample, order="F"
-                    )
-                    # event_dict['data'] = event_dict['data'].swapaxes()
+            event_dict["data"] = self._read_tev_blocks(
+                tevfilepath,
+                block_offsets=fp_loc,
+                samples_per_block=int(nsample),
+                dtype=table[formatNew, 3],
+                chunk_bytes=chunk_bytes,
+            )
             event_dict["npoints"] = nsample
         else:
             event_dict["data"] = np.asarray(header_df["strobe"][allIndexesWhereEventIsPresent[0]])

--- a/tests/unit/extractors/test_tdt_recording_extractor.py
+++ b/tests/unit/extractors/test_tdt_recording_extractor.py
@@ -109,6 +109,106 @@ def test_readtev_raises_when_store_name_not_present(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Chunked .tev reading
+# ---------------------------------------------------------------------------
+
+TSQ_DTYPE = np.dtype(
+    {
+        "names": ("size", "type", "name", "chan", "sort_code", "timestamp", "fp_loc", "strobe", "format", "frequency"),
+        "formats": (
+            np.int32,
+            np.int32,
+            "S4",
+            np.uint16,
+            np.uint16,
+            np.float64,
+            np.int64,
+            np.float64,
+            np.int32,
+            np.float32,
+        ),
+        "offsets": (0, 4, 8, 12, 14, 16, 24, 24, 32, 36),
+    },
+    align=True,
+)
+
+# Two float32 stores ("AAAA", "BBBB"; format 0, size 14 -> 4 samples, 16 bytes per block) and one
+# int16 store ("CCCC"; format 2, size 12 -> 4 samples, 8 bytes per block), interleaved in header
+# order. With a 4096-byte chunk the layout makes the first AAAA/BBBB reads straddle the chunk
+# boundary at 4096 and puts the last blocks past a gap wider than a chunk.
+SYNTHETIC_TANK_ROWS = [
+    ("AAAA", 14, 0, 0, np.float32, [1.0, 2.0, 3.0, 4.0]),
+    ("BBBB", 14, 0, 16, np.float32, [10.0, 20.0, 30.0, 40.0]),
+    ("CCCC", 12, 2, 32, np.int16, [-1, -2, -3, -4]),
+    ("AAAA", 14, 0, 4088, np.float32, [5.0, 6.0, 7.0, 8.0]),
+    ("BBBB", 14, 0, 4104, np.float32, [50.0, 60.0, 70.0, 80.0]),
+    ("AAAA", 14, 0, 10000, np.float32, [9.0, 10.0, 11.0, 12.0]),
+    ("BBBB", 14, 0, 10016, np.float32, [90.0, 100.0, 110.0, 120.0]),
+    ("CCCC", 12, 2, 10032, np.int16, [5, 6, 7, 8]),
+]
+SYNTHETIC_TEV_BYTES = 10040
+
+
+@pytest.fixture
+def synthetic_tank(tmp_path):
+    """Write a tiny TDT tank whose block values are known literals."""
+    header = np.zeros(len(SYNTHETIC_TANK_ROWS), dtype=TSQ_DTYPE)
+    # Gaps are filled with 0xFF so a read at the wrong offset yields NaN / -1 rather than zeros.
+    tev = bytearray(b"\xff" * SYNTHETIC_TEV_BYTES)
+    for row, (name, size, format_code, offset, dtype, values) in enumerate(SYNTHETIC_TANK_ROWS):
+        header[row]["name"] = name.encode()
+        header[row]["size"] = size
+        header[row]["format"] = format_code
+        header[row]["fp_loc"] = offset
+        header[row]["chan"] = 1
+        header[row]["timestamp"] = float(row)
+        header[row]["frequency"] = 1000.0
+        block = np.asarray(values, dtype=dtype).tobytes()
+        tev[offset : offset + len(block)] = block
+    header.tofile(tmp_path / "synthetic.tsq")
+    (tmp_path / "synthetic.tev").write_bytes(bytes(tev))
+    return tmp_path
+
+
+class TestTdtRecordingExtractorChunkedRead:
+    @pytest.mark.parametrize("chunk_bytes", [4096, 32 * 1024 * 1024])
+    def test_float_store_across_chunk_boundary_and_gap(self, synthetic_tank, chunk_bytes):
+        extractor = TdtRecordingExtractor(str(synthetic_tank))
+        result = extractor._readtev("AAAA", chunk_bytes=chunk_bytes)
+        np.testing.assert_array_equal(result["data"], np.arange(1.0, 13.0))
+        assert result["data"].dtype == np.float64
+        assert result["npoints"] == 4
+        np.testing.assert_array_equal(result["timestamps"], [0.0, 3.0, 5.0])
+
+    def test_interleaved_store_is_read_independently(self, synthetic_tank):
+        extractor = TdtRecordingExtractor(str(synthetic_tank))
+        result = extractor._readtev("BBBB", chunk_bytes=4096)
+        np.testing.assert_array_equal(result["data"], np.arange(10.0, 130.0, 10.0))
+
+    def test_int16_store_uses_two_samples_per_size_unit(self, synthetic_tank):
+        extractor = TdtRecordingExtractor(str(synthetic_tank))
+        result = extractor._readtev("CCCC", chunk_bytes=4096)
+        np.testing.assert_array_equal(result["data"], [-1.0, -2.0, -3.0, -4.0, 5.0, 6.0, 7.0, 8.0])
+        assert result["data"].dtype == np.float64
+
+    def test_truncated_tev_raises(self, synthetic_tank):
+        tev_path = synthetic_tank / "synthetic.tev"
+        tev_path.write_bytes(tev_path.read_bytes()[:10010])
+        extractor = TdtRecordingExtractor(str(synthetic_tank))
+        with pytest.raises(ValueError, match=r"Block 2 at byte 10000 .* truncated"):
+            extractor._readtev("AAAA", chunk_bytes=4096)
+
+    @pytest.mark.parametrize("event", ["Dv1A", "Fi1r"])
+    def test_stub_read_is_independent_of_chunk_size(self, event):
+        """Fi1r's 2048-byte blocks sit 2048 bytes apart, so a 4096-byte chunk straddles constantly."""
+        extractor = TdtRecordingExtractor(os.path.join(STUBBED_TESTING_DATA, "tdt", "Photo_63_207-181030-103332"))
+        default_chunks = extractor._readtev(event)
+        small_chunks = extractor._readtev(event, chunk_bytes=4096)
+        np.testing.assert_array_equal(small_chunks["data"], default_chunks["data"])
+        assert len(default_chunks["data"]) == extractor.count_samples(event=event)
+
+
+# ---------------------------------------------------------------------------
 # Shared fixtures for all TDT test classes
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR should fix the extreme network slowdown when GuPPy is used on network-mounted drives. It was tested on a local simulated version of the Server Message Block (SMB) using dummynet.

<details>
<summary>Details (AI-generated)</summary>

Closes #461.

`TdtRecordingExtractor._readtev` now reads a continuous store's blocks through a new `_read_tev_blocks` helper: the `.tev` is opened once and read 32 MiB at a time, each read starting at the next unread block, with blocks sliced out of the buffer. Blocks that straddle a buffer end are picked up by the next read, and gaps wider than a chunk are skipped. The returned array is unchanged in dtype, shape, and values; epoc stores, `count_samples`, and `stub` are untouched. A truncated `.tev` raises a `ValueError` naming the block.

Measured on a loopback SMB share with 2 ms injected one-way delay, Step 2 on the reference session went from 96 s to 2.8 s at one core. Locally the new read is also faster than the per-block loop. The trade-off is that a store now transfers its whole byte span rather than only its blocks.

Verification: `pytest tests/unit/extractors/test_tdt_recording_extractor.py` 121 passed (seven new tests: a synthetic tank with literal expected values that forces chunk-boundary straddles, a gap wider than a chunk, float32 and int16 stores, and the truncated-file error; plus chunk-size invariance on the real stub). `pytest tests/integration/test_integration_step2.py -k tdt` passed. Pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>