### PR TITLE
Migrate the rest of analysis/ and the leaf utils modules to pathlib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed the README's documentation links, which all carried an `/en/latest/` path prefix that 404s on the single-version Read the Docs project. [PR #469](https://github.com/LernerLab/GuPPy/pull/469)
 
 ## Improvements
+- The rest of the analysis layer and GuPPy's validation, custom-event and NWB helpers now build paths with `pathlib.Path`. [PR #484](https://github.com/LernerLab/GuPPy/pull/484)
 - GuPPy's core HDF5 and results I/O now builds paths with `pathlib.Path` rather than `os.path`, and `ruff`'s `PTH` rules are enabled with the not-yet-converted modules listed explicitly so the migration is tracked rather than open-ended. [PR #483](https://github.com/LernerLab/GuPPy/pull/483)
 - Every `zip()` over parallel sequences now declares `strict=`, so a pair that has silently truncated to the shorter operand raises instead. [PR #482](https://github.com/LernerLab/GuPPy/pull/482)
 - The six `write_*` helpers in `analysis/standard_io.py` no longer share a mutable list as their `index`/`columns` default, and each visualization dashboard now keeps its own render cache instead of one shared across every open dashboard. `ruff`'s `B006`, `B008`, `RUF012` and `DTZ` rules are enabled to keep both classes of shared state out. [PR #482](https://github.com/LernerLab/GuPPy/pull/482)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,15 +152,7 @@ fixable = ["ALL"]
 # The pathlib migration (#478) runs module by module. Every entry below is a module that
 # still uses os.path/glob; each migration PR deletes the entries it converts, so what is
 # left here is the remaining work rather than a permanent exemption.
-"src/guppy/analysis/control_channel.py" = ["PTH"]
-"src/guppy/analysis/psth_average.py" = ["PTH"]
-"src/guppy/analysis/psth_utils.py" = ["PTH"]
-"src/guppy/analysis/transients_average.py" = ["PTH"]
-"src/guppy/utils/custom_events.py" = ["PTH"]
-"src/guppy/utils/nwb_io.py" = ["PTH"]
-"src/guppy/utils/nwb_metadata.py" = ["PTH"]
 "src/guppy/utils/utils.py" = ["PTH"]
-"src/guppy/utils/validation.py" = ["PTH"]
 "src/guppy/extractors/*" = ["PTH"]
 "src/guppy/frontend/*" = ["PTH"]
 "src/guppy/orchestration/*" = ["PTH"]

--- a/src/guppy/analysis/control_channel.py
+++ b/src/guppy/analysis/control_channel.py
@@ -1,6 +1,6 @@
 import logging
-import os
 import shutil
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -72,9 +72,8 @@ def add_control_channel(filepath: str, store_array: np.ndarray) -> np.ndarray:
             expected_control_name = "control_" + str(name).lower()
             find_signal = [True for i in store_labels_lower if i == expected_control_name]
             if len(find_signal) == 0:
-                source_path, destination_path = os.path.join(filepath, store_array[0, i] + ".hdf5"), os.path.join(
-                    filepath, "cntrl" + str(i) + ".hdf5"
-                )
+                source_path = Path(filepath) / (store_array[0, i] + ".hdf5")
+                destination_path = Path(filepath) / ("cntrl" + str(i) + ".hdf5")
                 shutil.copyfile(source_path, destination_path)
                 store_array = np.concatenate(
                     (
@@ -121,7 +120,7 @@ def create_control_channel(filepath: str, store_array: np.ndarray, window: int =
             write_hdf5(control, event_name, filepath, "data")
             data_dict = {"timestamps": timestampNew, "data": control, "sampling_rate": sampling_rate}
             df = pd.DataFrame(data_dict)
-            df.to_csv(os.path.join(os.path.dirname(filepath), event.lower() + ".csv"), index=False)
+            df.to_csv(Path(filepath).parent / (event.lower() + ".csv"), index=False)
             logger.info("Control channel from signal channel created using curve-fitting")
 
 

--- a/src/guppy/analysis/psth_average.py
+++ b/src/guppy/analysis/psth_average.py
@@ -1,8 +1,7 @@
-import glob
 import logging
 import math
-import os
 import re
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -52,16 +51,16 @@ def average_psth_for_group(
     # combining paths to all the selected folders for doing average
     for i in range(len(member_run_folders)):
         if selectForComputePsth == "z_score":
-            matched_paths = glob.glob(os.path.join(member_run_folders[i], "z_score_*"))
+            matched_paths = list(Path(member_run_folders[i]).glob("z_score_*"))
         elif selectForComputePsth == "dff":
-            matched_paths = glob.glob(os.path.join(member_run_folders[i], "dff_*"))
+            matched_paths = list(Path(member_run_folders[i]).glob("dff_*"))
         else:
-            matched_paths = glob.glob(os.path.join(member_run_folders[i], "z_score_*")) + glob.glob(
-                os.path.join(member_run_folders[i], "dff_*")
+            matched_paths = list(Path(member_run_folders[i]).glob("z_score_*")) + list(
+                Path(member_run_folders[i]).glob("dff_*")
             )
 
         for j in range(len(matched_paths)):
-            basename = (os.path.basename(matched_paths[j])).split(".")[0]
+            basename = matched_paths[j].name.split(".")[0]
             name_1 = recording_site_from_preprocessed_label(basename)
             entry = [member_run_folders[i], event + "_" + name_1, basename]
             path.append(entry)
@@ -87,9 +86,8 @@ def average_psth_for_group(
         bin_columns = []
         session_entries = new_path[i]
         for j in range(len(session_entries)):
-            if not os.path.exists(
-                os.path.join(session_entries[j][0], session_entries[j][1] + f"_{session_entries[j][2]}.h5")
-            ):
+            psth_path = Path(session_entries[j][0]) / (session_entries[j][1] + f"_{session_entries[j][2]}.h5")
+            if not psth_path.exists():
                 continue
             else:
                 # read_Df arguments are filepath, event, name
@@ -98,7 +96,7 @@ def average_psth_for_group(
                 regex = re.compile("bin_[(]")
                 bin_columns = [column_names[i] for i in range(len(column_names)) if regex.match(column_names[i])]
                 psth.append(np.asarray(df["mean"]))
-                columns.append(os.path.basename(session_entries[j][0]))
+                columns.append(Path(session_entries[j][0]).name)
                 if len(bin_columns) > 0:
                     psth_bins.append(df[bin_columns])
 
@@ -142,11 +140,10 @@ def average_psth_for_group(
         row_indices = []
         session_entries = new_path[i]
         for j in range(len(session_entries)):
-            if not os.path.exists(
-                os.path.join(
-                    session_entries[j][0], "peak_AUC_" + session_entries[j][1] + "_" + session_entries[j][2] + ".h5"
-                )
-            ):
+            peak_auc_path = Path(session_entries[j][0]) / (
+                "peak_AUC_" + session_entries[j][1] + "_" + session_entries[j][2] + ".h5"
+            )
+            if not peak_auc_path.exists():
                 continue
             else:
                 df = read_Df_area_peak(session_entries[j][0], session_entries[j][1] + "_" + session_entries[j][2])
@@ -164,11 +161,11 @@ def average_psth_for_group(
         row_indices = list(np.concatenate(row_indices))
         new_df = pd.concat(peak_area_frames, axis=0)
         new_df.to_csv(
-            os.path.join(run_folder, f"peak_AUC_{session_entries[j][1]}_{session_entries[j][2]}.csv"),
+            Path(run_folder) / f"peak_AUC_{session_entries[j][1]}_{session_entries[j][2]}.csv",
             index=row_indices,
         )
         new_df.to_hdf(
-            os.path.join(run_folder, f"peak_AUC_{session_entries[j][1]}_{session_entries[j][2]}.h5"),
+            Path(run_folder) / f"peak_AUC_{session_entries[j][1]}_{session_entries[j][2]}.h5",
             key="df",
             mode="w",
             index=row_indices,
@@ -188,21 +185,14 @@ def average_psth_for_group(
         for j in range(len(member_run_folders)):
             corr_info, _ = getCorrCombinations(member_run_folders[j], inputParameters)
             for k in range(1, len(corr_info)):
-                path = os.path.join(
-                    member_run_folders[j],
-                    "cross_correlation_output",
-                    "corr_" + event + "_" + type[i] + "_" + corr_info[k - 1] + "_" + corr_info[k],
-                )
-                if not os.path.exists(path + ".h5"):
+                correlation_folder = Path(member_run_folders[j]) / "cross_correlation_output"
+                name = type[i] + "_" + corr_info[k - 1] + "_" + corr_info[k]
+                if not (correlation_folder / ("corr_" + event + "_" + name + ".h5")).exists():
                     continue
                 else:
-                    df = read_Df(
-                        os.path.join(member_run_folders[j], "cross_correlation_output"),
-                        "corr_" + event,
-                        type[i] + "_" + corr_info[k - 1] + "_" + corr_info[k],
-                    )
+                    df = read_Df(correlation_folder, "corr_" + event, name)
                     corr.append(df["mean"])
-                    columns.append(os.path.basename(member_run_folders[j]))
+                    columns.append(Path(member_run_folders[j]).name)
 
         if not isinstance(df, pd.DataFrame):
             break
@@ -273,7 +263,7 @@ def read_Df_area_peak(filepath: str, name: str) -> pd.DataFrame:
     df : pd.DataFrame
         DataFrame of peak and area-under-curve metrics.
     """
-    output_path = os.path.join(filepath, "peak_AUC_" + name + ".h5")
+    output_path = Path(filepath) / ("peak_AUC_" + name + ".h5")
     df = pd.read_hdf(output_path, key="df", mode="r")
 
     return df

--- a/src/guppy/analysis/psth_utils.py
+++ b/src/guppy/analysis/psth_utils.py
@@ -1,8 +1,7 @@
-import glob
 import logging
 import math
-import os
 import re
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -32,9 +31,9 @@ def create_Df_for_psth(filepath: str, event: str, name: str, psth: np.ndarray, c
     event = event.replace("\\", "_")
     event = event.replace("/", "_")
     if name:
-        output_path = os.path.join(filepath, event + f"_{name}.h5")
+        output_path = Path(filepath) / (event + f"_{name}.h5")
     else:
-        output_path = os.path.join(filepath, event + ".h5")
+        output_path = Path(filepath) / (event + ".h5")
 
     # removing psth binned trials
     columns = np.array(columns, dtype="str")
@@ -156,9 +155,9 @@ def create_Df_for_cross_correlation(
         Column labels for the trials axis. Default is an empty list.
     """
     if name:
-        output_path = os.path.join(filepath, event + f"_{name}.h5")
+        output_path = Path(filepath) / (event + f"_{name}.h5")
     else:
-        output_path = os.path.join(filepath, event + ".h5")
+        output_path = Path(filepath) / (event + ".h5")
 
     # removing psth binned trials
     columns = list(np.array(columns, dtype="str"))
@@ -203,18 +202,18 @@ def getCorrCombinations(filepath: str, inputParameters: dict[str, object]) -> tu
     """
     selectForComputePsth = inputParameters["selectForComputePsth"]
     if selectForComputePsth == "z_score":
-        path = glob.glob(os.path.join(filepath, "z_score_*"))
+        path = list(Path(filepath).glob("z_score_*"))
     elif selectForComputePsth == "dff":
-        path = glob.glob(os.path.join(filepath, "dff_*"))
+        path = list(Path(filepath).glob("dff_*"))
     else:
-        path = glob.glob(os.path.join(filepath, "z_score_*")) + glob.glob(os.path.join(filepath, "dff_*"))
+        path = list(Path(filepath).glob("z_score_*")) + list(Path(filepath).glob("dff_*"))
 
     names = list()
     type = list()
     for i in range(len(path)):
-        basename = (os.path.basename(path[i])).split(".")[0]
+        basename = path[i].name.split(".")[0]
         names.append(recording_site_from_preprocessed_label(basename))
-        type.append((os.path.basename(path[i])).split(".")[0].split("_" + names[-1], 1)[0])
+        type.append(path[i].name.split(".")[0].split("_" + names[-1], 1)[0])
 
     names = list(np.unique(np.array(names)))
     type = list(np.unique(np.array(type)))

--- a/src/guppy/analysis/transients_average.py
+++ b/src/guppy/analysis/transients_average.py
@@ -1,6 +1,5 @@
-import glob
 import logging
-import os
+from pathlib import Path
 
 import numpy as np
 
@@ -36,16 +35,16 @@ def average_transients_for_group(
 
     for i in range(len(member_run_folders)):
         if selectForTransientsComputation == "z_score":
-            matched_paths = glob.glob(os.path.join(member_run_folders[i], "z_score_*"))
+            matched_paths = list(Path(member_run_folders[i]).glob("z_score_*"))
         elif selectForTransientsComputation == "dff":
-            matched_paths = glob.glob(os.path.join(member_run_folders[i], "dff_*"))
+            matched_paths = list(Path(member_run_folders[i]).glob("dff_*"))
         else:
-            matched_paths = glob.glob(os.path.join(member_run_folders[i], "z_score_*")) + glob.glob(
-                os.path.join(member_run_folders[i], "dff_*")
+            matched_paths = list(Path(member_run_folders[i]).glob("z_score_*")) + list(
+                Path(member_run_folders[i]).glob("dff_*")
             )
 
         for j in range(len(matched_paths)):
-            basename = (os.path.basename(matched_paths[j])).split(".")[0]
+            basename = matched_paths[j].name.split(".")[0]
             entry = [member_run_folders[i], basename]
             path.append(entry)
 
@@ -68,12 +67,12 @@ def average_transients_for_group(
         fileName = []
         session_entries = new_path[i]
         for j in range(len(session_entries)):
-            if not os.path.exists(os.path.join(session_entries[j][0], "freqAndAmp_" + session_entries[j][1] + ".h5")):
+            if not (Path(session_entries[j][0]) / ("freqAndAmp_" + session_entries[j][1] + ".h5")).exists():
                 continue
             else:
                 df = read_freq_and_amp_from_hdf5(session_entries[j][0], session_entries[j][1])
                 freq_and_amp_values.append(np.array([df["freq (events/min)"].iloc[0], df["amplitude"].iloc[0]]))
-                fileName.append(os.path.basename(session_entries[j][0]))
+                fileName.append(Path(session_entries[j][0]).name)
 
         freq_and_amp_values = np.asarray(freq_and_amp_values)
         write_freq_and_amp_to_hdf5(

--- a/src/guppy/utils/custom_events.py
+++ b/src/guppy/utils/custom_events.py
@@ -12,6 +12,7 @@ are not part of the advertised pipeline API.
 
 import os
 import re
+from pathlib import Path
 
 import pandas as pd
 
@@ -70,7 +71,9 @@ def is_sorted(timestamps: list[float]) -> bool:
     return all(earlier <= later for earlier, later in zip(timestamps, timestamps[1:], strict=False))
 
 
-def write_custom_event_csv(*, name: str, timestamps: list[float], folder_path: str, overwrite: bool = False) -> str:
+def write_custom_event_csv(
+    *, name: str, timestamps: list[float], folder_path: str | Path, overwrite: bool = False
+) -> Path:
     """Write timestamps as a GuPPy-compatible event CSV named after the event.
 
     The file is written as ``<name>.csv`` into ``folder_path`` with a single
@@ -84,7 +87,7 @@ def write_custom_event_csv(*, name: str, timestamps: list[float], folder_path: s
         no path separators.
     timestamps : list of float
         Event timestamps in seconds.
-    folder_path : str
+    folder_path : str or Path
         Absolute path to the session directory the CSV is written into.
     overwrite : bool, optional
         If False (default) and a file named ``<name>.csv`` already exists, raise
@@ -92,7 +95,7 @@ def write_custom_event_csv(*, name: str, timestamps: list[float], folder_path: s
 
     Returns
     -------
-    str
+    Path
         Absolute path to the written CSV.
 
     Raises
@@ -107,8 +110,8 @@ def write_custom_event_csv(*, name: str, timestamps: list[float], folder_path: s
     if os.sep in name or (os.altsep and os.altsep in name):
         raise ValueError(f"Event name {name!r} must not contain a path separator.")
 
-    csv_path = os.path.join(folder_path, f"{name}.csv")
-    if os.path.exists(csv_path) and not overwrite:
+    csv_path = Path(folder_path) / f"{name}.csv"
+    if csv_path.exists() and not overwrite:
         raise FileExistsError(
             f"An event named {name!r} already exists at {csv_path}. Enable overwrite to replace it, "
             "or choose a different name."

--- a/src/guppy/utils/nwb_io.py
+++ b/src/guppy/utils/nwb_io.py
@@ -20,9 +20,7 @@ the container and accepts no other, so those versions are the only ones the outp
 is installed here. The extensions GuPPy adds on the way out are registered into that map first.
 """
 
-import os
 from copy import deepcopy
-from glob import glob
 from importlib import import_module
 from pathlib import Path
 
@@ -67,9 +65,10 @@ def _register_namespace(*, type_map: TypeMap, namespace: str) -> None:
     the versions already in the map.
     """
     module = import_module(namespace.replace("-", "_"))
-    specification_directory = os.path.join(os.path.dirname(module.__file__), "spec")
-    (namespace_path,) = glob(os.path.join(specification_directory, "*namespace.yaml"))
-    type_map.load_namespaces(namespace_path)
+    specification_directory = Path(module.__file__).parent / "spec"
+    (namespace_path,) = specification_directory.glob("*namespace.yaml")
+    # hdmf type-checks this argument and rejects a Path.
+    type_map.load_namespaces(str(namespace_path))
 
     installed_type_map = get_type_map()
     for source_file in type_map.namespace_catalog.get_namespace(namespace).get_source_files():

--- a/src/guppy/utils/nwb_metadata.py
+++ b/src/guppy/utils/nwb_metadata.py
@@ -651,13 +651,13 @@ def validate_metadata_dict(
 # ----------------------------------------------------------------------------------------------------------------------
 def load_yaml(path: str | Path) -> dict:
     """Load a YAML file into a dict."""
-    with open(path) as yaml_file:
+    with Path(path).open() as yaml_file:
         return yaml.safe_load(yaml_file) or {}
 
 
 def dump_yaml(*, metadata: dict, path: str | Path) -> None:
     """Write ``metadata`` to ``path`` as human-editable YAML (insertion order preserved)."""
-    with open(path, "w") as yaml_file:
+    with Path(path).open("w") as yaml_file:
         yaml.dump(metadata, yaml_file, Dumper=_RobustDumper, sort_keys=False, default_flow_style=False)
 
 

--- a/src/guppy/utils/validation.py
+++ b/src/guppy/utils/validation.py
@@ -30,10 +30,9 @@ Conventions
   the user the valid range or fix. See PR #283 for the established template.
 """
 
-import glob
 import logging
-import os
 from collections.abc import Sequence
+from pathlib import Path
 
 import numpy as np
 
@@ -347,7 +346,7 @@ def validate_artifact_coords_present(*, run_folders: Sequence[str]) -> None:
         If any run folder has no ``coordsForPreProcessing_<recording_site>.npy`` file.
     """
     for run_folder in run_folders:
-        if not glob.glob(os.path.join(run_folder, "coordsForPreProcessing_*.npy")):
+        if not any(Path(run_folder).glob("coordsForPreProcessing_*.npy")):
             message = (
                 f"No artifact windows have been selected for '{run_folder}'. Run Select Artifact Windows "
                 "and save at least one window before running Remove Artifacts."
@@ -374,7 +373,7 @@ def validate_preprocessing_outputs_present(
         If any run folder is missing its ``cntrl_sig_fit_<recording_site>.hdf5`` files.
     """
     for run_folder in run_folders:
-        if not glob.glob(os.path.join(run_folder, "cntrl_sig_fit_*.hdf5")):
+        if not any(Path(run_folder).glob("cntrl_sig_fit_*.hdf5")):
             message = f"No preprocessing outputs found in '{run_folder}'. Run Step 3 (Preprocess) before {action}."
             logger.error(message)
             raise ValueError(message)
@@ -402,7 +401,7 @@ def validate_group_member_run_folders(*, member_run_folders: Sequence[str]) -> N
         logger.error(message)
         raise ValueError(message)
 
-    not_output_directories = [path for path in member_run_folders if _RUN_NAME_MARKER not in os.path.basename(path)]
+    not_output_directories = [path for path in member_run_folders if _RUN_NAME_MARKER not in Path(path).name]
     if not_output_directories:
         message = (
             f"Group members must be output directories, but these are not: {not_output_directories!r}. "
@@ -412,13 +411,13 @@ def validate_group_member_run_folders(*, member_run_folders: Sequence[str]) -> N
         logger.error(message)
         raise ValueError(message)
 
-    missing = [path for path in member_run_folders if not os.path.isdir(path)]
+    missing = [path for path in member_run_folders if not Path(path).is_dir()]
     if missing:
         message = f"Group member run folders do not exist: {missing!r}. Re-select the group's members."
         logger.error(message)
         raise ValueError(message)
 
-    missing_stores = [path for path in member_run_folders if not os.path.exists(os.path.join(path, "storesList.csv"))]
+    missing_stores = [path for path in member_run_folders if not (Path(path) / "storesList.csv").exists()]
     if missing_stores:
         message = (
             f"Group member run folders are missing storesList.csv: {missing_stores!r}. "
@@ -454,13 +453,13 @@ def validate_group_definitions(*, group_folders: Sequence[str]) -> None:
         logger.error(message)
         raise ValueError(message)
 
-    missing = [path for path in group_folders if not os.path.isdir(path)]
+    missing = [path for path in group_folders if not Path(path).is_dir()]
     if missing:
         message = f"Group output directories do not exist: {missing!r}. Re-create them with the Label Groups step."
         logger.error(message)
         raise ValueError(message)
 
-    undefined = [path for path in group_folders if not os.path.exists(os.path.join(path, GROUP_MEMBERS_FILENAME))]
+    undefined = [path for path in group_folders if not (Path(path) / GROUP_MEMBERS_FILENAME).exists()]
     if undefined:
         message = (
             f"Group output directories hold no {GROUP_MEMBERS_FILENAME}: {undefined!r}. "

--- a/tests/unit/analysis/test_psth_average.py
+++ b/tests/unit/analysis/test_psth_average.py
@@ -7,7 +7,10 @@ from guppy.analysis.psth_average import (
     psth_shape_check,
     read_Df_area_peak,
 )
-from guppy.analysis.psth_utils import create_Df_for_psth
+from guppy.analysis.psth_utils import (
+    create_Df_for_cross_correlation,
+    create_Df_for_psth,
+)
 
 
 def test_psth_shape_check_all_same_length_returns_unchanged():
@@ -174,6 +177,104 @@ def test_average_psth_for_group_reports_false_when_no_member_has_the_event(tmp_p
 
     assert wrote_psth is False
     assert not (group_folder / "event_never_recorded_dms_z_score_dms.h5").exists()
+
+
+def test_average_psth_for_group_dff_mode_averages_the_dff_files(tmp_path, group_folder):
+    session1 = tmp_path / "session1"
+    session2 = tmp_path / "session2"
+    session1.mkdir()
+    session2.mkdir()
+
+    # A z-score trace is present but must be ignored in dff mode.
+    for session in (session1, session2):
+        (session / "z_score_dms.hdf5").touch()
+        (session / "dff_dms.hdf5").touch()
+
+    columns = ["trial1", "timestamps"]
+    create_Df_for_psth(
+        str(session1), "event_lever_dms", "dff_dms", np.array([[1.0, 2.0, 3.0], [0.0, 1.0, 2.0]]), columns=columns
+    )
+    create_Df_for_psth(
+        str(session2), "event_lever_dms", "dff_dms", np.array([[3.0, 4.0, 5.0], [0.0, 1.0, 2.0]]), columns=columns
+    )
+
+    wrote_psth = average_psth_for_group(
+        member_run_folders=[str(session1), str(session2)],
+        event="event_lever",
+        group_folder=str(group_folder),
+        inputParameters={"selectForComputePsth": "dff"},
+    )
+
+    assert wrote_psth is True
+    assert not (group_folder / "event_lever_dms_z_score_dms.h5").exists()
+    result = pd.read_hdf(group_folder / "event_lever_dms_dff_dms.h5", key="df", mode="r")
+    np.testing.assert_allclose(result["mean"].values, np.array([2.0, 3.0, 4.0]), atol=1e-6)
+
+
+def test_average_psth_for_group_both_modes_averages_z_score_and_dff(tmp_path, group_folder):
+    session = tmp_path / "session1"
+    session.mkdir()
+    (session / "z_score_dms.hdf5").touch()
+    (session / "dff_dms.hdf5").touch()
+
+    columns = ["trial1", "timestamps"]
+    create_Df_for_psth(
+        str(session), "event_lever_dms", "z_score_dms", np.array([[1.0, 2.0, 3.0], [0.0, 1.0, 2.0]]), columns=columns
+    )
+    create_Df_for_psth(
+        str(session), "event_lever_dms", "dff_dms", np.array([[7.0, 8.0, 9.0], [0.0, 1.0, 2.0]]), columns=columns
+    )
+
+    wrote_psth = average_psth_for_group(
+        member_run_folders=[str(session)],
+        event="event_lever",
+        group_folder=str(group_folder),
+        inputParameters={"selectForComputePsth": "both"},
+    )
+
+    assert wrote_psth is True
+    z_score_result = pd.read_hdf(group_folder / "event_lever_dms_z_score_dms.h5", key="df", mode="r")
+    dff_result = pd.read_hdf(group_folder / "event_lever_dms_dff_dms.h5", key="df", mode="r")
+    np.testing.assert_allclose(z_score_result["mean"].values, np.array([1.0, 2.0, 3.0]), atol=1e-6)
+    np.testing.assert_allclose(dff_result["mean"].values, np.array([7.0, 8.0, 9.0]), atol=1e-6)
+
+
+def test_average_psth_for_group_averages_the_members_cross_correlations(tmp_path, group_folder):
+    """Two recording sites give one correlated pair, whose per-member results are averaged."""
+    session1 = tmp_path / "session1"
+    session2 = tmp_path / "session2"
+    session1.mkdir()
+    session2.mkdir()
+
+    for session, first_lag_values in ((session1, [1.0, 2.0, 3.0]), (session2, [3.0, 4.0, 5.0])):
+        (session / "z_score_dms.hdf5").touch()
+        (session / "z_score_nac.hdf5").touch()
+        correlation_folder = session / "cross_correlation_output"
+        correlation_folder.mkdir()
+        create_Df_for_cross_correlation(
+            str(correlation_folder),
+            "corr_event_lever",
+            "z_score_dms_nac",
+            np.array([first_lag_values, [0.0, 1.0, 2.0]]),
+            columns=["trial1", "timestamps"],
+        )
+
+    average_psth_for_group(
+        member_run_folders=[str(session1), str(session2)],
+        event="event_lever",
+        group_folder=str(group_folder),
+        inputParameters={"selectForComputePsth": "z_score"},
+    )
+
+    averaged = pd.read_hdf(
+        group_folder / "cross_correlation_output" / "corr_event_lever_z_score_dms_nac.h5", key="df", mode="r"
+    )
+    np.testing.assert_allclose(averaged["session1"].values, np.array([1.0, 2.0, 3.0]), atol=1e-6)
+    np.testing.assert_allclose(averaged["session2"].values, np.array([3.0, 4.0, 5.0]), atol=1e-6)
+    # Across-member mean, and the SEM over the 2 members: std (ddof=0) = 1.0 -> 1.0 / sqrt(2)
+    np.testing.assert_allclose(averaged["mean"].values, np.array([2.0, 3.0, 4.0]), atol=1e-6)
+    np.testing.assert_allclose(averaged["err"].values, np.full(3, 0.7071068), atol=1e-6)
+    np.testing.assert_allclose(averaged["timestamps"].values, np.array([0.0, 1.0, 2.0]))
 
 
 def test_average_psth_for_group_handles_non_overlapping_stores_without_indexerror(tmp_path, group_folder):

--- a/tests/unit/analysis/test_psth_utils.py
+++ b/tests/unit/analysis/test_psth_utils.py
@@ -40,6 +40,19 @@ def test_create_df_for_psth_timestamps_column_excluded_from_mean(tmp_path):
     np.testing.assert_allclose(df["mean"].iloc[0], 10.0, atol=1e-4)
 
 
+def test_create_df_for_psth_without_a_name_writes_the_event_only_filename(tmp_path):
+    psth = np.array([[1.0, 2.0, 3.0], [3.0, 4.0, 5.0], [0.0, 1.0, 2.0]])
+    columns = ["trial1", "trial2", "timestamps"]
+
+    create_Df_for_psth(str(tmp_path), "event_lever", "", psth, columns=columns)
+
+    assert (tmp_path / "event_lever.h5").exists()
+    assert not (tmp_path / "event_lever_.h5").exists()
+    df = pd.read_hdf(tmp_path / "event_lever.h5", key="df")
+    # mean over the two trial columns at each timepoint: [(1+3)/2, (2+4)/2, (3+5)/2]
+    np.testing.assert_allclose(df["mean"].values, np.array([2.0, 3.0, 4.0]), atol=1e-4)
+
+
 # ── create_Df_for_cross_correlation ───────────────────────────────────────────
 
 
@@ -53,6 +66,19 @@ def test_create_df_for_cross_correlation_creates_hdf5_file_with_mean_column(tmp_
     assert (tmp_path / "corr_lever_z_score_dms_nac.h5").exists()
     df = pd.read_hdf(tmp_path / "corr_lever_z_score_dms_nac.h5", key="df")
     assert "mean" in df.columns
+    # mean at timepoint 0: mean([0.1, 0.2]) = 0.15
+    np.testing.assert_allclose(df["mean"].iloc[0], 0.15, atol=1e-4)
+
+
+def test_create_df_for_cross_correlation_without_a_name_writes_the_event_only_filename(tmp_path):
+    psth = np.array([[0.1, 0.3, 0.5], [0.2, 0.4, 0.6], [0.0, 1.0, 2.0]])
+    columns = ["sess1", "sess2", "timestamps"]
+
+    create_Df_for_cross_correlation(str(tmp_path), "corr_lever", "", psth, columns=columns)
+
+    assert (tmp_path / "corr_lever.h5").exists()
+    assert not (tmp_path / "corr_lever_.h5").exists()
+    df = pd.read_hdf(tmp_path / "corr_lever.h5", key="df")
     # mean at timepoint 0: mean([0.1, 0.2]) = 0.15
     np.testing.assert_allclose(df["mean"].iloc[0], 0.15, atol=1e-4)
 
@@ -93,6 +119,27 @@ def test_get_corr_combinations_one_signal_returns_single_name(tmp_path):
     corr_info, _ = getCorrCombinations(str(tmp_path), input_parameters)
 
     assert corr_info == ["dms"]
+
+
+def test_get_corr_combinations_dff_mode_reads_the_dff_files(tmp_path):
+    (tmp_path / "z_score_dms.hdf5").touch()
+    (tmp_path / "dff_dms.hdf5").touch()
+    (tmp_path / "dff_nac.hdf5").touch()
+
+    corr_info, signal_type = getCorrCombinations(str(tmp_path), {"selectForComputePsth": "dff"})
+
+    assert set(corr_info) == {"dms", "nac"}
+    assert signal_type == ["dff"]
+
+
+def test_get_corr_combinations_both_modes_reads_z_score_and_dff(tmp_path):
+    (tmp_path / "z_score_dms.hdf5").touch()
+    (tmp_path / "dff_nac.hdf5").touch()
+
+    corr_info, signal_type = getCorrCombinations(str(tmp_path), {"selectForComputePsth": "both"})
+
+    assert set(corr_info) == {"dms", "nac"}
+    assert signal_type == ["dff", "z_score"]
 
 
 # ── match_trials_by_timestamp ─────────────────────────────────────────────────

--- a/tests/unit/analysis/test_transients_average.py
+++ b/tests/unit/analysis/test_transients_average.py
@@ -61,6 +61,100 @@ def test_average_transients_for_group_stacks_the_members_freq_and_amp(tmp_path, 
     np.testing.assert_allclose(df["amplitude"].values, np.array([1.5, 2.5]))
 
 
+def test_average_transients_for_group_dff_mode_reads_the_dff_results(tmp_path, group_folder):
+    session1 = tmp_path / "session1"
+    session2 = tmp_path / "session2"
+    session1.mkdir()
+    session2.mkdir()
+
+    # A z-score trace is present but must be ignored in dff mode.
+    for session, values in ((session1, [[2.0, 1.5]]), (session2, [[3.0, 2.5]])):
+        (session / "z_score_dms.hdf5").touch()
+        (session / "dff_dms.hdf5").touch()
+        write_freq_and_amp_to_hdf5(
+            str(session),
+            np.array(values),
+            "dff_dms",
+            index=[session.name],
+            columns=["freq (events/min)", "amplitude"],
+        )
+
+    average_transients_for_group(
+        member_run_folders=[str(session1), str(session2)],
+        group_folder=str(group_folder),
+        inputParameters={"selectForTransientsComputation": "dff"},
+    )
+
+    assert not (group_folder / "freqAndAmp_z_score_dms.h5").exists()
+    df = read_freq_and_amp_from_hdf5(str(group_folder), "dff_dms")
+    np.testing.assert_allclose(df["freq (events/min)"].values, np.array([2.0, 3.0]))
+    np.testing.assert_allclose(df["amplitude"].values, np.array([1.5, 2.5]))
+
+
+def test_average_transients_for_group_both_modes_reads_z_score_and_dff(tmp_path, group_folder):
+    session = tmp_path / "session1"
+    session.mkdir()
+    (session / "z_score_dms.hdf5").touch()
+    (session / "dff_dms.hdf5").touch()
+
+    write_freq_and_amp_to_hdf5(
+        str(session),
+        np.array([[2.0, 1.5]]),
+        "z_score_dms",
+        index=["session1"],
+        columns=["freq (events/min)", "amplitude"],
+    )
+    write_freq_and_amp_to_hdf5(
+        str(session),
+        np.array([[8.0, 6.5]]),
+        "dff_dms",
+        index=["session1"],
+        columns=["freq (events/min)", "amplitude"],
+    )
+
+    average_transients_for_group(
+        member_run_folders=[str(session)],
+        group_folder=str(group_folder),
+        inputParameters={"selectForTransientsComputation": "both"},
+    )
+
+    z_score_df = read_freq_and_amp_from_hdf5(str(group_folder), "z_score_dms")
+    dff_df = read_freq_and_amp_from_hdf5(str(group_folder), "dff_dms")
+    np.testing.assert_allclose(z_score_df["freq (events/min)"].values, np.array([2.0]))
+    np.testing.assert_allclose(dff_df["freq (events/min)"].values, np.array([8.0]))
+
+
+def test_average_transients_for_group_skips_a_member_with_no_freq_and_amp_results(tmp_path, group_folder):
+    """A member whose transients were never computed is left out rather than failing the group."""
+    session1 = tmp_path / "session1"
+    session2 = tmp_path / "session2"
+    session1.mkdir()
+    session2.mkdir()
+
+    (session1 / "z_score_dms.hdf5").touch()
+    (session2 / "z_score_dms.hdf5").touch()
+
+    # Only session1 has freqAndAmp results; session2's were never written.
+    write_freq_and_amp_to_hdf5(
+        str(session1),
+        np.array([[2.0, 1.5]]),
+        "z_score_dms",
+        index=["session1"],
+        columns=["freq (events/min)", "amplitude"],
+    )
+
+    average_transients_for_group(
+        member_run_folders=[str(session1), str(session2)],
+        group_folder=str(group_folder),
+        inputParameters={"selectForTransientsComputation": "z_score"},
+    )
+
+    df = read_freq_and_amp_from_hdf5(str(group_folder), "z_score_dms")
+    assert list(df.index) == ["session1"]
+    np.testing.assert_allclose(df["freq (events/min)"].values, np.array([2.0]))
+    np.testing.assert_allclose(df["amplitude"].values, np.array([1.5]))
+
+
 def test_average_transients_for_group_handles_non_overlapping_stores_without_indexerror(tmp_path, group_folder):
     """Non-overlapping store_ids across sessions must not cause an IndexError.
 

--- a/tests/unit/utils/test_custom_events.py
+++ b/tests/unit/utils/test_custom_events.py
@@ -47,7 +47,7 @@ class TestIsSorted:
 class TestWriteCustomEventCsv:
     def test_writes_header_and_rows(self, tmp_path):
         path = write_custom_event_csv(name="movement_onset", timestamps=[0.5, 1.5, 2.5], folder_path=str(tmp_path))
-        assert path == os.path.join(str(tmp_path), "movement_onset.csv")
+        assert path == tmp_path / "movement_onset.csv"
         df = pd.read_csv(path)
         assert list(df.columns) == ["timestamps"]
         assert df["timestamps"].tolist() == [0.5, 1.5, 2.5]


### PR DESCRIPTION
<!-- summary line goes here -->

<details>
<summary>Details (AI-generated)</summary>

Second of the #478 stack. Stacked on #483 → #482 → #481 → #480 — review the last commit.

Finishes `src/guppy/analysis/` (`control_channel.py`, `psth_average.py`, `psth_utils.py`, `transients_average.py`) and the leaf modules of `src/guppy/utils/` (`custom_events.py`, `nwb_io.py`, `nwb_metadata.py`, `validation.py`), and deletes their entries from the `PTH` per-file-ignore list.

`utils/utils.py` is deliberately left behind. Its run-folder helpers return path *strings* that flow into `inputParameters` and out to `GuPPyParamtersUsed.json`, and their callers are all in `orchestration/`; converting them in isolation would just move the `str(...)` wrapping around. It goes with the orchestration PR.

Two things worth a look:

- `write_custom_event_csv` now returns a `Path`.
- `nwb_io._register_namespace` builds its namespace path with `Path` but passes `str(namespace_path)` to `hdmf`, which type-checks that argument and raises `TypeError: incorrect type for 'namespace_path' (got 'PosixPath', expected 'str')`. The integration suite caught this; the `str()` is annotated at the call.

Unit suite (2248) and integration suite (189) both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>
