### PR TITLE
Migrate the frontend result views to pathlib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed the README's documentation links, which all carried an `/en/latest/` path prefix that 404s on the single-version Read the Docs project. [PR #469](https://github.com/LernerLab/GuPPy/pull/469)
 
 ## Improvements
+- The Step-5 dashboard tabs, artifact-window and tonic pages, and the plotter now build paths with `pathlib.Path`. [PR #486](https://github.com/LernerLab/GuPPy/pull/486)
 - The TDT, Doric, NPM and CSV extractors and the acquisition-format detector now build paths with `pathlib.Path`. [PR #485](https://github.com/LernerLab/GuPPy/pull/485)
 - The rest of the analysis layer and GuPPy's validation, custom-event and NWB helpers now build paths with `pathlib.Path`. [PR #484](https://github.com/LernerLab/GuPPy/pull/484)
 - GuPPy's core HDF5 and results I/O now builds paths with `pathlib.Path` rather than `os.path`, and `ruff`'s `PTH` rules are enabled with the not-yet-converted modules listed explicitly so the migration is tracked rather than open-ended. [PR #483](https://github.com/LernerLab/GuPPy/pull/483)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,7 +153,10 @@ fixable = ["ALL"]
 # still uses os.path/glob; each migration PR deletes the entries it converts, so what is
 # left here is the remaining work rather than a permanent exemption.
 "src/guppy/utils/utils.py" = ["PTH"]
-"src/guppy/frontend/*" = ["PTH"]
+"src/guppy/frontend/dandi_selector.py" = ["PTH"]
+"src/guppy/frontend/frontend_utils.py" = ["PTH"]
+"src/guppy/frontend/group_labeling.py" = ["PTH"]
+"src/guppy/frontend/input_parameters.py" = ["PTH"]
 "src/guppy/orchestration/*" = ["PTH"]
 "src/guppy/testing/*" = ["PTH"]
 "tests/*" = ["PTH"]

--- a/src/guppy/frontend/artifact_removal.py
+++ b/src/guppy/frontend/artifact_removal.py
@@ -12,10 +12,9 @@ server teardown):
 The interactive marking page lives in ``frontend/artifact_windows_page.py``.
 """
 
-import glob
 import logging
-import os
 from collections.abc import Callable
+from pathlib import Path
 
 import holoviews as hv
 import numpy as np
@@ -60,8 +59,8 @@ def load_pair_traces(filepath: str) -> dict[str, dict[str, object]]:
             "signal": np.asarray(read_hdf5("", path[1, i], "data")).ravel(),
             "fit": np.asarray(read_hdf5("cntrl_sig_fit_" + site, filepath, "data")).ravel(),
             "plot_name": [
-                os.path.basename(path[0, i]).split(".")[0],
-                os.path.basename(path[1, i]).split(".")[0],
+                Path(path[0, i]).name.split(".")[0],
+                Path(path[1, i]).name.split(".")[0],
                 "cntrl_sig_fit_" + site,
             ],
         }
@@ -82,8 +81,8 @@ def load_preprocessed_traces(filepath: str) -> dict[str, dict[str, np.ndarray]]:
         Mapping recording-site name → ``{"x", "y_zscore", "y_dff"}``.
     """
     traces: dict[str, dict[str, np.ndarray]] = {}
-    for path in sorted(glob.glob(os.path.join(filepath, "z_score_*"))):
-        site = recording_site_from_preprocessed_label(os.path.basename(path).split(".")[0])
+    for path in sorted(Path(filepath).glob("z_score_*")):
+        site = recording_site_from_preprocessed_label(path.name.split(".")[0])
         traces[site] = {
             "x": np.asarray(read_hdf5("timeCorrection_" + site, filepath, "timestampNew")).ravel(),
             "y_zscore": np.asarray(read_hdf5("", path, "data")).ravel(),
@@ -119,7 +118,7 @@ class PreprocessingReviewView:
 
         heading = "Artifact removal review" if artifacts_removed else "Preprocessing review"
         self.widget = pn.Column(
-            f"## {heading} — {os.path.basename(filepath)}",
+            f"## {heading} — {Path(filepath).name}",
             self.site_select,
             self.plot_pane,
             sizing_mode="stretch_width",
@@ -135,7 +134,7 @@ class PreprocessingReviewView:
             signal=trace["signal"],
             fit=trace["fit"],
             titles=trace["plot_name"],
-            suptitle=os.path.basename(self.filepath),
+            suptitle=Path(self.filepath).name,
             extra_traces={
                 f"z_score_{site}": preprocessed["y_zscore"],
                 f"dff_{site}": preprocessed["y_dff"],
@@ -169,7 +168,7 @@ def build_run_folder_page(
     if len(run_folders) == 1:
         return content
 
-    options = {f"{os.path.basename(os.path.dirname(f))}/{os.path.basename(f)}": f for f in run_folders}
+    options = {f"{Path(f).parent.name}/{Path(f).name}": f for f in run_folders}
     folder_select = pn.widgets.Select(name="Run folder", options=options, value=run_folders[0])
 
     def _on_folder_change(event: object) -> None:

--- a/src/guppy/frontend/artifact_windows_page.py
+++ b/src/guppy/frontend/artifact_windows_page.py
@@ -6,10 +6,9 @@ traces. Saving writes the complementary keep-windows to
 run's ``GuPPyParamtersUsed.json``, which the Remove Artifacts step then consumes.
 """
 
-import glob
 import logging
-import os
 from collections.abc import Callable
+from pathlib import Path
 
 import numpy as np
 import panel as pn
@@ -141,13 +140,14 @@ def _margined_span(timestamps: np.ndarray) -> tuple[float, float]:
 
 def _has_saved_windows(filepath: str, site: str) -> bool:
     """Whether a run folder holds a keep-windows file for one recording site."""
-    return os.path.exists(os.path.join(filepath, f"coordsForPreProcessing_{site}.npy"))
+    return (Path(filepath) / f"coordsForPreProcessing_{site}.npy").exists()
 
 
 def _sites_with_saved_windows(filepath: str) -> list[str]:
     """The recording sites a run folder holds keep-windows for, in filename order."""
-    prefix = os.path.join(filepath, "coordsForPreProcessing_")
-    return sorted(path[len(prefix) : -len(".npy")] for path in glob.glob(prefix + "*.npy"))
+    prefix = "coordsForPreProcessing_"
+    paths = Path(filepath).glob(prefix + "*.npy")
+    return sorted(path.name[len(prefix) : -len(".npy")] for path in paths)
 
 
 def _saved_artifact_windows(filepath: str, site: str, timestamps: np.ndarray) -> list[tuple[float, float]]:
@@ -174,9 +174,9 @@ def _runs_with_saved_windows(filepath: str) -> dict[str, str]:
     """
     return {
         parse_run_name(run_folder): run_folder
-        for run_folder in discover_run_folders(os.path.dirname(filepath))
-        if os.path.abspath(run_folder) != os.path.abspath(filepath)
-        and glob.glob(os.path.join(run_folder, "coordsForPreProcessing_*.npy"))
+        for run_folder in discover_run_folders(str(Path(filepath).parent))
+        if Path(run_folder).resolve() != Path(filepath).resolve()
+        and any(Path(run_folder).glob("coordsForPreProcessing_*.npy"))
     }
 
 
@@ -284,7 +284,7 @@ class ArtifactWindowSelector:
             else []
         )
         self.widget = pn.Column(
-            f"# Select Artifact Windows — {os.path.basename(filepath)}",
+            f"# Select Artifact Windows — {Path(filepath).name}",
             pn.pane.Markdown(_INSTRUCTIONS),
             *copy_from_section,
             pn.Row(self.site_select, self.trace_select, self.mode_toggle),
@@ -470,7 +470,7 @@ class ArtifactWindowSelector:
 
         for site, keep_windows in site_to_keep_windows.items():
             np.save(
-                os.path.join(self.filepath, f"coordsForPreProcessing_{site}.npy"),
+                Path(self.filepath) / (f"coordsForPreProcessing_{site}.npy"),
                 windows_to_coords(windows=keep_windows),
             )
             logger.info("Saved %s keep-window(s) for recording site %s.", len(keep_windows), site)
@@ -517,7 +517,7 @@ class ArtifactWindowSelector:
             x=trace["x"],
             values=values,
             overlay=overlay,
-            title=f"{os.path.basename(self.filepath)} — {title}",
+            title=f"{Path(self.filepath).name} — {title}",
             spans=self.spans_pipe,
             on_x_select=self._on_drag,
             hooks=[self._capture_figure],

--- a/src/guppy/frontend/binned_metrics_view.py
+++ b/src/guppy/frontend/binned_metrics_view.py
@@ -6,9 +6,8 @@ binned metrics parameter have no such tables, so the tab renders a short note
 instead and can be added to the dashboard unconditionally.
 """
 
-import glob
 import logging
-import os
+from pathlib import Path
 
 import holoviews as hv
 import numpy as np
@@ -46,8 +45,8 @@ def binned_metrics_sites(filepath: str) -> list[str]:
     list of str
         Recording site names, empty when the session has no binned metrics.
     """
-    paths = glob.glob(os.path.join(filepath, _FILE_PREFIX + "*.h5"))
-    return sorted(os.path.basename(path)[len(_FILE_PREFIX) : -len(".h5")] for path in paths)
+    paths = Path(filepath).glob(_FILE_PREFIX + "*.h5")
+    return sorted(path.name[len(_FILE_PREFIX) : -len(".h5")] for path in paths)
 
 
 class BinnedMetricsView:

--- a/src/guppy/frontend/covariate_correlation_view.py
+++ b/src/guppy/frontend/covariate_correlation_view.py
@@ -8,9 +8,8 @@ covariate store have no such tables, so the tab renders a short note instead and
 be added to the dashboard unconditionally.
 """
 
-import glob
 import logging
-import os
+from pathlib import Path
 
 import holoviews as hv
 import numpy as np
@@ -52,8 +51,8 @@ def covariate_correlation_sites(filepath: str) -> list[str]:
     list of str
         Recording site names, empty when the session has no covariate correlations.
     """
-    paths = glob.glob(os.path.join(filepath, _FILE_PREFIX + "*.h5"))
-    return sorted(os.path.basename(path)[len(_FILE_PREFIX) : -len(".h5")] for path in paths)
+    paths = Path(filepath).glob(_FILE_PREFIX + "*.h5")
+    return sorted(path.name[len(_FILE_PREFIX) : -len(".h5")] for path in paths)
 
 
 class CovariateCorrelationView:

--- a/src/guppy/frontend/parameterized_plotter.py
+++ b/src/guppy/frontend/parameterized_plotter.py
@@ -1,9 +1,9 @@
 import logging
 import math
-import os
 import re
 from collections.abc import Callable
 from io import BytesIO
+from pathlib import Path
 from typing import ClassVar
 
 import datashader as ds
@@ -86,12 +86,11 @@ def make_dir(filepath: str) -> str:
 
     Returns
     -------
-    str
+    Path
         Absolute path to the ``saved_plots`` directory.
     """
-    run_folder = os.path.join(filepath, "saved_plots")
-    if not os.path.exists(run_folder):
-        os.mkdir(run_folder)
+    run_folder = Path(filepath) / "saved_plots"
+    run_folder.mkdir(exist_ok=True)
 
     return run_folder
 
@@ -650,7 +649,7 @@ class ParameterizedPlotter(param.Parameterized):
                 .opts(shared_axes=False)
             )
             run_folder = make_dir(self.filepath)
-            output_filename = os.path.join(run_folder, str(selected_events) + "_mean")
+            output_filename = Path(run_folder) / (str(selected_events) + "_mean")
 
             plot_combine = plot_combine.opts(
                 hooks=[
@@ -727,7 +726,7 @@ class ParameterizedPlotter(param.Parameterized):
                 ]
             )
             run_folder = make_dir(self.filepath)
-            output_filename = os.path.join(run_folder, self.event_selector + "_" + self.y)
+            output_filename = Path(run_folder) / (self.event_selector + "_" + self.y)
             self.results_psth["plot"] = image
             self.results_psth["op"] = output_filename
 
@@ -775,7 +774,7 @@ class ParameterizedPlotter(param.Parameterized):
                 ]
             )
             run_folder = make_dir(self.filepath)
-            output_filename = os.path.join(run_folder, self.event_selector + "_" + self.y)
+            output_filename = Path(run_folder) / (self.event_selector + "_" + self.y)
             self.results_psth["plot"] = plot
             self.results_psth["op"] = output_filename
 
@@ -804,7 +803,7 @@ class ParameterizedPlotter(param.Parameterized):
                 ]
             )
             run_folder = make_dir(self.filepath)
-            output_filename = os.path.join(run_folder, self.event_selector + "_" + self.y)
+            output_filename = Path(run_folder) / (self.event_selector + "_" + self.y)
             self.results_psth["plot"] = plot
             self.results_psth["op"] = output_filename
 
@@ -901,7 +900,7 @@ class ParameterizedPlotter(param.Parameterized):
         )
 
         run_folder = make_dir(self.filepath)
-        output_filename = os.path.join(run_folder, self.event_selector + "_selected_trials")
+        output_filename = Path(run_folder) / (self.event_selector + "_selected_trials")
         self.results_psth["trials"] = result
         self.results_psth["op_trials"] = output_filename
         return result
@@ -1026,7 +1025,7 @@ class ParameterizedPlotter(param.Parameterized):
         )
 
         run_folder = make_dir(self.filepath)
-        output_filename = os.path.join(run_folder, self.event_selector_heatmap + "_" + "heatmap")
+        output_filename = Path(run_folder) / (self.event_selector_heatmap + "_" + "heatmap")
         self.results_hm["plot"] = image
         self.results_hm["op"] = output_filename
 

--- a/src/guppy/frontend/psth_significance_view.py
+++ b/src/guppy/frontend/psth_significance_view.py
@@ -10,9 +10,8 @@ the caption differs, since a group's comparison resamples session averages rathe
 trials.
 """
 
-import glob
 import logging
-import os
+from pathlib import Path
 
 import holoviews as hv
 import panel as pn
@@ -63,8 +62,9 @@ def significance_comparisons(filepath: str) -> list[str]:
     list of str
         Comparison names, empty when the directory has no significance results.
     """
-    pattern = os.path.join(filepath, PSTH_SIGNIFICANCE_DIRNAME, PSTH_SIGNIFICANCE_PREFIX + "*.h5")
-    return sorted(os.path.basename(path)[len(PSTH_SIGNIFICANCE_PREFIX) : -len(".h5")] for path in glob.glob(pattern))
+    results_folder = Path(filepath) / PSTH_SIGNIFICANCE_DIRNAME
+    paths = results_folder.glob(PSTH_SIGNIFICANCE_PREFIX + "*.h5")
+    return sorted(path.name[len(PSTH_SIGNIFICANCE_PREFIX) : -len(".h5")] for path in paths)
 
 
 def describe_comparison(*, name: str, n: int, n_b: int | None) -> str:
@@ -103,7 +103,7 @@ class PsthSignificanceView:
 
     def __init__(self, filepath: str) -> None:
         self.filepath = filepath
-        self.results_path = os.path.join(filepath, PSTH_SIGNIFICANCE_DIRNAME)
+        self.results_path = Path(filepath) / PSTH_SIGNIFICANCE_DIRNAME
         self.comparisons = significance_comparisons(filepath)
 
         self.comparison_select = pn.widgets.Select(

--- a/src/guppy/frontend/store_labeling_instructions.py
+++ b/src/guppy/frontend/store_labeling_instructions.py
@@ -1,5 +1,5 @@
 import logging
-import os
+from pathlib import Path
 
 import holoviews as hv
 import numpy as np
@@ -55,7 +55,7 @@ class StoreLabelingInstructions:
             width=550,
         )
 
-        self.widget = pn.Column("# " + os.path.basename(folder_path), self.mark_down)
+        self.widget = pn.Column("# " + Path(folder_path).name, self.mark_down)
 
 
 class StoreLabelingInstructionsNPM(StoreLabelingInstructions):
@@ -168,7 +168,7 @@ class StoreLabelingInstructionsNPM(StoreLabelingInstructions):
         self.plot_area = pn.Column()
 
         self.widget = pn.Column(
-            "# " + os.path.basename(folder_path),
+            "# " + Path(folder_path).name,
             self.mark_down,
             self.mark_down_np,
             config_form,

--- a/src/guppy/frontend/tonic_epochs.py
+++ b/src/guppy/frontend/tonic_epochs.py
@@ -9,10 +9,9 @@ Saving averages the traces over the windows and writes both the definitions
 (``tonic_epochs_<site>.csv``) and the per-epoch means (``tonic_<site>.h5``).
 """
 
-import glob
 import logging
-import os
 from collections.abc import Callable
+from pathlib import Path
 
 import holoviews as hv
 import numpy as np
@@ -80,13 +79,13 @@ def load_site_traces(filepath: str) -> dict[str, dict[str, np.ndarray]]:
         Mapping recording-site name → ``{"x", "y_zscore", "y_dff"}`` arrays.
     """
     site_traces: dict[str, dict[str, np.ndarray]] = {}
-    for path in sorted(glob.glob(os.path.join(filepath, "z_score_*"))):
-        basename = os.path.basename(path).split(".")[0]
+    for path in sorted(Path(filepath).glob("z_score_*")):
+        basename = path.name.split(".")[0]
         site = recording_site_from_preprocessed_label(basename)
         site_traces[site] = {
             "x": np.asarray(read_hdf5("timeCorrection_" + site, filepath, "timestampNew")).ravel(),
             "y_zscore": np.asarray(read_hdf5("", path, "data")).ravel(),
-            "y_dff": np.asarray(read_hdf5("", os.path.join(filepath, "dff_" + site + ".hdf5"), "data")).ravel(),
+            "y_dff": np.asarray(read_hdf5("", Path(filepath) / ("dff_" + site + ".hdf5"), "data")).ravel(),
         }
     return site_traces
 
@@ -188,7 +187,7 @@ class TonicEpochConfig:
         self.save_button.on_click(self._on_save)
 
         self.widget = pn.Column(
-            f"# Tonic Analysis — {os.path.basename(filepath)}",
+            f"# Tonic Analysis — {Path(filepath).name}",
             pn.pane.Markdown(_INSTRUCTIONS),
             self.site_select,
             self.plot_pane,
@@ -286,7 +285,7 @@ class TonicEpochConfig:
                 remove_tonic_results(self.filepath, site)
 
         for site, complete in to_write.items():
-            complete.to_csv(os.path.join(self.filepath, "tonic_epochs_" + site + ".csv"), index=False)
+            complete.to_csv(Path(self.filepath) / ("tonic_epochs_" + site + ".csv"), index=False)
             trace = self.site_traces[site]
             write_tonic_to_hdf5(
                 self.filepath,
@@ -313,7 +312,7 @@ class TonicEpochConfig:
         return build_stacked_traces(
             x=trace["x"],
             traces={"z-score": trace["y_zscore"], "ΔF/F": trace["y_dff"]},
-            suptitle=os.path.basename(self.filepath),
+            suptitle=Path(self.filepath).name,
             spans=self.spans_pipe,
         )
 
@@ -351,8 +350,8 @@ def build_tonic_epoch_page(*, run_folders: list[str]) -> pn.viewable.Viewable:
 
 def _tonic_result_sites(filepath: str) -> list[str]:
     sites = []
-    for path in sorted(glob.glob(os.path.join(filepath, "tonic_*.h5"))):
-        basename = os.path.basename(path)
+    for path in sorted(Path(filepath).glob("tonic_*.h5")):
+        basename = path.name
         sites.append(basename[len("tonic_") : -len(".h5")])
     return sites
 
@@ -384,7 +383,7 @@ class TonicResultsView:
         self.baseline_select.param.watch(self._refresh, "value")
 
         self.widget = pn.Column(
-            f"## Tonic / basal analysis — {os.path.basename(filepath)}",
+            f"## Tonic / basal analysis — {Path(filepath).name}",
             pn.Row(self.site_select, self.baseline_select),
             self.bars_pane,
             pn.pane.Markdown(_BASELINE_HINT),
@@ -394,7 +393,7 @@ class TonicResultsView:
         )
 
     def _means(self, site: str) -> pd.DataFrame:
-        return pd.read_hdf(os.path.join(self.filepath, "tonic_" + site + ".h5"), key="df")
+        return pd.read_hdf(Path(self.filepath) / ("tonic_" + site + ".h5"), key="df")
 
     def _make_bars(self) -> hv.Layout:
         """Each epoch's change from the baseline epoch, as bars, one panel per signal.
@@ -445,10 +444,8 @@ class TonicResultsView:
         site = self.site_select.value
         timestamps = np.asarray(read_hdf5("timeCorrection_" + site, self.filepath, "timestampNew")).ravel()
         traces = {
-            "z-score": np.asarray(
-                read_hdf5("", os.path.join(self.filepath, "z_score_" + site + ".hdf5"), "data")
-            ).ravel(),
-            "ΔF/F": np.asarray(read_hdf5("", os.path.join(self.filepath, "dff_" + site + ".hdf5"), "data")).ravel(),
+            "z-score": np.asarray(read_hdf5("", Path(self.filepath) / ("z_score_" + site + ".hdf5"), "data")).ravel(),
+            "ΔF/F": np.asarray(read_hdf5("", Path(self.filepath) / ("dff_" + site + ".hdf5"), "data")).ravel(),
         }
         # The analysed windows are fixed on disk, so the pipe is seeded once per rebuild
         # rather than driven by edits; it is retained so the spans layer keeps its source.
@@ -459,7 +456,7 @@ class TonicResultsView:
         return build_stacked_traces(
             x=timestamps,
             traces=traces,
-            suptitle=os.path.basename(self.filepath),
+            suptitle=Path(self.filepath).name,
             spans=self.spans_pipe,
         )
 

--- a/src/guppy/frontend/transient_peaks.py
+++ b/src/guppy/frontend/transient_peaks.py
@@ -6,9 +6,8 @@ selector switches between every ``z_score`` / ``dff`` trace across the run folde
 shown with its detected transient peaks marked.
 """
 
-import glob
 import logging
-import os
+from pathlib import Path
 
 import holoviews as hv
 import numpy as np
@@ -26,10 +25,10 @@ logger = logging.getLogger(__name__)
 
 def _trace_paths(filepath: str, select_for_transients: str) -> list[str]:
     if select_for_transients == "z_score":
-        return glob.glob(os.path.join(filepath, "z_score_*"))
+        return list(Path(filepath).glob("z_score_*"))
     if select_for_transients == "dff":
-        return glob.glob(os.path.join(filepath, "dff_*"))
-    return glob.glob(os.path.join(filepath, "z_score_*")) + glob.glob(os.path.join(filepath, "dff_*"))
+        return list(Path(filepath).glob("dff_*"))
+    return list(Path(filepath).glob("z_score_*")) + list(Path(filepath).glob("dff_*"))
 
 
 def load_peaks(run_folders: list[str], select_for_transients: str) -> dict[str, dict[str, np.ndarray]]:
@@ -51,8 +50,8 @@ def load_peaks(run_folders: list[str], select_for_transients: str) -> dict[str, 
     entries: dict[str, dict[str, np.ndarray]] = {}
     for filepath in run_folders:
         for path in _trace_paths(filepath, select_for_transients):
-            title = os.path.basename(path).split(".")[0]
-            suptitle = os.path.basename(os.path.dirname(path))
+            title = path.name.split(".")[0]
+            suptitle = path.parent.name
             z_score, timestamps, peaksInd = read_transients_from_hdf5(filepath, title)
             entries[f"{suptitle} / {title}"] = {
                 "z_score": np.asarray(z_score).ravel(),

--- a/tests/unit/frontend/test_parameterized_plotter.py
+++ b/tests/unit/frontend/test_parameterized_plotter.py
@@ -1,4 +1,3 @@
-import os
 from io import BytesIO
 from types import SimpleNamespace
 
@@ -94,14 +93,14 @@ def test_make_dir_creates_saved_plots_directory(tmp_path):
 
 def test_make_dir_returns_correct_path(tmp_path):
     result = make_dir(str(tmp_path))
-    assert result == str(tmp_path / "saved_plots")
+    assert result == tmp_path / "saved_plots"
 
 
 def test_make_dir_is_idempotent(tmp_path):
     make_dir(str(tmp_path))
     # Second call must not raise even though directory already exists
     result = make_dir(str(tmp_path))
-    assert result == str(tmp_path / "saved_plots")
+    assert result == tmp_path / "saved_plots"
 
 
 # ---------------------------------------------------------------------------
@@ -386,7 +385,7 @@ class TestParameterizedPlotter:
         plot = plotter.update_selector()
 
         assert plot is not None
-        assert plotter.results_psth["op_combine"].endswith(os.path.join("saved_plots", "['event1_bin_1']_mean"))
+        assert plotter.results_psth["op_combine"].parts[-2:] == ("saved_plots", "['event1_bin_1']_mean")
 
     def test_cont_plot_all_trials_branch(self, plotter):
         plotter.param["y"].objects = ["trial_1", "trial_2", "trial_3", "bin_1", "mean", "All"]
@@ -395,7 +394,7 @@ class TestParameterizedPlotter:
         plot = plotter.contPlot()
 
         assert plot is not None
-        assert plotter.results_psth["op"].endswith(os.path.join("saved_plots", "event1_All"))
+        assert plotter.results_psth["op"].parts[-2:] == ("saved_plots", "event1_All")
 
     def test_plot_specific_trials_mean_branch(self, plotter):
         plotter.psth_y = ["1 - trial_1", "2 - trial_2"]
@@ -419,7 +418,7 @@ class TestParameterizedPlotter:
         image = plotter.heatmap()
 
         assert image is not None
-        assert plotter.results_hm["op"].endswith(os.path.join("saved_plots", "event1_heatmap"))
+        assert plotter.results_hm["op"].parts[-2:] == ("saved_plots", "event1_heatmap")
 
     def test_heatmap_single_trial_uses_datashaded_path(self, single_trial_plotter, plotter):
         # A single-trial heatmap used to build a raw QuadMesh spanning the full


### PR DESCRIPTION
<!-- summary line goes here -->

<details>
<summary>Details (AI-generated)</summary>

Fourth of the #478 stack. Stacked on #485 → #484 → #483 → #482 → #481 → #480 — review the last commit.

Converts the read-only half of `src/guppy/frontend/`: the Step-5 dashboard tabs (`binned_metrics_view`, `covariate_correlation_view`, `psth_significance_view`), the artifact-window and tonic pages, the preprocessing and transient review views, `store_labeling_instructions`, and `parameterized_plotter`. The `"src/guppy/frontend/*"` ignore is replaced by four per-file entries for the selector modules (`input_parameters`, `dandi_selector`, `group_labeling`, `frontend_utils`), which hold the paths that flow into `inputParameters` and are better converted alongside `utils/utils.py` and the orchestration layer.

`make_dir` and the plotter's recorded output filenames are `Path` now; those filenames are written but never read back in production, so only the plotter tests needed updating. The copy-windows picker compares run folders with `Path.resolve()` instead of `os.path.abspath`.

**One thing worth knowing for the rest of the stack.** `ast` column offsets are UTF-8 *byte* offsets, so a mechanical splice using them misaligns on any line containing a non-ASCII character. That corrupted exactly one rewrite here — the `os.path.join` sharing a line with `tonic_epochs`' `"ΔF/F"` trace label — and it was converted by hand instead. I audited every `os.path.join`, `logger.<level>(f"...")` and `zip()` call in the tree against `origin/main` for the same hazard: that site was the only one, so nothing already merged in this stack or in #481/#482 is affected.

Unit suite (2248) and integration suite (189) both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>
