### PR TITLE
Migrate the extractors to pathlib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed the README's documentation links, which all carried an `/en/latest/` path prefix that 404s on the single-version Read the Docs project. [PR #469](https://github.com/LernerLab/GuPPy/pull/469)
 
 ## Improvements
+- The TDT, Doric, NPM and CSV extractors and the acquisition-format detector now build paths with `pathlib.Path`. [PR #485](https://github.com/LernerLab/GuPPy/pull/485)
 - The rest of the analysis layer and GuPPy's validation, custom-event and NWB helpers now build paths with `pathlib.Path`. [PR #484](https://github.com/LernerLab/GuPPy/pull/484)
 - GuPPy's core HDF5 and results I/O now builds paths with `pathlib.Path` rather than `os.path`, and `ruff`'s `PTH` rules are enabled with the not-yet-converted modules listed explicitly so the migration is tracked rather than open-ended. [PR #483](https://github.com/LernerLab/GuPPy/pull/483)
 - Every `zip()` over parallel sequences now declares `strict=`, so a pair that has silently truncated to the shorter operand raises instead. [PR #482](https://github.com/LernerLab/GuPPy/pull/482)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,7 +153,6 @@ fixable = ["ALL"]
 # still uses os.path/glob; each migration PR deletes the entries it converts, so what is
 # left here is the remaining work rather than a permanent exemption.
 "src/guppy/utils/utils.py" = ["PTH"]
-"src/guppy/extractors/*" = ["PTH"]
 "src/guppy/frontend/*" = ["PTH"]
 "src/guppy/orchestration/*" = ["PTH"]
 "src/guppy/testing/*" = ["PTH"]

--- a/src/guppy/extractors/csv_recording_extractor.py
+++ b/src/guppy/extractors/csv_recording_extractor.py
@@ -1,6 +1,4 @@
-import glob
 import logging
-import os
 import shutil
 from pathlib import Path
 from typing import Any
@@ -48,7 +46,7 @@ class CsvRecordingExtractor(BaseRecordingExtractor):
             Format indicators or file type flags.
         """
         logger.debug("If it exists, importing either NPM or Doric or csv file based on the structure of file")
-        path = sorted(glob.glob(os.path.join(folder_path, "*.csv")))
+        path = sorted(Path(folder_path).glob("*.csv"))
         # Only process files classified as standard CSV (event_csv or data_csv).
         # Skips NPM multi-column files and Doric CSV files when coexisting in the same folder.
         path = [p for p in path if _classify_csv_file(p) == "csv"]
@@ -57,7 +55,7 @@ class CsvRecordingExtractor(BaseRecordingExtractor):
         event_from_filename = []
         flags = []
         for i in range(len(path)):
-            extension = os.path.basename(path[i]).split(".")[-1]
+            extension = path[i].name.split(".")[-1]
             if extension != "csv":
                 raise ValueError(f"Only .csv files are supported by CsvRecordingExtractor; got '{path[i]}'.")
             df = pd.read_csv(path[i], header=None, nrows=2, index_col=False, dtype=str)
@@ -119,7 +117,7 @@ class CsvRecordingExtractor(BaseRecordingExtractor):
 
             flags.append(flag)
             logger.info(flag)
-            name = os.path.basename(path[i]).split(".")[0]
+            name = path[i].name.split(".")[0]
             event_from_filename.append(name)
 
         logger.info("Importing of csv file is done.")
@@ -152,17 +150,17 @@ class CsvRecordingExtractor(BaseRecordingExtractor):
 
     def count_samples(self, *, event: str) -> int:
         """Return the number of data rows in ``<event>.csv`` (excludes header)."""
-        csv_path = os.path.join(self.folder_path, event + ".csv")
-        if not os.path.exists(csv_path):
+        csv_path = Path(self.folder_path) / (event + ".csv")
+        if not csv_path.exists():
             return 0
-        with open(csv_path, "rb") as file:
+        with csv_path.open("rb") as file:
             total_lines = sum(1 for _ in file)
         return max(0, total_lines - 1)
 
     def _read_csv(self, event: str) -> pd.DataFrame:
         logger.debug("Trying to read data for %s from csv file.", event)
-        csv_path = os.path.join(self.folder_path, event + ".csv")
-        if not os.path.exists(csv_path):
+        csv_path = Path(self.folder_path) / (event + ".csv")
+        if not csv_path.exists():
             message = f"No CSV file found for event '{event}' at '{csv_path}'."
             logger.error(message)
             raise FileNotFoundError(message)

--- a/src/guppy/extractors/detect_acquisition_formats.py
+++ b/src/guppy/extractors/detect_acquisition_formats.py
@@ -1,6 +1,5 @@
-import glob
 import logging
-import os
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -8,13 +7,13 @@ import pandas as pd
 logger = logging.getLogger(__name__)
 
 
-def _classify_csv_file(path: str) -> str:
+def _classify_csv_file(path: str | Path) -> str:
     """
     Classify a single CSV file as belonging to one of three modalities.
 
     Parameters
     ----------
-    path : str
+    path : str or Path
         Absolute path to a CSV file.
 
     Returns
@@ -84,13 +83,13 @@ def _is_float(value: object) -> bool:
         return False
 
 
-def _is_event_csv(path: str) -> bool:
+def _is_event_csv(path: str | Path) -> bool:
     """
     Return True if the CSV file is an event_csv: a single column named 'timestamps'.
 
     Parameters
     ----------
-    path : str
+    path : str or Path
         Absolute path to a CSV file.
 
     Returns
@@ -110,18 +109,19 @@ def _detect(folder_path: str) -> tuple[set[str], bool]:
     formats = set()
 
     # NWB .nwb files provide photometry channels via acquisition series
-    if glob.glob(os.path.join(folder_path, "*.nwb")):
+    session_folder = Path(folder_path)
+    if any(session_folder.glob("*.nwb")):
         formats.add("nwb")
 
     # TDT .tsq files provide both photometry stores and TTL event stores
-    if glob.glob(os.path.join(folder_path, "*.tsq")):
+    if any(session_folder.glob("*.tsq")):
         formats.add("tdt")
 
     # Doric .doric files provide both photometry channels and digital TTL channels
-    if glob.glob(os.path.join(folder_path, "*.doric")):
+    if any(session_folder.glob("*.doric")):
         formats.add("doric")
 
-    csv_paths = glob.glob(os.path.join(folder_path, "*.csv"))
+    csv_paths = list(session_folder.glob("*.csv"))
     event_csv_by_path = {csv_path: _is_event_csv(csv_path) for csv_path in csv_paths}
 
     # Multi-column CSV files can be NPM, Doric CSV exports, or 3-column data_csv files.

--- a/src/guppy/extractors/doric_recording_extractor.py
+++ b/src/guppy/extractors/doric_recording_extractor.py
@@ -1,6 +1,4 @@
-import glob
 import logging
-import os
 import re
 import shutil
 import warnings
@@ -57,18 +55,17 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
             List of format flags (e.g., 'doric_csv', 'doric_doric')
         """
         logger.debug("Discovering Doric events from file headers")
-        path = sorted(glob.glob(os.path.join(folder_path, "*.csv"))) + sorted(
-            glob.glob(os.path.join(folder_path, "*.doric"))
-        )
+        session_folder = Path(folder_path)
+        path = sorted(session_folder.glob("*.csv")) + sorted(session_folder.glob("*.doric"))
         # Exclude event CSV files (single 'timestamps' column) — those belong to CsvRecordingExtractor
-        path = [data_path for data_path in path if not (data_path.endswith(".csv") and _is_event_csv(data_path))]
+        path = [data_path for data_path in path if not (data_path.suffix == ".csv" and _is_event_csv(data_path))]
         path = sorted(list(set(path)))
         flag = "None"
         event_from_filename = []
         flags = []
 
         for i in range(len(path)):
-            extension = os.path.basename(path[i]).split(".")[-1]
+            extension = path[i].name.split(".")[-1]
             if extension == "doric":
                 key_names = cls._read_doric_file(path[i])
                 event_from_filename.extend(key_names)
@@ -246,14 +243,14 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
         """Return the number of samples for ``event`` using only metadata reads."""
         flag = self._check_doric()
         if flag == "doric_csv":
-            csv_paths = glob.glob(os.path.join(self.folder_path, "*.csv"))
+            csv_paths = list(Path(self.folder_path).glob("*.csv"))
             if not csv_paths:
                 return 0
-            with open(csv_paths[0], "rb") as file:
+            with csv_paths[0].open("rb") as file:
                 total_lines = sum(1 for _ in file)
             return max(0, total_lines - 2)
         if flag == "doric_doric":
-            doric_paths = glob.glob(os.path.join(self.folder_path, "*.doric"))
+            doric_paths = list(Path(self.folder_path).glob("*.doric"))
             if not doric_paths:
                 return 0
             with h5py.File(doric_paths[0], "r") as doric_file:
@@ -287,11 +284,12 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
 
     def _check_doric(self) -> str | int:
         logger.debug("Checking if doric file exists")
-        path = glob.glob(os.path.join(self.folder_path, "*.csv")) + glob.glob(os.path.join(self.folder_path, "*.doric"))
+        session_folder = Path(self.folder_path)
+        path = list(session_folder.glob("*.csv")) + list(session_folder.glob("*.doric"))
 
         flags = []
         for i in range(len(path)):
-            extension = os.path.basename(path[i]).split(".")[-1]
+            extension = path[i].name.split(".")[-1]
             if extension == "csv":
                 with warnings.catch_warnings():
                     warnings.simplefilter("error")
@@ -308,10 +306,7 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
                 pass
 
         if len(flags) > 1:
-            doric_paths = sorted(
-                glob.glob(os.path.join(self.folder_path, "*.csv"))
-                + glob.glob(os.path.join(self.folder_path, "*.doric"))
-            )
+            doric_paths = sorted(list(session_folder.glob("*.csv")) + list(session_folder.glob("*.doric")))
             message = (
                 f"Multiple Doric data files found in '{self.folder_path}': {doric_paths}. "
                 "Each session folder must contain exactly one Doric file."
@@ -325,7 +320,7 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
         return flags[0]
 
     def _read_doric_csv(self, events: list[str]) -> list[dict[str, object]]:
-        path = glob.glob(os.path.join(self.folder_path, "*.csv"))
+        path = list(Path(self.folder_path).glob("*.csv"))
         if len(path) > 1:
             message = (
                 f"Multiple Doric .csv files found in '{self.folder_path}': {sorted(path)}. "
@@ -372,7 +367,7 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
         return output_dicts
 
     def _read_doric_doric(self, events: list[str]) -> list[dict[str, object]]:
-        path = glob.glob(os.path.join(self.folder_path, "*.doric"))
+        path = list(Path(self.folder_path).glob("*.doric"))
         if len(path) > 1:
             message = (
                 f"Multiple Doric .doric files found in '{self.folder_path}': {sorted(path)}. "
@@ -578,7 +573,7 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
             self._stub_doric_csv(folder_path=folder_path, duration_in_seconds=duration_in_seconds)
 
     def _stub_doric_hdf5(self, *, folder_path: Path | str, duration_in_seconds: float) -> None:
-        doric_paths = glob.glob(os.path.join(folder_path, "*.doric"))
+        doric_paths = list(Path(folder_path).glob("*.doric"))
         doric_path = doric_paths[0]
 
         with h5py.File(doric_path, "r") as source_file:
@@ -592,9 +587,9 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
                 )
 
         # Replace after closing source_file so Windows does not raise PermissionError on open files.
-        os.replace(temporary_path, doric_path)
+        temporary_path.replace(doric_path)
 
-    def _stub_doric_hdf5_v1(self, *, source_file: h5py.File, doric_path: str, duration_in_seconds: float) -> str:
+    def _stub_doric_hdf5_v1(self, *, source_file: h5py.File, doric_path: Path, duration_in_seconds: float) -> Path:
         timestamps = np.array(source_file["Traces"]["Console"]["Time(s)"]["Console_time(s)"])
         cutoff_timestamp = timestamps[0] + duration_in_seconds
         cutoff_index = int(np.searchsorted(timestamps, cutoff_timestamp, side="right"))
@@ -607,7 +602,7 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
         for key in channel_keys:
             channel_data[key] = np.array(source_file["Traces"]["Console"][key][key])
 
-        temporary_path = doric_path + ".tmp"
+        temporary_path = doric_path.with_name(doric_path.name + ".tmp")
         with h5py.File(temporary_path, "w") as destination_file:
             console = destination_file.require_group("Traces/Console")
             time_group = console.require_group("Time(s)")
@@ -618,8 +613,8 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
 
         return temporary_path
 
-    def _stub_doric_hdf5_v6(self, *, source_file: h5py.File, doric_path: str, duration_in_seconds: float) -> str:
-        temporary_path = doric_path + ".tmp"
+    def _stub_doric_hdf5_v6(self, *, source_file: h5py.File, doric_path: Path, duration_in_seconds: float) -> Path:
+        temporary_path = doric_path.with_name(doric_path.name + ".tmp")
         with h5py.File(temporary_path, "w") as destination_file:
             if "Configurations" in source_file:
                 source_file.copy("Configurations", destination_file)
@@ -651,7 +646,7 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
                     destination_group.create_dataset(key, data=item[:])
 
     def _stub_doric_csv(self, *, folder_path: Path | str, duration_in_seconds: float) -> None:
-        csv_paths = glob.glob(os.path.join(folder_path, "*.csv"))
+        csv_paths = list(Path(folder_path).glob("*.csv"))
         csv_path = csv_paths[0]
 
         # Row 0 is the channel descriptor row; row 1 is the column name row (header=1 skips both)
@@ -662,7 +657,7 @@ class DoricRecordingExtractor(BaseRecordingExtractor):
         cutoff_timestamp = dataframe["Time(s)"].iloc[0] + duration_in_seconds
         dataframe = dataframe[dataframe["Time(s)"] <= cutoff_timestamp]
 
-        with open(csv_path, "w") as file:
+        with csv_path.open("w") as file:
             header_rows.to_csv(file, index=False, header=False)
             dataframe.to_csv(file, index=False, header=False)
 

--- a/src/guppy/extractors/npm_recording_extractor.py
+++ b/src/guppy/extractors/npm_recording_extractor.py
@@ -1,6 +1,4 @@
-import glob
 import logging
-import os
 import shutil
 from pathlib import Path
 from typing import Any
@@ -115,7 +113,7 @@ class NpmRecordingExtractor(CsvRecordingExtractor):
         return list(streams.keys()), flags
 
     @staticmethod
-    def _list_npm_files(folder_path: str) -> list[str]:
+    def _list_npm_files(folder_path: str | Path) -> list[Path]:
         """List the raw NPM source files in a session folder, in processing order.
 
         Excludes the derived per-channel/per-event filenames and the
@@ -129,30 +127,29 @@ class NpmRecordingExtractor(CsvRecordingExtractor):
 
         Returns
         -------
-        list of str
+        list of Path
             Sorted paths of the raw NPM files. The index of a path in this list
             is the ``file{i}_`` prefix its channels are named with, and the
             index its ``npm_split_events`` entry is read from.
         """
-        path = sorted(glob.glob(os.path.join(folder_path, "*.csv"))) + sorted(
-            glob.glob(os.path.join(folder_path, "*.doric"))
-        )
-        path_chev = glob.glob(os.path.join(folder_path, "*chev*"))
-        path_chod = glob.glob(os.path.join(folder_path, "*chod*"))
-        path_chpr = glob.glob(os.path.join(folder_path, "*chpr*"))
-        path_event = glob.glob(os.path.join(folder_path, "event*"))
+        session_folder = Path(folder_path)
+        path = sorted(session_folder.glob("*.csv")) + sorted(session_folder.glob("*.doric"))
+        path_chev = list(session_folder.glob("*chev*"))
+        path_chod = list(session_folder.glob("*chod*"))
+        path_chpr = list(session_folder.glob("*chpr*"))
+        path_event = list(session_folder.glob("event*"))
         path_chev_chod_event = path_chev + path_chod + path_event + path_chpr
 
-        path = sorted(list(set(path) - set(path_chev_chod_event)))
-        return [csv_path for csv_path in path if not (csv_path.endswith(".csv") and _is_event_csv(csv_path))]
+        path = sorted(set(path) - set(path_chev_chod_event))
+        return [csv_path for csv_path in path if not (csv_path.suffix == ".csv" and _is_event_csv(csv_path))]
 
     @classmethod
-    def _classify_npm_file(cls, path: str) -> tuple[str, pd.DataFrame, bool]:
+    def _classify_npm_file(cls, path: str | Path) -> tuple[str, pd.DataFrame, bool]:
         """Read one raw NPM file and determine which NPM layout it uses.
 
         Parameters
         ----------
-        path : str
+        path : str or Path
             Path to a raw NPM file, as returned by :meth:`_list_npm_files`.
 
         Returns
@@ -168,7 +165,7 @@ class NpmRecordingExtractor(CsvRecordingExtractor):
         columns_are_strings : bool
             Whether the file carries a text header row.
         """
-        extension = os.path.basename(path).split(".")[-1]
+        extension = Path(path).name.split(".")[-1]
         if extension == "doric":
             raise ValueError(f"Doric files are not supported by NpmRecordingExtractor; got '{path}'.")
         df = pd.read_csv(path, header=None, nrows=2, index_col=False, dtype=str)

--- a/src/guppy/extractors/tdt_recording_extractor.py
+++ b/src/guppy/extractors/tdt_recording_extractor.py
@@ -1,4 +1,3 @@
-import glob
 import logging
 import math
 import os
@@ -89,7 +88,7 @@ class TdtRecordingExtractor(BaseRecordingExtractor):
         formats = (int32, int32, "S4", uint16, uint16, float64, int64, float64, int32, float32)
         offsets = 0, 4, 8, 12, 14, 16, 24, 24, 32, 36
         tsq_dtype = np.dtype({"names": names, "formats": formats, "offsets": offsets}, align=True)
-        path = glob.glob(os.path.join(folder_path, "*.tsq"))
+        path = list(Path(folder_path).glob("*.tsq"))
         if len(path) > 1:
             message = (
                 f"Multiple .tsq files found in '{folder_path}': {sorted(path)}. "
@@ -150,7 +149,7 @@ class TdtRecordingExtractor(BaseRecordingExtractor):
         """
         block_bytes = samples_per_block * np.dtype(dtype).itemsize
         data = np.zeros((len(block_offsets), samples_per_block))
-        with open(tev_file_path, "rb") as tev_file:
+        with Path(tev_file_path).open("rb") as tev_file:
             block_index = 0
             while block_index < len(block_offsets):
                 chunk_start = int(block_offsets[block_index])
@@ -178,7 +177,7 @@ class TdtRecordingExtractor(BaseRecordingExtractor):
         folder_path = self.folder_path
 
         logger.debug("Reading data for event %s ...", event)
-        tevfilepath = glob.glob(os.path.join(folder_path, "*.tev"))
+        tevfilepath = list(Path(folder_path).glob("*.tev"))
         if len(tevfilepath) > 1:
             raise ValueError(
                 f"Multiple .tev files found in '{folder_path}': {sorted(tevfilepath)}. "
@@ -466,10 +465,11 @@ class TdtRecordingExtractor(BaseRecordingExtractor):
             Mapping from original file-pointer positions to their new positions in the stubbed TEV.
         """
         stream_names_bytes = {name.encode() for name in stream_name_to_num_segments}
-        with open(tev_file_path, "r+b") as file:
+        with Path(tev_file_path).open("r+b") as file:
             content = file.read()
-        if os.path.exists(stubbed_tev_file_path):
-            os.remove(stubbed_tev_file_path)
+        stubbed_tev_file_path = Path(stubbed_tev_file_path)
+        if stubbed_tev_file_path.exists():
+            stubbed_tev_file_path.unlink()
 
         all_starts, all_stops, all_stream_names = [], [], []
         for stream_name_bytes in stream_names_bytes:
@@ -493,7 +493,7 @@ class TdtRecordingExtractor(BaseRecordingExtractor):
         original_to_new_fp_loc = {}
         stream_name_to_num_written = {name.encode(): 0 for name in stream_name_to_num_segments}
         for start, stop, stream_name_bytes in zip(all_starts, all_stops, all_stream_names, strict=True):
-            with open(stubbed_tev_file_path, "a+b") as file:
+            with stubbed_tev_file_path.open("a+b") as file:
                 gap = content[previous_stop:start]
                 file.write(gap)
                 write_position += len(gap)
@@ -506,7 +506,7 @@ class TdtRecordingExtractor(BaseRecordingExtractor):
                     write_position += len(segment)
                     stream_name_to_num_written[stream_name_bytes] += 1
             previous_stop = stop
-        with open(stubbed_tev_file_path, "a+b") as file:
+        with stubbed_tev_file_path.open("a+b") as file:
             file.write(content[previous_stop:])
         return original_to_new_fp_loc
 
@@ -650,15 +650,15 @@ class TdtRecordingExtractor(BaseRecordingExtractor):
             shutil.rmtree(folder_path)
         shutil.copytree(source_folder_path, folder_path)
 
-        tev_file_path = glob.glob(os.path.join(self.folder_path, "*.tev"))[0]
-        tsq_file_path = glob.glob(os.path.join(self.folder_path, "*.tsq"))[0]
+        tev_file_path = next(source_folder_path.glob("*.tev"))
+        tsq_file_path = next(source_folder_path.glob("*.tsq"))
 
-        stubbed_tev_file_path = folder_path / Path(tev_file_path).name
-        stubbed_tsq_file_path = folder_path / Path(tsq_file_path).name
+        stubbed_tev_file_path = folder_path / tev_file_path.name
+        stubbed_tsq_file_path = folder_path / tsq_file_path.name
 
         # Remove originals from stub folder so we can write the truncated replacements
-        os.remove(stubbed_tev_file_path)
-        os.remove(stubbed_tsq_file_path)
+        stubbed_tev_file_path.unlink()
+        stubbed_tsq_file_path.unlink()
 
         original_to_new_fp_loc = self._stub_tev_file(
             tev_file_path=tev_file_path,

--- a/tests/unit/extractors/test_csv_recording_extractor.py
+++ b/tests/unit/extractors/test_csv_recording_extractor.py
@@ -1,6 +1,7 @@
 """Contract tests for CsvRecordingExtractor."""
 
 import os
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -91,13 +92,10 @@ def test_read_csv_missing_event_raises_file_not_found(tmp_path):
 
 
 def test_discover_raises_for_non_csv_extension(monkeypatch, tmp_path):
-    # Bypass the *.csv glob filter by monkeypatching glob to return a .txt path
+    # Bypass the *.csv glob filter by monkeypatching Path.glob to return a .txt path
     fake_path = tmp_path / "fake.txt"
     fake_path.write_text("timestamps\n0\n")
-    monkeypatch.setattr(
-        "guppy.extractors.csv_recording_extractor.glob.glob",
-        lambda pattern: [str(fake_path)],
-    )
+    monkeypatch.setattr(Path, "glob", lambda self, pattern: [fake_path])
     _force_classify_to_csv(monkeypatch)
     with pytest.raises(ValueError, match="Only .csv files are supported"):
         CsvRecordingExtractor.discover_events_and_flags(str(tmp_path))


### PR DESCRIPTION
<!-- summary line goes here -->

<details>
<summary>Details (AI-generated)</summary>

Third of the #478 stack. Stacked on #484 → #483 → #482 → #481 → #480 — review the last commit.

Converts `src/guppy/extractors/` — all five extractors plus `detect_acquisition_formats.py`, 75 findings — and deletes the `"src/guppy/extractors/*"` entry from the `PTH` ignore list.

Three places needed more than a mechanical swap:

- `_list_npm_files` and the CSV/Doric discovery methods now return `Path` objects, so the `path.endswith(".csv")` filters become `path.suffix == ".csv"` and the `os.path.basename(p).split(".")` calls become `p.name.split(".")`.
- The Doric stub writes to a `<file>.doric.tmp` scratch path and renames over the original. `Path` has no `+`, so that is `doric_path.with_name(doric_path.name + ".tmp")` — not `with_suffix`, which would replace `.doric` rather than append. The unit suite caught the `+`.
- `test_discover_raises_for_non_csv_extension` reached the extension check by monkeypatching `glob.glob`; it now patches `Path.glob`.

Unit suite (2248) and integration suite (189) both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>
