### PR TITLE
Sweep legacy Python syntax: f-strings, lazy logging, collections.abc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed the README's documentation links, which all carried an `/en/latest/` path prefix that 404s on the single-version Read the Docs project. [PR #469](https://github.com/LernerLab/GuPPy/pull/469)
 
 ## Improvements
+- Logging calls now hand their arguments to the logger instead of formatting the message up front, so a filtered-out record costs nothing to build. Pre-f-string syntax (`.format()`, `typing.Callable`/`Sequence`/`Iterable`, `lru_cache(maxsize=None)`) is swept, and `ruff`'s `UP` and `G` rule sets are enabled to keep it that way. [PR #481](https://github.com/LernerLab/GuPPy/pull/481)
 - Reading and writing `storesList.csv` now goes through a single `read_stores_list()`/`write_stores_list()` pair instead of a `np.genfromtxt(...).reshape(2, -1)` incantation copy-pasted across 22 call sites. [PR #480](https://github.com/LernerLab/GuPPy/pull/480)
 - Which existing run Steps 2–5 read can now be chosen by name: a **Run name(s) for all sessions** picker above the Output Folder Selection browser selects that run in every selected session at once, and directories ticked in the browser are left alone. Changing the session selection no longer discards the run choices already made for the other sessions. [PR #474](https://github.com/LernerLab/GuPPy/pull/474)
 - Reading TDT tanks is much faster on a network share: each continuous store's `.tev` data is now fetched in large sequential chunks instead of one small read per data block, so Read Raw Data no longer pays a network round trip for every block. [PR #473](https://github.com/LernerLab/GuPPy/pull/473)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,8 +133,8 @@ select = [
     "D101",  # Missing docstring in public class
     "D102",  # Missing docstring in public method
     "D103",  # Missing docstring in public function
-    "UP006", # non-pep585 annotation (tuple, list -> tuple, list)
-    "UP007", # non-pep604 annotation (Union[x, y] -> X | Y )
+    "UP", # All pyupgrade rules (includes UP006 non-pep585 and UP007 non-pep604 annotations)
+    "G", # All flake8-logging-format rules (lazy %-formatting in logging calls)
     "ANN", # All type hint rules
 ]
 fixable = ["ALL"]

--- a/src/guppy/analysis/compute_psth.py
+++ b/src/guppy/analysis/compute_psth.py
@@ -110,7 +110,7 @@ def compute_psth(
     # skip the event if there are no TTLs
     if len(event_timestamps) == 0:
         kept_timestamps = np.array([])
-        logger.info(f"Warning : No TTLs present for {event}. This will cause an error in Visualization step")
+        logger.info("Warning : No TTLs present for %s. This will cause an error in Visualization step", event)
     else:
         kept_timestamps = [event_timestamps[0]]
         for i in range(1, event_timestamps.shape[0]):

--- a/src/guppy/analysis/control_fit.py
+++ b/src/guppy/analysis/control_fit.py
@@ -173,7 +173,7 @@ def _fit_with_bleaching(control: np.ndarray, signal: np.ndarray, sample_index: n
         ),
     )
     intercept, slope, bleaching_amplitude, decay_constant = coefficients
-    logger.debug(f"Control fit bleaching term: decay constant {decay_constant:.4g} samples")
+    logger.debug("Control fit bleaching term: decay constant %.4g samples", decay_constant)
 
     return ControlFitModel(
         slope=float(slope),

--- a/src/guppy/analysis/covariates.py
+++ b/src/guppy/analysis/covariates.py
@@ -211,8 +211,12 @@ def compute_covariate_correlations(*, binned_metrics: pd.DataFrame, binned_covar
 
             if n_bins < _MINIMUM_PAIRS:
                 logger.warning(
-                    f"Only {n_bins} bin(s) pair '{covariate}' with '{metric}'; reporting no coefficients "
-                    f"for this pair, which needs at least {_MINIMUM_PAIRS}."
+                    "Only %s bin(s) pair '%s' with '%s'; reporting no coefficients for this pair, which needs at least "
+                    "%s.",
+                    n_bins,
+                    covariate,
+                    metric,
+                    _MINIMUM_PAIRS,
                 )
                 pearson = float("nan")
                 spearman = float("nan")
@@ -221,8 +225,10 @@ def compute_covariate_correlations(*, binned_metrics: pd.DataFrame, binned_covar
                 spearman = _spearman_rho(x=covariate_values[usable], y=metric_values[usable])
                 if np.isnan(pearson):
                     logger.warning(
-                        f"'{covariate}' or '{metric}' is constant across the {n_bins} paired bins, "
-                        "so their correlation is undefined."
+                        "'%s' or '%s' is constant across the %s paired bins, so their correlation is undefined.",
+                        covariate,
+                        metric,
+                        n_bins,
                     )
 
             rows.append(

--- a/src/guppy/analysis/psth_average.py
+++ b/src/guppy/analysis/psth_average.py
@@ -88,7 +88,7 @@ def average_psth_for_group(
         session_entries = new_path[i]
         for j in range(len(session_entries)):
             if not os.path.exists(
-                os.path.join(session_entries[j][0], session_entries[j][1] + "_{}.h5".format(session_entries[j][2]))
+                os.path.join(session_entries[j][0], session_entries[j][1] + f"_{session_entries[j][2]}.h5")
             ):
                 continue
             else:
@@ -104,9 +104,11 @@ def average_psth_for_group(
 
         if len(psth) == 0:
             logger.warning(
-                f"No PSTH files found for event {event!r} (basename {session_entries[0][2]!r}, "
-                f"selectForComputePsth={selectForComputePsth!r}) across the selected folders; "
-                "skipping average for this event."
+                "No PSTH files found for event %r (basename %r, selectForComputePsth=%r) across the selected folders; "
+                "skipping average for this event.",
+                event,
+                session_entries[0][2],
+                selectForComputePsth,
             )
             continue
 
@@ -118,7 +120,7 @@ def average_psth_for_group(
             error_rename_map = {}
             for column_name in error_column_names:
                 name_parts = column_name.split("_")
-                error_rename_map[column_name] = "{}_err_{}".format(name_parts[0], name_parts[1])
+                error_rename_map[column_name] = f"{name_parts[0]}_err_{name_parts[1]}"
             df_bins_err = df_bins_err.rename(columns=error_rename_map)
             columns = columns + list(df_bins_mean.columns) + list(df_bins_err.columns)
             df_bins_mean_err = pd.concat([df_bins_mean, df_bins_err], axis=1).T
@@ -153,18 +155,20 @@ def average_psth_for_group(
 
         if len(peak_area_frames) == 0:
             logger.warning(
-                f"No peak/AUC files found for event {event!r} (basename {session_entries[0][2]!r}) "
-                "across the selected folders; skipping peak/AUC average for this event."
+                "No peak/AUC files found for event %r (basename %r) across the selected folders; skipping peak/AUC "
+                "average for this event.",
+                event,
+                session_entries[0][2],
             )
             continue
         row_indices = list(np.concatenate(row_indices))
         new_df = pd.concat(peak_area_frames, axis=0)
         new_df.to_csv(
-            os.path.join(run_folder, "peak_AUC_{}_{}.csv".format(session_entries[j][1], session_entries[j][2])),
+            os.path.join(run_folder, f"peak_AUC_{session_entries[j][1]}_{session_entries[j][2]}.csv"),
             index=row_indices,
         )
         new_df.to_hdf(
-            os.path.join(run_folder, "peak_AUC_{}_{}.h5".format(session_entries[j][1], session_entries[j][2])),
+            os.path.join(run_folder, f"peak_AUC_{session_entries[j][1]}_{session_entries[j][2]}.h5"),
             key="df",
             mode="w",
             index=row_indices,

--- a/src/guppy/analysis/psth_utils.py
+++ b/src/guppy/analysis/psth_utils.py
@@ -32,7 +32,7 @@ def create_Df_for_psth(filepath: str, event: str, name: str, psth: np.ndarray, c
     event = event.replace("\\", "_")
     event = event.replace("/", "_")
     if name:
-        output_path = os.path.join(filepath, event + "_{}.h5".format(name))
+        output_path = os.path.join(filepath, event + f"_{name}.h5")
     else:
         output_path = os.path.join(filepath, event + ".h5")
 
@@ -156,7 +156,7 @@ def create_Df_for_cross_correlation(
         Column labels for the trials axis. Default is an empty list.
     """
     if name:
-        output_path = os.path.join(filepath, event + "_{}.h5".format(name))
+        output_path = os.path.join(filepath, event + f"_{name}.h5")
     else:
         output_path = os.path.join(filepath, event + ".h5")
 

--- a/src/guppy/analysis/standard_io.py
+++ b/src/guppy/analysis/standard_io.py
@@ -733,7 +733,7 @@ def remove_tonic_results(filepath: str, site: str) -> None:
         path = os.path.join(filepath, name)
         if os.path.exists(path):
             os.remove(path)
-            logger.info(f"Removed {name} for recording site {site}.")
+            logger.info("Removed %s for recording site %s.", name, site)
 
 
 def write_freq_and_amp_to_hdf5(

--- a/src/guppy/analysis/timestamp_correction.py
+++ b/src/guppy/analysis/timestamp_correction.py
@@ -121,7 +121,8 @@ def timestampCorrection(
         Store label → sliced data array.
     """
     logger.debug(
-        f"Correcting timestamps by getting rid of the first {timeForLightsTurnOn} seconds and convert timestamps to seconds"
+        "Correcting timestamps by getting rid of the first %s seconds and convert timestamps to seconds",
+        timeForLightsTurnOn,
     )
     if mode not in ["tdt", "csv"]:
         message = f"Mode {mode!r} is not supported; must be either 'tdt' or 'csv'."

--- a/src/guppy/extractors/base_recording_extractor.py
+++ b/src/guppy/extractors/base_recording_extractor.py
@@ -195,4 +195,4 @@ def read_and_save_events_for_extractor(
     for event in normalized_events:
         already_committed = int(extractor.committed_samples_for_event(event))
         add_samples_done(int(event_total_samples.get(event, 0)) - already_committed)
-        logger.info("Data for event {} fetched and stored.".format(event))
+        logger.info("Data for event %s fetched and stored.", event)

--- a/src/guppy/extractors/csv_recording_extractor.py
+++ b/src/guppy/extractors/csv_recording_extractor.py
@@ -160,7 +160,7 @@ class CsvRecordingExtractor(BaseRecordingExtractor):
         return max(0, total_lines - 1)
 
     def _read_csv(self, event: str) -> pd.DataFrame:
-        logger.debug(f"Trying to read data for {event} from csv file.")
+        logger.debug("Trying to read data for %s from csv file.", event)
         csv_path = os.path.join(self.folder_path, event + ".csv")
         if not os.path.exists(csv_path):
             message = f"No CSV file found for event '{event}' at '{csv_path}'."

--- a/src/guppy/extractors/tdt_recording_extractor.py
+++ b/src/guppy/extractors/tdt_recording_extractor.py
@@ -177,7 +177,7 @@ class TdtRecordingExtractor(BaseRecordingExtractor):
         header_df = self._header_df.copy()
         folder_path = self.folder_path
 
-        logger.debug("Reading data for event {} ...".format(event))
+        logger.debug("Reading data for event %s ...", event)
         tevfilepath = glob.glob(os.path.join(folder_path, "*.tev"))
         if len(tevfilepath) > 1:
             raise ValueError(

--- a/src/guppy/frontend/artifact_removal.py
+++ b/src/guppy/frontend/artifact_removal.py
@@ -119,7 +119,7 @@ class PreprocessingReviewView:
 
         heading = "Artifact removal review" if artifacts_removed else "Preprocessing review"
         self.widget = pn.Column(
-            "## {} — {}".format(heading, os.path.basename(filepath)),
+            f"## {heading} — {os.path.basename(filepath)}",
             self.site_select,
             self.plot_pane,
             sizing_mode="stretch_width",

--- a/src/guppy/frontend/artifact_windows_page.py
+++ b/src/guppy/frontend/artifact_windows_page.py
@@ -284,7 +284,7 @@ class ArtifactWindowSelector:
             else []
         )
         self.widget = pn.Column(
-            "# Select Artifact Windows — {}".format(os.path.basename(filepath)),
+            f"# Select Artifact Windows — {os.path.basename(filepath)}",
             pn.pane.Markdown(_INSTRUCTIONS),
             *copy_from_section,
             pn.Row(self.site_select, self.trace_select, self.mode_toggle),
@@ -414,7 +414,7 @@ class ArtifactWindowSelector:
 
         for site in matched:
             self.set_windows(site, _saved_artifact_windows(run_folder, site, self.pair_traces[site]["x"]))
-        logger.info(f"Loaded artifact windows from run {run_name} for {', '.join(matched)}.")
+        logger.info("Loaded artifact windows from run %s for %s.", run_name, ", ".join(matched))
 
         message = f"Loaded artifact windows from run {run_name} for {', '.join(matched)}."
         skipped = [site for site in self.sites if site not in matched]
@@ -473,7 +473,7 @@ class ArtifactWindowSelector:
                 os.path.join(self.filepath, f"coordsForPreProcessing_{site}.npy"),
                 windows_to_coords(windows=keep_windows),
             )
-            logger.info(f"Saved {len(keep_windows)} keep-window(s) for recording site {site}.")
+            logger.info("Saved %s keep-window(s) for recording site %s.", len(keep_windows), site)
 
         record_artifact_provenance(destination=self.filepath, artifacts_removal_method=self.method_select.value)
         for message in clamped:

--- a/src/guppy/frontend/group_labeling.py
+++ b/src/guppy/frontend/group_labeling.py
@@ -249,4 +249,4 @@ def save_group_definition(*, group_folder: str, member_run_folders: list[str]) -
     """
     os.makedirs(group_folder, exist_ok=True)
     write_group_members(group_folder=group_folder, member_run_folders=member_run_folders)
-    logger.info(f"Group definition saved at {group_folder} with {len(member_run_folders)} member run(s).")
+    logger.info("Group definition saved at %s with %s member run(s).", group_folder, len(member_run_folders))

--- a/src/guppy/frontend/parameterized_plotter.py
+++ b/src/guppy/frontend/parameterized_plotter.py
@@ -511,7 +511,7 @@ class ParameterizedPlotter(param.Parameterized):
     def _update_df(self) -> None:
         columns = self.columns_dict[self.event_selector_heatmap]
         trial_no = range(1, len(remove_cols(columns)[:-2]) + 1)
-        trial_ts = ["{} - {}".format(i, j) for i, j in zip(trial_no, remove_cols(columns)[:-2])] + ["All"]
+        trial_ts = [f"{i} - {j}" for i, j in zip(trial_no, remove_cols(columns)[:-2])] + ["All"]
         self.param["heatmap_y"].objects = trial_ts
         self.heatmap_y = [trial_ts[-1]]
 
@@ -519,7 +519,7 @@ class ParameterizedPlotter(param.Parameterized):
     def _update_psth_y(self) -> None:
         columns = self.columns_dict[self.event_selector]
         trial_no = range(1, len(remove_cols(columns)[:-2]) + 1)
-        trial_ts = ["{} - {}".format(i, j) for i, j in zip(trial_no, remove_cols(columns)[:-2])]
+        trial_ts = [f"{i} - {j}" for i, j in zip(trial_no, remove_cols(columns)[:-2])]
         self.param["psth_y"].objects = trial_ts
         self.psth_y = [trial_ts[0]]
 
@@ -570,8 +570,8 @@ class ParameterizedPlotter(param.Parameterized):
             if "bin" in selected_events[i]:
                 split = selected_events[i].rsplit("_", 2)
                 df_name = split[0]  #'{}_{}'.format(split[0], split[1])
-                col_name_mean = "{}_{}".format(split[-2], split[-1])
-                col_name_err = "{}_err_{}".format(split[-2], split[-1])
+                col_name_mean = f"{split[-2]}_{split[-1]}"
+                col_name_err = f"{split[-2]}_err_{split[-1]}"
                 data_curve.append(event_dataframes[df_name][col_name_mean])
                 columns_curve.append(selected_events[i])
                 data_spread.append(event_dataframes[df_name][col_name_err])
@@ -737,7 +737,7 @@ class ParameterizedPlotter(param.Parameterized):
                 standard_error = event_dataframe["err"]
             else:
                 split = self.y.split("_")
-                standard_error = event_dataframe["{}_err_{}".format(split[0], split[1])]
+                standard_error = event_dataframe[f"{split[0]}_err_{split[1]}"]
 
             index = np.arange(0, xpoints.shape[0], 3)
 

--- a/src/guppy/frontend/tonic_epochs.py
+++ b/src/guppy/frontend/tonic_epochs.py
@@ -188,7 +188,7 @@ class TonicEpochConfig:
         self.save_button.on_click(self._on_save)
 
         self.widget = pn.Column(
-            "# Tonic Analysis — {}".format(os.path.basename(filepath)),
+            f"# Tonic Analysis — {os.path.basename(filepath)}",
             pn.pane.Markdown(_INSTRUCTIONS),
             self.site_select,
             self.plot_pane,
@@ -293,7 +293,7 @@ class TonicEpochConfig:
                 compute_tonic_means(trace["y_zscore"], trace["y_dff"], trace["x"], complete),
                 site,
             )
-            logger.info(f"Saved {len(complete)} tonic epoch(s) and means for recording site {site}.")
+            logger.info("Saved %s tonic epoch(s) and means for recording site %s.", len(complete), site)
 
     def _remove_row(self, row: TonicEpochRow) -> None:
         self.site_to_rows[self.site_select.value].remove(row)
@@ -384,7 +384,7 @@ class TonicResultsView:
         self.baseline_select.param.watch(self._refresh, "value")
 
         self.widget = pn.Column(
-            "## Tonic / basal analysis — {}".format(os.path.basename(filepath)),
+            f"## Tonic / basal analysis — {os.path.basename(filepath)}",
             pn.Row(self.site_select, self.baseline_select),
             self.bars_pane,
             pn.pane.Markdown(_BASELINE_HINT),

--- a/src/guppy/orchestration/export_nwb.py
+++ b/src/guppy/orchestration/export_nwb.py
@@ -212,7 +212,7 @@ def _export_session_from_nwb_source(
             added_namespaces=("ndx-guppy",),
         )
 
-    logger.info(f"Wrote NWB file to {nwbfile_path}")
+    logger.info("Wrote NWB file to %s", nwbfile_path)
     return nwbfile_path
 
 
@@ -295,7 +295,7 @@ def export_session_to_nwb(
         overwrite=True,
     )
 
-    logger.info(f"Wrote NWB file to {nwbfile_path}")
+    logger.info("Wrote NWB file to %s", nwbfile_path)
     return nwbfile_path
 
 
@@ -334,11 +334,11 @@ def orchestrate_export_nwb(inputParameters: dict[str, object]) -> None:
                 nwbfile_path=nwbfile_path,
                 nwb_source=nwb_source,
             )
-            logger.info(f"Exported {session_basename} ({run_name}) to NWB.")
+            logger.info("Exported %s (%s) to NWB.", session_basename, run_name)
         except Exception as exception:
             # logger.exception so the traceback survives: the user-facing summary below is only the
             # message, and a partial-success batch is exactly the case where the log is all there is.
-            logger.exception(f"NWB export failed for {session_basename} ({run_name})")
+            logger.exception("NWB export failed for %s (%s)", session_basename, run_name)
             failures.append(f"{session_basename} ({run_name}): {exception}")
         finally:
             progress.advance()

--- a/src/guppy/orchestration/group_analysis.py
+++ b/src/guppy/orchestration/group_analysis.py
@@ -207,7 +207,7 @@ def average_one_group(*, group_folder: str, inputParameters: dict[str, object]) 
     _validate_fiber_recording_sites_consistent_for_group(member_run_folders=member_run_folders)
 
     group_name = parse_group_name(group_folder)
-    logger.info(f"Averaging {len(member_run_folders)} member run(s) into '{group_folder}'...")
+    logger.info("Averaging %s member run(s) into '%s'...", len(member_run_folders), group_folder)
 
     _clear_group_results(group_folder=group_folder)
     write_analysis_parameters(
@@ -236,7 +236,9 @@ def average_one_group(*, group_folder: str, inputParameters: dict[str, object]) 
         run_folder=group_folder,
         store_array=_filter_stores_list_to_averaged_events(store_array=store_array, averaged_events=averaged_events),
     )
-    logger.info(f"Group '{group_name}' averaged {len(averaged_events)} event(s) from {len(member_run_folders)} run(s).")
+    logger.info(
+        "Group '%s' averaged %s event(s) from %s run(s).", group_name, len(averaged_events), len(member_run_folders)
+    )
 
     # After the filtered storesList.csv is written: comparison planning reads it to learn
     # which events the group actually holds averaged results for.

--- a/src/guppy/orchestration/home.py
+++ b/src/guppy/orchestration/home.py
@@ -1,9 +1,9 @@
 import logging
 import os
+from collections.abc import Callable
 from contextvars import copy_context
 from importlib.metadata import version
 from threading import Thread
-from typing import Callable
 
 import panel as pn
 

--- a/src/guppy/orchestration/import_custom_events.py
+++ b/src/guppy/orchestration/import_custom_events.py
@@ -27,7 +27,7 @@ def build_custom_events_template(folder_path: str) -> pn.template.BootstrapTempl
     pn.template.BootstrapTemplate
         Fully configured Panel template ready to be served.
     """
-    template = pn.template.BootstrapTemplate(title="Import Custom Events - {}".format(os.path.basename(folder_path)))
+    template = pn.template.BootstrapTemplate(title=f"Import Custom Events - {os.path.basename(folder_path)}")
     config = CustomEventsConfig()
 
     def save_button(event: object = None) -> None:
@@ -100,7 +100,7 @@ def build_custom_events_page(inputParameters: dict[str, object], folder_path: st
             csv_path = write_custom_event_csv(
                 name=name, timestamps=list(timestamps), folder_path=folder_path, overwrite=True
             )
-            logger.info(f"Custom event saved at {csv_path}")
+            logger.info("Custom event saved at %s", csv_path)
         return
 
     template = build_custom_events_template(folder_path)

--- a/src/guppy/orchestration/preprocess.py
+++ b/src/guppy/orchestration/preprocess.py
@@ -71,7 +71,7 @@ def execute_timestamp_correction(session_folders: list[str], inputParameters: di
         filepath = session_folders[i]
         run_folders = select_run_folders(filepath, selected_runs.get(filepath))
         mode = "tdt" if check_TDT(session_folders[i]) else "csv"
-        logger.debug(f"Timestamps corrections started for {filepath}")
+        logger.debug("Timestamps corrections started for %s", filepath)
         for j in range(len(run_folders)):
             filepath = run_folders[j]
             store_array = read_stores_list(run_folder=filepath)
@@ -118,7 +118,7 @@ def execute_timestamp_correction(session_folders: list[str], inputParameters: di
                 create_control_channel(filepath, store_array, window=101)
 
             progress.advance()
-        logger.info(f"Timestamps corrections finished for {filepath}")
+        logger.info("Timestamps corrections finished for %s", filepath)
 
 
 def execute_zscore(session_folders: list[str], inputParameters: dict[str, object], *, remove_artifacts: bool) -> None:
@@ -183,7 +183,7 @@ def execute_zscore(session_folders: list[str], inputParameters: dict[str, object
 
     for j in range(len(run_folders)):
         filepath = run_folders[j]
-        logger.debug(f"Computing z-score for each of the data in {filepath}")
+        logger.debug("Computing z-score for each of the data in %s", filepath)
         path = decide_naming_convention(filepath)
         _, artifactsRemovalMethod = read_artifact_provenance(destination=filepath)
 
@@ -211,7 +211,7 @@ def execute_zscore(session_folders: list[str], inputParameters: dict[str, object
             )
             write_zscore(filepath, name, z_score, dff, control_fit, control_array)
 
-        logger.info(f"z-score for the data in {filepath} computed.")
+        logger.info("z-score for the data in %s computed.", filepath)
         progress.advance()
 
     logger.info("Z-score computation completed.")
@@ -425,8 +425,8 @@ def extractTsAndSignal(inputParameters: dict[str, object]) -> None:
     save_parameters(inputParameters=inputParameters, remove_artifacts=False)
 
     session_folders = inputParameters["session_folders"]
-    logger.info(f"Combine Data : {inputParameters['combine_data']}")
-    logger.info(f"Isosbestic Control Channel : {inputParameters['isosbestic_control']}")
+    logger.info("Combine Data : %s", inputParameters["combine_data"])
+    logger.info("Isosbestic Control Channel : %s", inputParameters["isosbestic_control"])
 
     _start_progress(inputParameters, passes_per_folder=2)
     folders = _correct_and_maybe_combine(session_folders, inputParameters)
@@ -455,8 +455,8 @@ def removeArtifactsFromSignal(inputParameters: dict[str, object]) -> None:
 
     save_parameters(inputParameters=inputParameters, remove_artifacts=True)
 
-    logger.info(f"Combine Data : {inputParameters['combine_data']}")
-    logger.info(f"Isosbestic Control Channel : {inputParameters['isosbestic_control']}")
+    logger.info("Combine Data : %s", inputParameters["combine_data"])
+    logger.info("Isosbestic Control Channel : %s", inputParameters["isosbestic_control"])
 
     _start_progress(inputParameters, passes_per_folder=3)
     folders = _correct_and_maybe_combine(session_folders, inputParameters)

--- a/src/guppy/orchestration/psth.py
+++ b/src/guppy/orchestration/psth.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 import glob
 import logging
 import multiprocessing as mp
@@ -89,7 +87,7 @@ def execute_compute_psth(filepath: str, event: str, inputParameters: dict[str, o
     a = 1
 
     for i in range(len(path)):
-        logger.info(f"Computing PSTH for event {event}...")
+        logger.info("Computing PSTH for event %s...", event)
         basename = (os.path.basename(path[i])).split(".")[0]
         name_1 = recording_site_from_preprocessed_label(basename)
         control = read_hdf5("control_" + name_1, os.path.dirname(path[i]), "data")
@@ -137,7 +135,7 @@ def execute_compute_psth(filepath: str, event: str, inputParameters: dict[str, o
             columns=columns,
         )
         create_Df_for_psth(filepath, event + "_" + name_1, basename, psth, columns=columns)
-        logger.info(f"PSTH for event {event} computed.")
+        logger.info("PSTH for event %s computed.", event)
 
 
 def execute_compute_psth_peak_and_area(filepath: str, event: str, inputParameters: dict[str, object]) -> None:
@@ -170,7 +168,7 @@ def execute_compute_psth_peak_and_area(filepath: str, event: str, inputParameter
         path = glob.glob(os.path.join(filepath, "z_score_*")) + glob.glob(os.path.join(filepath, "dff_*"))
 
     for i in range(len(path)):
-        logger.info(f"Computing peak and area for PSTH mean signal for event {event}...")
+        logger.info("Computing peak and area for PSTH mean signal for event %s...", event)
         basename = (os.path.basename(path[i])).split(".")[0]
         name_1 = recording_site_from_preprocessed_label(basename)
         sampling_rate = read_hdf5("timeCorrection_" + name_1, filepath, "sampling_rate")[0]
@@ -190,7 +188,7 @@ def execute_compute_psth_peak_and_area(filepath: str, event: str, inputParameter
         index = [fileName[0] + "_" + name for name in psth_mean_bin_names]
         write_peak_and_area_to_hdf5(filepath, peak_area, event + "_" + name_1 + "_" + basename, index=index)
         write_peak_and_area_to_csv(filepath, peak_area, event + "_" + name_1 + "_" + basename, index=index)
-        logger.info(f"Peak and Area for PSTH mean signal for event {event} computed.")
+        logger.info("Peak and Area for PSTH mean signal for event %s computed.", event)
 
 
 def execute_compute_cross_correlation(filepath: str, event: str, inputParameters: dict[str, object]) -> None:
@@ -237,7 +235,7 @@ def execute_compute_cross_correlation(filepath: str, event: str, inputParameters
             return
         else:
             for i in range(1, len(corr_info)):
-                logger.debug(f"Computing cross-correlation for event {event}...")
+                logger.debug("Computing cross-correlation for event %s...", event)
                 for j in range(len(type)):
                     psth_a = read_Df(filepath, event + "_" + corr_info[i - 1], type[j] + "_" + corr_info[i - 1])
                     psth_b = read_Df(filepath, event + "_" + corr_info[i], type[j] + "_" + corr_info[i])
@@ -257,10 +255,15 @@ def execute_compute_cross_correlation(filepath: str, event: str, inputParameters
                         )
                     if len(matched_labels) < max(len(psth_a.columns), len(psth_b.columns)):
                         logger.warning(
-                            f"Recording sites '{corr_info[i - 1]}' and '{corr_info[i]}' have a different set of "
-                            f"surviving trials for event '{event}' (uneven artifact removal): "
-                            f"{len(psth_a.columns)} vs {len(psth_b.columns)} trials, {len(matched_labels)} matched. "
-                            f"Cross-correlating only the matched trials."
+                            "Recording sites '%s' and '%s' have a different set of surviving trials for event '%s' "
+                            "(uneven artifact removal): %s vs %s trials, %s matched. Cross-correlating only the matched "
+                            "trials.",
+                            corr_info[i - 1],
+                            corr_info[i],
+                            event,
+                            len(psth_a.columns),
+                            len(psth_b.columns),
+                            len(matched_labels),
                         )
                     psth_array_a = np.array(psth_a).T[indices_a]
                     psth_array_b = np.array(psth_b).T[indices_b]
@@ -274,7 +277,7 @@ def execute_compute_cross_correlation(filepath: str, event: str, inputParameters
                         cross_corr,
                         columns,
                     )
-                logger.info(f"Cross-correlation for event {event} computed.")
+                logger.info("Cross-correlation for event %s computed.", event)
 
 
 def orchestrate_psth(inputParameters: dict[str, object]) -> None:
@@ -293,7 +296,7 @@ def orchestrate_psth(inputParameters: dict[str, object]) -> None:
     spawn_context = mp.get_context("spawn")
     selected_runs = inputParameters.get("selected_runs") or {}
     for i in range(len(session_folders)):
-        logger.debug(f"Computing PSTH, Peak and Area for each event in {session_folders[i]}")
+        logger.debug("Computing PSTH, Peak and Area for each event in %s", session_folders[i])
         run_folders = select_run_folders(session_folders[i], selected_runs.get(session_folders[i]))
         for j in range(len(run_folders)):
             filepath = run_folders[j]
@@ -330,7 +333,7 @@ def orchestrate_psth(inputParameters: dict[str, object]) -> None:
             execute_compute_psth_significance(filepath, inputParameters)
             if inputParameters["computePsthSignificance"]:
                 progress.advance()
-        logger.info(f"PSTH, Area and Peak are computed for all events in {session_folders[i]}.")
+        logger.info("PSTH, Area and Peak are computed for all events in %s.", session_folders[i])
 
 
 def execute_psth_combined(inputParameters: dict[str, object]) -> None:
@@ -459,8 +462,10 @@ def psthForEachStore(inputParameters: dict[str, object]) -> None:
         numProcesses = mp.cpu_count()
     elif numProcesses > mp.cpu_count():
         logger.warning(
-            f"Number of cores requested ({numProcesses}) exceeds available cores "
-            f"({mp.cpu_count()}); using {mp.cpu_count() - 1}."
+            "Number of cores requested (%s) exceeds available cores (%s); using %s.",
+            numProcesses,
+            mp.cpu_count(),
+            mp.cpu_count() - 1,
         )
         numProcesses = mp.cpu_count() - 1
 

--- a/src/guppy/orchestration/psth_significance.py
+++ b/src/guppy/orchestration/psth_significance.py
@@ -255,14 +255,18 @@ def execute_one_comparison(
     sample_counts = [samples_a.shape[0]] + ([samples_b.shape[0]] if samples_b is not None else [])
     if min(sample_counts) < MINIMUM_SAMPLES:
         logger.warning(
-            f"Skipping significance for {name}: needs at least {MINIMUM_SAMPLES} trials or sessions "
-            f"to resample, found {min(sample_counts)}."
+            "Skipping significance for %s: needs at least %s trials or sessions to resample, found %s.",
+            name,
+            MINIMUM_SAMPLES,
+            min(sample_counts),
         )
         return f"{name} (found {min(sample_counts)})"
     if min(sample_counts) < SMALL_SAMPLE_WARNING_THRESHOLD:
         logger.warning(
-            f"Significance for {name} is computed from only {min(sample_counts)} trials or sessions; "
-            f"the confidence interval is unreliable at this sample size."
+            "Significance for %s is computed from only %s trials or sessions; the confidence interval is unreliable at "
+            "this sample size.",
+            name,
+            min(sample_counts),
         )
 
     significance = compute_comparison(
@@ -282,15 +286,16 @@ def execute_one_comparison(
     uncomputable = float(np.mean(~np.isfinite(significance["ci_lower"].to_numpy())))
     if uncomputable > UNCOMPUTABLE_FRACTION_WARNING_THRESHOLD:
         logger.warning(
-            f"No confidence interval could be computed for {uncomputable:.0%} of the window in {name}, "
-            f"where too few trials or sessions overlap. Those timepoints are reported as "
-            f"not significant."
+            "No confidence interval could be computed for %.0f%% of the window in %s, where too few trials or sessions "
+            "overlap. Those timepoints are reported as not significant.",
+            uncomputable * 100,
+            name,
         )
 
     output_path = make_dir_for_psth_significance(filepath)
     write_psth_significance_to_hdf5(filepath=output_path, significance=significance, name=name)
     write_psth_significance_to_csv(filepath=output_path, significance=significance, name=name)
-    logger.info(f"Significance for {name} computed.")
+    logger.info("Significance for %s computed.", name)
 
     return None
 
@@ -396,7 +401,7 @@ def execute_compute_psth_significance(filepath: str, inputParameters: dict[str, 
 
     planned = plan_comparisons(filepath, inputParameters)
     if not planned:
-        logger.info(f"No PSTH results to test for significance in {filepath}.")
+        logger.info("No PSTH results to test for significance in %s.", filepath)
         return
 
     # Reported rather than refused: how many resamples to spend is the user's call, but
@@ -407,12 +412,14 @@ def execute_compute_psth_significance(filepath: str, inputParameters: dict[str, 
     resamples_per_tail = num_resamples * significance_level / 2
     if resamples_per_tail < 1:
         logger.warning(
-            f"psthBootstrapResamples={num_resamples} cannot resolve a {significance_level:g} "
-            f"two-sided interval: that needs at least {int(np.ceil(2 / significance_level))} resamples. "
-            f"The interval will be narrower than requested."
+            "psthBootstrapResamples=%s cannot resolve a %g two-sided interval: that needs at least %s resamples. The "
+            "interval will be narrower than requested.",
+            num_resamples,
+            significance_level,
+            int(np.ceil(2 / significance_level)),
         )
 
-    logger.info(f"Computing significance for {len(planned)} comparison(s) in {filepath}...")
+    logger.info("Computing significance for %s comparison(s) in %s...", len(planned), filepath)
     # Pinned rather than inherited, for the same reason as the step-4 pools: forking a
     # process holding other live threads can leave a logging or HDF5 lock held forever.
     spawn_context = mp.get_context("spawn")

--- a/src/guppy/orchestration/read_raw_data.py
+++ b/src/guppy/orchestration/read_raw_data.py
@@ -142,8 +142,10 @@ def orchestrate_read_raw_data(inputParameters: dict[str, object]) -> None:
         numProcesses = mp.cpu_count()
     elif numProcesses > mp.cpu_count():
         logger.warning(
-            f"Number of cores requested ({numProcesses}) exceeds available cores "
-            f"({mp.cpu_count()}); using {mp.cpu_count() - 1}."
+            "Number of cores requested (%s) exceeds available cores (%s); using %s.",
+            numProcesses,
+            mp.cpu_count(),
+            mp.cpu_count() - 1,
         )
         numProcesses = mp.cpu_count() - 1
 
@@ -211,7 +213,7 @@ def orchestrate_read_raw_data(inputParameters: dict[str, object]) -> None:
         base_module._SAMPLES_DONE = samples_done
         try:
             for extractor, grouped_events, run_folder, event_totals in tasks:
-                logger.debug(f"### Reading raw data for {len(grouped_events)} event(s) into {run_folder}")
+                logger.debug("### Reading raw data for %s event(s) into %s", len(grouped_events), run_folder)
                 read_and_save_events_for_extractor(extractor, grouped_events, run_folder, event_totals)
         finally:
             base_module._SAMPLES_DONE = None

--- a/src/guppy/orchestration/save_parameters.py
+++ b/src/guppy/orchestration/save_parameters.py
@@ -68,7 +68,7 @@ def record_artifact_provenance(
 
     with open(parameters_path, "w") as parameters_file:
         json.dump(parameters, parameters_file, indent=4)
-    logger.info(f"Artifact provenance updated at {destination}")
+    logger.info("Artifact provenance updated at %s", destination)
 
 
 def build_analysis_parameters(*, inputParameters: dict[str, object]) -> dict[str, object]:
@@ -166,7 +166,7 @@ def write_analysis_parameters(
     )
     with open(os.path.join(destination, "GuPPyParamtersUsed.json"), "w") as parameters_file:
         json.dump(destinationParameters, parameters_file, indent=4)
-    logger.info(f"Input Parameters file saved at {destination}")
+    logger.info("Input Parameters file saved at %s", destination)
 
 
 def save_parameters(

--- a/src/guppy/orchestration/step_view.py
+++ b/src/guppy/orchestration/step_view.py
@@ -69,5 +69,5 @@ class StepView:
         self.pending[token] = (session_folders, inputParameters)
         parts = urlsplit(_current_href())
         url = f"{parts.scheme}://{parts.netloc}/{self.route}?token={token}"
-        logger.info(f"Opening {self.route} at {url}")
+        logger.info("Opening %s at %s", self.route, url)
         webbrowser.open(url)

--- a/src/guppy/orchestration/store_labeling.py
+++ b/src/guppy/orchestration/store_labeling.py
@@ -102,7 +102,7 @@ def _fetchValues(
                 return "####Alert !! \n One of the text box entry is empty."
             if len(name.split()) > 1:
                 return "####Alert !! \n Whitespace is not allowed in the text box entry."
-            store_labels.append("signal_{}".format(name))
+            store_labels.append(f"signal_{name}")
             signal_names.append(name)
         elif dropdown_value == "control":
             signal_key = store_id_control_refs[key].value
@@ -112,7 +112,7 @@ def _fetchValues(
                     "Select the signal each control belongs to."
                 )
             signal_name = signal_key_to_name.get(signal_key, "")
-            store_labels.append("control_{}".format(signal_name))
+            store_labels.append(f"control_{signal_name}")
             signals_with_control.add(signal_name)
         elif dropdown_value == "event TTLs":
             name = store_id_textboxes[key].value or ""
@@ -127,7 +127,7 @@ def _fetchValues(
                 return "####Alert !! \n One of the text box entry is empty."
             if len(name.split()) > 1:
                 return "####Alert !! \n Whitespace is not allowed in the text box entry."
-            store_labels.append("covariate_{}".format(name))
+            store_labels.append(f"covariate_{name}")
         else:
             store_labels.append(dropdown_value)
 
@@ -262,14 +262,14 @@ def _save(
             return f"#### Alert !! \n {detail}"
         # Overwrite mode: clear all derived data from the previous run before saving the new store_array.
         shutil.rmtree(select_location)
-        logger.info(f"Cleared output directory for overwrite: {select_location}")
+        logger.info("Cleared output directory for overwrite: %s", select_location)
     os.mkdir(select_location)
 
     write_stores_list(run_folder=select_location, store_array=store_array)
     if npm_params is not None:
         write_npm_params(run_folder=select_location, npm_params=npm_params)
-    logger.info(f"Storeslist file saved at {select_location}")
-    logger.info("Storeslist : \n" + str(store_array))
+    logger.info("Storeslist file saved at %s", select_location)
+    logger.info("Storeslist : \n%s", store_array)
     return "#### No alerts !!"
 
 
@@ -312,7 +312,7 @@ def build_store_labeling_template(
     """
     allnames = events
 
-    template = pn.template.BootstrapTemplate(title="Label Stores GUI - {}".format(os.path.basename(folder_path)))
+    template = pn.template.BootstrapTemplate(title=f"Label Stores GUI - {os.path.basename(folder_path)}")
 
     if npm_interactive is not None:
         store_labeling_instructions = StoreLabelingInstructionsNPM(

--- a/src/guppy/orchestration/transients.py
+++ b/src/guppy/orchestration/transients.py
@@ -233,8 +233,10 @@ def executeFindFreqAndAmp(inputParameters: dict[str, object]) -> None:
         numProcesses = mp.cpu_count()
     elif numProcesses > mp.cpu_count():
         logger.warning(
-            f"Number of cores requested ({numProcesses}) exceeds available cores "
-            f"({mp.cpu_count()}); using {mp.cpu_count() - 1}."
+            "Number of cores requested (%s) exceeds available cores (%s); using %s.",
+            numProcesses,
+            mp.cpu_count(),
+            mp.cpu_count() - 1,
         )
         numProcesses = mp.cpu_count() - 1
 
@@ -265,7 +267,7 @@ def execute_find_freq_and_amp(
     selected_runs = inputParameters.get("selected_runs") or {}
     for i in range(len(session_folders)):
         logger.debug(
-            f"Finding transients in z-score data of {session_folders[i]} and calculating frequency and amplitude."
+            "Finding transients in z-score data of %s and calculating frequency and amplitude.", session_folders[i]
         )
         filepath = session_folders[i]
         run_folders = select_run_folders(filepath, selected_runs.get(filepath))

--- a/src/guppy/orchestration/visualize.py
+++ b/src/guppy/orchestration/visualize.py
@@ -110,7 +110,7 @@ def helper_plots(filepath: str, event: list[str], name: list[str], inputParamete
             bin_columns = bins[bins_keys[i]]
             if len(bin_columns) > 0:
                 for j in bin_columns:
-                    multiple_plots_options.append("{}_{}".format(bins_keys[i], j))
+                    multiple_plots_options.append(f"{bins_keys[i]}_{j}")
 
         multiple_plots_options = new_event + multiple_plots_options
     else:
@@ -127,9 +127,7 @@ def helper_plots(filepath: str, event: list[str], name: list[str], inputParamete
     x = [columns_dict[new_event[0]][-4]]
     y = overview_y_options(columns_dict[new_event[0]])
     trial_no = range(1, len(remove_cols(columns_dict[heatmap_options[0]])[:-2]) + 1)
-    trial_ts = [
-        "{} - {}".format(i, j) for i, j in zip(trial_no, remove_cols(columns_dict[heatmap_options[0]])[:-2])
-    ] + ["All"]
+    trial_ts = [f"{i} - {j}" for i, j in zip(trial_no, remove_cols(columns_dict[heatmap_options[0]])[:-2])] + ["All"]
 
     plotter = ParameterizedPlotter(
         event_selector_objects=new_event,

--- a/src/guppy/testing/api.py
+++ b/src/guppy/testing/api.py
@@ -12,7 +12,8 @@ This module is intentionally minimal and non-invasive.
 from __future__ import annotations
 
 import os
-from typing import Iterable, Literal
+from collections.abc import Iterable
+from typing import Literal
 
 import numpy as np
 import pandas as pd

--- a/src/guppy/utils/nwb_metadata.py
+++ b/src/guppy/utils/nwb_metadata.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from functools import lru_cache
+from functools import cache
 from pathlib import Path
 
 import numpy as np
@@ -290,7 +290,7 @@ ENUM_OPTIONS: dict[str, tuple[str, ...]] = {
 }
 
 
-@lru_cache(maxsize=None)
+@cache
 def _type_spec(type_name: str):  # noqa: ANN202  (returns an hdmf Spec)
     import ndx_fiber_photometry  # noqa: F401  (register extensions)
     import ndx_ophys_devices  # noqa: F401

--- a/src/guppy/utils/progress.py
+++ b/src/guppy/utils/progress.py
@@ -13,8 +13,8 @@ the pipeline steps emit.
 import functools
 import logging
 import threading
+from collections.abc import Callable
 from contextvars import ContextVar
-from typing import Callable
 
 logger = logging.getLogger(__name__)
 

--- a/src/guppy/utils/utils.py
+++ b/src/guppy/utils/utils.py
@@ -598,7 +598,7 @@ def read_Df(filepath: str, event: str, name: str) -> pd.DataFrame:
     event = event.replace("\\", "_")
     event = event.replace("/", "_")
     if name:
-        hdf5_path = os.path.join(filepath, event + "_{}.h5".format(name))
+        hdf5_path = os.path.join(filepath, event + f"_{name}.h5")
     else:
         hdf5_path = os.path.join(filepath, event + ".h5")
     df = pd.read_hdf(hdf5_path, key="df", mode="r")

--- a/src/guppy/utils/validation.py
+++ b/src/guppy/utils/validation.py
@@ -33,7 +33,7 @@ Conventions
 import glob
 import logging
 import os
-from typing import Sequence
+from collections.abc import Sequence
 
 import numpy as np
 

--- a/tests/integration/test_integration_save_parameters.py
+++ b/tests/integration/test_integration_save_parameters.py
@@ -69,7 +69,7 @@ def test_save_parameters(tmp_path, default_parameters):
     for s in sessions:
         out_fp = os.path.join(s, "GuPPyParamtersUsed.json")
         assert os.path.exists(out_fp), f"Missing file: {out_fp}"
-        with open(out_fp, "r") as f:
+        with open(out_fp) as f:
             data = json.load(f)
 
         assert data["guppy_version"] == version("guppy-neuro")


### PR DESCRIPTION
<!-- summary line goes here -->

<details>
<summary>Details (AI-generated)</summary>

Closes #476. Stacked on #480 — review the last commit, or wait for #480 to merge.

The 57 logging sites are the substantive part: each now passes its arguments to the logger instead of the formatted result. Two required more than a mechanical translation — `psth_significance.py`'s `{uncomputable:.0%}` became `%.0f%%` over `uncomputable * 100` (`%` has no percent conversion), and `store_labeling.py`'s `"Storeslist : \n" + str(store_array)` became a `%s`. Templates that grew past 120 characters are wrapped with implicit concatenation.

The rest is what `ruff --fix` produces for `UP`: 25 `.format()` calls, four `Callable`/`Sequence`/`Iterable` imports moved to `collections.abc`, one `# coding: utf-8`, one `lru_cache(maxsize=None)`, and one redundant `open()` mode in the tests.

`UP` and `G` are added to the `select` list in `pyproject.toml`, replacing the individual `UP006`/`UP007` entries they subsume.

A static check over the result confirms all 57 templates have as many conversion specifiers as arguments, and no stray unescaped `%`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>
