### PR TITLE
Consolidate storesList.csv reads and writes behind one helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed the README's documentation links, which all carried an `/en/latest/` path prefix that 404s on the single-version Read the Docs project. [PR #469](https://github.com/LernerLab/GuPPy/pull/469)
 
 ## Improvements
+- Reading and writing `storesList.csv` now goes through a single `read_stores_list()`/`write_stores_list()` pair instead of a `np.genfromtxt(...).reshape(2, -1)` incantation copy-pasted across 22 call sites. [PR #480](https://github.com/LernerLab/GuPPy/pull/480)
 - Which existing run Steps 2–5 read can now be chosen by name: a **Run name(s) for all sessions** picker above the Output Folder Selection browser selects that run in every selected session at once, and directories ticked in the browser are left alone. Changing the session selection no longer discards the run choices already made for the other sessions. [PR #474](https://github.com/LernerLab/GuPPy/pull/474)
 - Reading TDT tanks is much faster on a network share: each continuous store's `.tev` data is now fetched in large sequential chunks instead of one small read per data block, so Read Raw Data no longer pays a network round trip for every block. [PR #473](https://github.com/LernerLab/GuPPy/pull/473)
 - GuPPy now reports its own version: `guppy --version` prints it, the user interface header shows it, and the [installation page](https://guppy.readthedocs.io/en/latest/installation.html) covers how to check it and how to upgrade an existing install. [PR #471](https://github.com/LernerLab/GuPPy/pull/471)

--- a/src/guppy/analysis/control_channel.py
+++ b/src/guppy/analysis/control_channel.py
@@ -12,6 +12,7 @@ from .io_utils import (
     recording_site_from_channel_label,
     write_hdf5,
 )
+from ..utils.stores_list import write_stores_list
 
 logger = logging.getLogger(__name__)
 
@@ -83,7 +84,7 @@ def add_control_channel(filepath: str, store_array: np.ndarray) -> np.ndarray:
                     axis=1,
                 )
 
-    np.savetxt(os.path.join(filepath, "storesList.csv"), store_array, delimiter=",", fmt="%s")
+    write_stores_list(run_folder=filepath, store_array=store_array)
 
     return store_array
 

--- a/src/guppy/analysis/io_utils.py
+++ b/src/guppy/analysis/io_utils.py
@@ -7,6 +7,11 @@ import re
 import numpy as np
 
 from ..utils._hdf5_io import read_hdf5, write_hdf5  # noqa: F401  (re-exported)
+from ..utils.stores_list import (
+    COMBINED_STORES_LIST_FILENAME,
+    read_stores_list,
+    write_stores_list,
+)
 from ..utils.utils import takeOnlyDirs
 
 logger = logging.getLogger(__name__)
@@ -385,7 +390,7 @@ def check_storeslistfile(session_folders: list[str]) -> np.ndarray:
             store_array = np.concatenate(
                 (
                     store_array,
-                    np.genfromtxt(os.path.join(filepath, "storesList.csv"), dtype="str", delimiter=",").reshape(2, -1),
+                    read_stores_list(run_folder=filepath),
                 ),
                 axis=1,
             )
@@ -408,7 +413,7 @@ def write_combined_stores_list(run_folders: list[object], store_array: np.ndarra
     """
     for k in range(len(run_folders)):
         filepath = run_folders[k][0]
-        np.savetxt(os.path.join(filepath, "combine_storesList.csv"), store_array, fmt="%s", delimiter=",")
+        write_stores_list(run_folder=filepath, store_array=store_array, filename=COMBINED_STORES_LIST_FILENAME)
 
 
 def get_control_and_signal_channel_names(store_array: np.ndarray) -> np.ndarray:
@@ -506,7 +511,7 @@ def recording_sites_for_output_directory(filepath: str) -> list[str]:
     list of str
         Recording-site names, in the order their channels appear in ``storesList.csv``.
     """
-    store_array = np.genfromtxt(os.path.join(filepath, "storesList.csv"), dtype="str", delimiter=",").reshape(2, -1)
+    store_array = read_stores_list(run_folder=filepath)
     sites = []
     for label in store_array[1, :]:
         if not is_channel_label(label):

--- a/src/guppy/analysis/standard_io.py
+++ b/src/guppy/analysis/standard_io.py
@@ -17,6 +17,7 @@ from .io_utils import (
     write_hdf5,
 )
 from .tonic import TONIC_EPOCH_COLUMNS
+from ..utils.stores_list import read_stores_list
 from ..utils.utils import TRANSIENT_EVENT_PREFIX
 
 logger = logging.getLogger(__name__)
@@ -1137,7 +1138,7 @@ def read_covariate_series(filepath: str) -> dict[str, tuple[np.ndarray, np.ndarr
     dict of str to tuple of np.ndarray
         Covariate name (label minus its prefix) → ``(timestamps, values)``.
     """
-    store_array = np.genfromtxt(os.path.join(filepath, "storesList.csv"), dtype="str", delimiter=",").reshape(2, -1)
+    store_array = read_stores_list(run_folder=filepath)
 
     covariate_series = {}
     for store_id, store_label in zip(store_array[0, :], store_array[1, :]):

--- a/src/guppy/orchestration/group_analysis.py
+++ b/src/guppy/orchestration/group_analysis.py
@@ -23,6 +23,7 @@ from ..analysis.psth_average import average_psth_for_group
 from ..analysis.transients_average import average_transients_for_group
 from ..utils import progress
 from ..utils.progress import step_error_handler
+from ..utils.stores_list import read_stores_list, write_stores_list
 from ..utils.utils import (
     GROUP_MEMBERS_FILENAME,
     event_labels_for_analysis,
@@ -65,9 +66,7 @@ def _validate_fiber_recording_sites_consistent_for_group(*, member_run_folders: 
     """
     per_member_fibers = {}
     for run_folder in member_run_folders:
-        member_stores_list = np.genfromtxt(
-            os.path.join(run_folder, "storesList.csv"), dtype="str", delimiter=","
-        ).reshape(2, -1)
+        member_stores_list = read_stores_list(run_folder=run_folder)
         fiber_stores = tuple(sorted(name for name in set(member_stores_list[1, :]) if is_channel_label(name)))
         per_member_fibers[run_folder] = fiber_stores
 
@@ -109,7 +108,7 @@ def _merge_group_stores_list(*, member_run_folders: list[str]) -> np.ndarray:
         store_array = np.concatenate(
             (
                 store_array,
-                np.genfromtxt(os.path.join(run_folder, "storesList.csv"), dtype="str", delimiter=",").reshape(2, -1),
+                read_stores_list(run_folder=run_folder),
             ),
             axis=1,
         )
@@ -233,11 +232,9 @@ def average_one_group(*, group_folder: str, inputParameters: dict[str, object]) 
             averaged_events.append(event)
         progress.advance()
 
-    np.savetxt(
-        os.path.join(group_folder, "storesList.csv"),
-        _filter_stores_list_to_averaged_events(store_array=store_array, averaged_events=averaged_events),
-        delimiter=",",
-        fmt="%s",
+    write_stores_list(
+        run_folder=group_folder,
+        store_array=_filter_stores_list_to_averaged_events(store_array=store_array, averaged_events=averaged_events),
     )
     logger.info(f"Group '{group_name}' averaged {len(averaged_events)} event(s) from {len(member_run_folders)} run(s).")
 

--- a/src/guppy/orchestration/preprocess.py
+++ b/src/guppy/orchestration/preprocess.py
@@ -39,6 +39,7 @@ from ..analysis.timestamp_correction import correct_timestamps
 from ..analysis.z_score import compute_z_score
 from ..utils import progress
 from ..utils.progress import step_error_handler
+from ..utils.stores_list import read_stores_list
 from ..utils.utils import (
     get_all_stores_for_combining_data,
     resolve_run_folders,
@@ -73,9 +74,7 @@ def execute_timestamp_correction(session_folders: list[str], inputParameters: di
         logger.debug(f"Timestamps corrections started for {filepath}")
         for j in range(len(run_folders)):
             filepath = run_folders[j]
-            store_array = np.genfromtxt(os.path.join(filepath, "storesList.csv"), dtype="str", delimiter=",").reshape(
-                2, -1
-            )
+            store_array = read_stores_list(run_folder=filepath)
 
             if isosbestic_control == False:
                 store_array = add_control_channel(filepath, store_array)
@@ -246,7 +245,7 @@ def execute_artifact_removal(session_folders: list[str], inputParameters: dict[s
 
     for j in range(len(run_folders)):
         filepath = run_folders[j]
-        store_array = np.genfromtxt(os.path.join(filepath, "storesList.csv"), dtype="str", delimiter=",").reshape(2, -1)
+        store_array = read_stores_list(run_folder=filepath)
         _, artifactsRemovalMethod = read_artifact_provenance(destination=filepath)
 
         store_label_to_data = read_corrected_data_dict(filepath, store_array)
@@ -308,9 +307,6 @@ def execute_combine_data(
         session_run_folders = select_run_folders(filepath, selected_runs.get(filepath))
         for j in range(len(session_run_folders)):
             filepath = session_run_folders[j]
-            storesList_new = np.genfromtxt(
-                os.path.join(filepath, "storesList.csv"), dtype="str", delimiter=","
-            ).reshape(2, -1)
             sampling_rate_filepaths.append(glob.glob(os.path.join(filepath, "timeCorrection_*")))
 
     # check if sampling rate is same for both data

--- a/src/guppy/orchestration/psth.py
+++ b/src/guppy/orchestration/psth.py
@@ -35,6 +35,7 @@ from ..analysis.standard_io import (
 )
 from ..utils import progress
 from ..utils.progress import step_error_handler
+from ..utils.stores_list import read_stores_list
 from ..utils.utils import (
     event_labels_for_analysis,
     get_all_stores_for_combining_data,
@@ -296,9 +297,7 @@ def orchestrate_psth(inputParameters: dict[str, object]) -> None:
         run_folders = select_run_folders(session_folders[i], selected_runs.get(session_folders[i]))
         for j in range(len(run_folders)):
             filepath = run_folders[j]
-            store_array = np.genfromtxt(os.path.join(filepath, "storesList.csv"), dtype="str", delimiter=",").reshape(
-                2, -1
-            )
+            store_array = read_stores_list(run_folder=filepath)
             event_labels = event_labels_for_analysis(store_array=store_array, inputParameters=inputParameters)
 
             # Each pool is closed and joined before leaving its block. The context manager's
@@ -355,9 +354,7 @@ def execute_psth_combined(inputParameters: dict[str, object]) -> None:
             store_array = np.concatenate(
                 (
                     store_array,
-                    np.genfromtxt(
-                        os.path.join(combined_output_groups[i][j], "storesList.csv"), dtype="str", delimiter=","
-                    ).reshape(2, -1),
+                    read_stores_list(run_folder=combined_output_groups[i][j]),
                 ),
                 axis=1,
             )

--- a/src/guppy/orchestration/psth_significance.py
+++ b/src/guppy/orchestration/psth_significance.py
@@ -36,6 +36,7 @@ from ..analysis.standard_io import (
     write_psth_significance_to_hdf5,
 )
 from ..utils import progress
+from ..utils.stores_list import read_stores_list
 from ..utils.utils import event_labels_for_analysis, read_Df
 from ..utils.validation import (
     validate_comparison_events_available,
@@ -319,7 +320,7 @@ def plan_comparisons(filepath: str, inputParameters: dict[str, object]) -> list[
     ValueError
         If a named comparison event has no results in this directory.
     """
-    store_array = np.genfromtxt(os.path.join(filepath, "storesList.csv"), dtype="str", delimiter=",").reshape(2, -1)
+    store_array = read_stores_list(run_folder=filepath)
     events = [
         event.replace("\\", "_").replace("/", "_")
         for event in event_labels_for_analysis(store_array=store_array, inputParameters=inputParameters)

--- a/src/guppy/orchestration/read_raw_data.py
+++ b/src/guppy/orchestration/read_raw_data.py
@@ -1,6 +1,5 @@
 import logging
 import multiprocessing as mp
-import os
 
 import numpy as np
 
@@ -19,6 +18,7 @@ from guppy.extractors.base_recording_extractor import _pool_initializer
 from guppy.orchestration.save_parameters import save_parameters
 from guppy.utils import progress
 from guppy.utils.progress import step_error_handler
+from guppy.utils.stores_list import read_stores_list
 from guppy.utils.utils import load_npm_params, select_run_folders
 
 logger = logging.getLogger(__name__)
@@ -236,7 +236,7 @@ def _load_stores_list(run_folder: str) -> np.ndarray:
     store_array is finalized in step 1 (including TDT split sub-events) and is no
     longer mutated during extraction, so it is read directly.
     """
-    return np.genfromtxt(os.path.join(run_folder, "storesList.csv"), dtype="str", delimiter=",").reshape(2, -1)
+    return read_stores_list(run_folder=run_folder)
 
 
 @step_error_handler

--- a/src/guppy/orchestration/store_labeling.py
+++ b/src/guppy/orchestration/store_labeling.py
@@ -24,6 +24,7 @@ from guppy.frontend.store_labeling_instructions import (
     StoreLabelingInstructionsNPM,
 )
 from guppy.frontend.store_labeling_selector import StoreLabelingSelector
+from guppy.utils.stores_list import write_stores_list
 from guppy.utils.utils import (
     NPM_PARAM_KEYS,
     discover_run_folders,
@@ -264,7 +265,7 @@ def _save(
         logger.info(f"Cleared output directory for overwrite: {select_location}")
     os.mkdir(select_location)
 
-    np.savetxt(os.path.join(select_location, "storesList.csv"), store_array, delimiter=",", fmt="%s")
+    write_stores_list(run_folder=select_location, store_array=store_array)
     if npm_params is not None:
         write_npm_params(run_folder=select_location, npm_params=npm_params)
     logger.info(f"Storeslist file saved at {select_location}")

--- a/src/guppy/orchestration/transients.py
+++ b/src/guppy/orchestration/transients.py
@@ -271,9 +271,6 @@ def execute_find_freq_and_amp(
         run_folders = select_run_folders(filepath, selected_runs.get(filepath))
         for j in range(len(run_folders)):
             filepath = run_folders[j]
-            store_array = np.genfromtxt(os.path.join(filepath, "storesList.csv"), dtype="str", delimiter=",").reshape(
-                2, -1
-            )
             findFreqAndAmp(filepath, inputParameters, window=moving_window, numProcesses=numProcesses)
             progress.advance()
         logger.info("Transients in z-score data found and frequency and amplitude are calculated.")
@@ -304,6 +301,5 @@ def execute_find_freq_and_amp_combined(
     combined_output_groups = get_all_stores_for_combining_data(run_folders)
     for i in range(len(combined_output_groups)):
         filepath = combined_output_groups[i][0]
-        store_array = np.genfromtxt(os.path.join(filepath, "storesList.csv"), dtype="str", delimiter=",").reshape(2, -1)
         findFreqAndAmp(filepath, inputParameters, window=moving_window, numProcesses=numProcesses)
         progress.advance()

--- a/src/guppy/orchestration/visualize.py
+++ b/src/guppy/orchestration/visualize.py
@@ -19,6 +19,7 @@ from ..frontend.parameterized_plotter import (
     remove_cols,
 )
 from ..frontend.visualization_dashboard import VisualizationDashboard
+from ..utils.stores_list import read_stores_list
 from ..utils.utils import (
     event_labels_for_analysis,
     get_all_stores_for_combining_data,
@@ -295,11 +296,7 @@ def visualizeResults(inputParameters: dict[str, object]) -> None:
                 store_array = np.concatenate(
                     (
                         store_array,
-                        np.genfromtxt(
-                            os.path.join(combined_output_groups[i][j], "storesList.csv"),
-                            dtype="str",
-                            delimiter=",",
-                        ).reshape(2, -1),
+                        read_stores_list(run_folder=combined_output_groups[i][j]),
                     ),
                     axis=1,
                 )
@@ -316,9 +313,7 @@ def visualizeResults(inputParameters: dict[str, object]) -> None:
             run_folders = select_run_folders(filepath, selected_runs.get(filepath))
             for j in range(len(run_folders)):
                 filepath = run_folders[j]
-                store_array = np.genfromtxt(
-                    os.path.join(filepath, "storesList.csv"), dtype="str", delimiter=","
-                ).reshape(2, -1)
+                store_array = read_stores_list(run_folder=filepath)
 
                 createPlots(
                     filepath,
@@ -329,9 +324,7 @@ def visualizeResults(inputParameters: dict[str, object]) -> None:
     # Groups are ordinary output directories to the visualizer: one dashboard each,
     # opened alongside any selected session runs rather than instead of them.
     for group_folder in group_folders:
-        store_array = np.genfromtxt(os.path.join(group_folder, "storesList.csv"), dtype="str", delimiter=",").reshape(
-            2, -1
-        )
+        store_array = read_stores_list(run_folder=group_folder)
         createPlots(
             group_folder,
             event_labels_for_analysis(store_array=store_array, inputParameters=inputParameters),

--- a/src/guppy/utils/nwb_metadata.py
+++ b/src/guppy/utils/nwb_metadata.py
@@ -20,7 +20,6 @@ This module knows nothing about Panel or neuroconv. It provides:
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass, field
 from datetime import datetime
 from functools import lru_cache
@@ -29,6 +28,7 @@ from pathlib import Path
 import numpy as np
 import yaml
 
+from .stores_list import read_stores_list
 from ..analysis.io_utils import (
     CONTROL_PREFIX,
     SIGNAL_PREFIX,
@@ -74,7 +74,7 @@ def derive_channels(*, output_dir: str | Path) -> list[Channel]:
     response series' ``fiber_photometry_table_region`` against that order to recover which
     fiber recorded which site.
     """
-    stores_list = np.genfromtxt(os.path.join(output_dir, "storesList.csv"), dtype="str", delimiter=",").reshape(2, -1)
+    stores_list = read_stores_list(run_folder=output_dir)
     store_labels = [str(label) for label in stores_list[1, :]]
     label_to_store_name = {label: str(store) for store, label in zip(stores_list[0, :], store_labels)}
 

--- a/src/guppy/utils/stores_list.py
+++ b/src/guppy/utils/stores_list.py
@@ -1,0 +1,52 @@
+"""Read and write ``storesList.csv``, the store id ↔ store label mapping for a run.
+
+Step 1 writes one ``storesList.csv`` into every run folder and the rest of the
+pipeline reads it back to learn which stores exist and what they are called. The
+file is a headerless two-row CSV: row 0 holds the raw store ids as they appear in
+the acquisition format (``Dv1A``, ``PrtA``, ...) and row 1 holds the GuPPy store
+labels the user assigned to them (``control_DMS``, ``signal_DMS``, ...). Column
+``i`` of one row pairs with column ``i`` of the other, and that column order is
+itself meaningful — the NWB converter walks recording sites in it.
+"""
+
+import os
+
+import numpy as np
+
+STORES_LIST_FILENAME = "storesList.csv"
+COMBINED_STORES_LIST_FILENAME = "combine_storesList.csv"
+
+
+def read_stores_list(*, run_folder: str, filename: str = STORES_LIST_FILENAME) -> np.ndarray:
+    """Read a run folder's store mapping.
+
+    Parameters
+    ----------
+    run_folder : str
+        Directory holding the store-mapping CSV.
+    filename : str, optional
+        Name of the CSV within ``run_folder``. Defaults to ``storesList.csv``.
+
+    Returns
+    -------
+    np.ndarray
+        String array of shape ``(2, n_stores)``: row 0 store ids, row 1 store
+        labels. A single-store file still comes back 2-D.
+    """
+    return np.genfromtxt(os.path.join(run_folder, filename), dtype="str", delimiter=",").reshape(2, -1)
+
+
+def write_stores_list(*, run_folder: str, store_array: np.ndarray, filename: str = STORES_LIST_FILENAME) -> None:
+    """Write a store mapping into a run folder.
+
+    Parameters
+    ----------
+    run_folder : str
+        Directory to write the store-mapping CSV into.
+    store_array : np.ndarray
+        String array of shape ``(2, n_stores)``: row 0 store ids, row 1 store
+        labels.
+    filename : str, optional
+        Name of the CSV within ``run_folder``. Defaults to ``storesList.csv``.
+    """
+    np.savetxt(os.path.join(run_folder, filename), store_array, delimiter=",", fmt="%s")

--- a/tests/unit/utils/test_stores_list.py
+++ b/tests/unit/utils/test_stores_list.py
@@ -1,0 +1,50 @@
+import numpy as np
+
+from guppy.utils.stores_list import (
+    COMBINED_STORES_LIST_FILENAME,
+    read_stores_list,
+    write_stores_list,
+)
+
+
+class TestWriteStoresList:
+    def test_writes_two_rows_of_comma_separated_values(self, tmp_path):
+        store_array = np.array([["Dv1A", "Dv2A", "PrtA"], ["control_DMS", "signal_DMS", "reward"]])
+
+        write_stores_list(run_folder=str(tmp_path), store_array=store_array)
+
+        assert (tmp_path / "storesList.csv").read_text() == "Dv1A,Dv2A,PrtA\ncontrol_DMS,signal_DMS,reward\n"
+
+    def test_filename_selects_the_combined_sibling(self, tmp_path):
+        store_array = np.array([["Dv1A"], ["control_DMS"]])
+
+        write_stores_list(run_folder=str(tmp_path), store_array=store_array, filename=COMBINED_STORES_LIST_FILENAME)
+
+        assert not (tmp_path / "storesList.csv").exists()
+        assert (tmp_path / "combine_storesList.csv").read_text() == "Dv1A\ncontrol_DMS\n"
+
+
+class TestReadStoresList:
+    def test_reads_ids_and_labels(self, tmp_path):
+        (tmp_path / "storesList.csv").write_text("Dv1A,Dv2A,PrtA\ncontrol_DMS,signal_DMS,reward\n")
+
+        store_array = read_stores_list(run_folder=str(tmp_path))
+
+        np.testing.assert_array_equal(
+            store_array, np.array([["Dv1A", "Dv2A", "PrtA"], ["control_DMS", "signal_DMS", "reward"]])
+        )
+
+    def test_single_store_stays_two_dimensional(self, tmp_path):
+        (tmp_path / "storesList.csv").write_text("Dv1A\ncontrol_DMS\n")
+
+        store_array = read_stores_list(run_folder=str(tmp_path))
+
+        assert store_array.shape == (2, 1)
+        np.testing.assert_array_equal(store_array, np.array([["Dv1A"], ["control_DMS"]]))
+
+    def test_round_trips_through_write(self, tmp_path):
+        store_array = np.array([["Dv1A", "Dv2A"], ["control_DMS", "signal_DMS"]])
+
+        write_stores_list(run_folder=str(tmp_path), store_array=store_array)
+
+        np.testing.assert_array_equal(read_stores_list(run_folder=str(tmp_path)), store_array)


### PR DESCRIPTION
<!-- summary line goes here -->

<details>
<summary>Details (AI-generated)</summary>

Closes #475.

Adds `read_stores_list()` / `write_stores_list()` in a new `src/guppy/utils/stores_list.py` and routes all 22 call sites through them. The `.reshape(2, -1)` shape contract and the `combine_storesList.csv` filename now live in one documented place.

Three of the converted reads turned out to be dead — the store array they built was never used — so they are deleted rather than converted: `execute_find_freq_and_amp` and `execute_find_freq_and_amp_combined` in `orchestration/transients.py`, and `execute_combine_data` in `orchestration/preprocess.py`. That is the only behavior-adjacent change in the PR; everything else is a mechanical substitution.

New unit tests in `tests/unit/utils/test_stores_list.py` cover the round trip, the single-store case that the reshape exists for, and the `combine_storesList.csv` filename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>
