### PR TITLE
Migrate utils/utils.py and the frontend selectors to pathlib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed the README's documentation links, which all carried an `/en/latest/` path prefix that 404s on the single-version Read the Docs project. [PR #469](https://github.com/LernerLab/GuPPy/pull/469)
 
 ## Improvements
+- GuPPy's run-folder and group-folder helpers and the parameter, DANDI and group-labeling selectors now build paths with `pathlib.Path`. [PR #487](https://github.com/LernerLab/GuPPy/pull/487)
 - The Step-5 dashboard tabs, artifact-window and tonic pages, and the plotter now build paths with `pathlib.Path`. [PR #486](https://github.com/LernerLab/GuPPy/pull/486)
 - The TDT, Doric, NPM and CSV extractors and the acquisition-format detector now build paths with `pathlib.Path`. [PR #485](https://github.com/LernerLab/GuPPy/pull/485)
 - The rest of the analysis layer and GuPPy's validation, custom-event and NWB helpers now build paths with `pathlib.Path`. [PR #484](https://github.com/LernerLab/GuPPy/pull/484)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,11 +152,6 @@ fixable = ["ALL"]
 # The pathlib migration (#478) runs module by module. Every entry below is a module that
 # still uses os.path/glob; each migration PR deletes the entries it converts, so what is
 # left here is the remaining work rather than a permanent exemption.
-"src/guppy/utils/utils.py" = ["PTH"]
-"src/guppy/frontend/dandi_selector.py" = ["PTH"]
-"src/guppy/frontend/frontend_utils.py" = ["PTH"]
-"src/guppy/frontend/group_labeling.py" = ["PTH"]
-"src/guppy/frontend/input_parameters.py" = ["PTH"]
 "src/guppy/orchestration/*" = ["PTH"]
 "src/guppy/testing/*" = ["PTH"]
 "tests/*" = ["PTH"]

--- a/src/guppy/frontend/dandi_selector.py
+++ b/src/guppy/frontend/dandi_selector.py
@@ -22,7 +22,7 @@ _DANDISET_ID_PATTERN = re.compile(r"^\d{6}$")
 # lets the user navigate DANDI assets with the same ``FileSelector`` they know
 # from local mode. We leave cleanup to the OS — the parent lives under the
 # system temp dir.
-_MIRROR_ROOT = os.path.join(tempfile.gettempdir(), "guppy_dandi_mirror")
+_MIRROR_ROOT = str(Path(tempfile.gettempdir()) / "guppy_dandi_mirror")
 
 
 def _build_dandiset_mirror(*, dandiset_id: str, mirror_parent: str) -> tuple[str, int]:
@@ -37,13 +37,13 @@ def _build_dandiset_mirror(*, dandiset_id: str, mirror_parent: str) -> tuple[str
     with DandiAPIClient() as client:
         dandiset = client.get_dandiset(dandiset_id)
         asset_paths = [asset.path for asset in dandiset.get_assets() if asset.path.endswith(".nwb")]
-    mirror_root = os.path.join(mirror_parent, dandiset_id)
-    os.makedirs(mirror_root, exist_ok=True)
+    mirror_root = Path(mirror_parent) / dandiset_id
+    mirror_root.mkdir(parents=True, exist_ok=True)
     for asset_path in asset_paths:
-        absolute_path = os.path.join(mirror_root, asset_path)
-        os.makedirs(os.path.dirname(absolute_path), exist_ok=True)
-        Path(absolute_path).touch(exist_ok=True)
-    return mirror_root, len(asset_paths)
+        absolute_path = mirror_root / asset_path
+        absolute_path.parent.mkdir(parents=True, exist_ok=True)
+        absolute_path.touch(exist_ok=True)
+    return str(mirror_root), len(asset_paths)
 
 
 class DandiSelector:
@@ -89,7 +89,7 @@ class DandiSelector:
         # Allow tests to inject a tmp_path-based parent; default to the
         # module-level stable location.
         self._mirror_parent = mirror_parent if mirror_parent is not None else _MIRROR_ROOT
-        os.makedirs(self._mirror_parent, exist_ok=True)
+        Path(self._mirror_parent).mkdir(parents=True, exist_ok=True)
 
         self._current_mirror_root = None
         # Re-attached to each rebuilt asset FileSelector by _make_asset_file_selector.
@@ -111,7 +111,7 @@ class DandiSelector:
         self._asset_file_selector_slot = pn.Column(self.asset_file_selector)
 
         self.output_root_selector = pn.widgets.FileSelector(
-            start_path if start_path and os.path.isdir(start_path) else default_root_path(),
+            start_path if start_path and Path(start_path).is_dir() else default_root_path(),
             root_directory="/",
             name="Local output directory",
             width=950,

--- a/src/guppy/frontend/frontend_utils.py
+++ b/src/guppy/frontend/frontend_utils.py
@@ -1,6 +1,6 @@
 import logging
-import os
 import socket
+from pathlib import Path
 from random import randint
 
 logger = logging.getLogger(__name__)
@@ -14,7 +14,7 @@ def default_root_path() -> str:
     str
         The user's home directory.
     """
-    return os.path.expanduser("~")
+    return str(Path.home())
 
 
 # Ports that all major browsers refuse to connect to (ERR_UNSAFE_PORT).

--- a/src/guppy/frontend/group_labeling.py
+++ b/src/guppy/frontend/group_labeling.py
@@ -7,7 +7,7 @@ homepage.
 """
 
 import logging
-import os
+from pathlib import Path
 
 import panel as pn
 
@@ -44,10 +44,10 @@ class GroupLabelingPage:
     """
 
     def __init__(self, *, start_path: str, selected_group_folders: list[str]) -> None:
-        self.start_path = start_path if start_path and os.path.isdir(start_path) else default_root_path()
+        self.start_path = start_path if start_path and Path(start_path).is_dir() else default_root_path()
         self.selected_group_folders = list(selected_group_folders)
         self.edit_start_path = (
-            os.path.dirname(self.selected_group_folders[0]) if self.selected_group_folders else self.start_path
+            str(Path(self.selected_group_folders[0]).parent) if self.selected_group_folders else self.start_path
         )
         self.setup_widgets()
         self.attach_callbacks()
@@ -158,7 +158,7 @@ group — run **Group Analysis** afterwards to compute the averages.
         selected = list(event.new or [])
         if len(selected) != 1 or not is_group_folder(selected[0]):
             return
-        if not os.path.exists(os.path.join(selected[0], GROUP_MEMBERS_FILENAME)):
+        if not (Path(selected[0]) / GROUP_MEMBERS_FILENAME).exists():
             return
         self._show_members(read_group_members(group_folder=selected[0]))
 
@@ -173,7 +173,7 @@ group — run **Group Analysis** afterwards to compute the averages.
         if not member_run_folders:
             self.members_selector.value = []
             return
-        self.members_selector.directory = os.path.dirname(member_run_folders[0])
+        self.members_selector.directory = str(Path(member_run_folders[0]).parent)
         self.members_selector._update_files()
         self.members_selector._selector.value = list(member_run_folders)
 
@@ -220,7 +220,7 @@ group — run **Group Analysis** afterwards to compute the averages.
         self.path.value = group_folder
         # Point the edit browser at the group just written, so switching to edit mode lands
         # on it rather than back at the starting directory.
-        self.group_to_edit_selector.directory = os.path.dirname(group_folder)
+        self.group_to_edit_selector.directory = str(Path(group_folder).parent)
         self.group_to_edit_selector._update_files()
 
     def build_template(self) -> pn.template.BootstrapTemplate:
@@ -247,6 +247,6 @@ def save_group_definition(*, group_folder: str, member_run_folders: list[str]) -
     member_run_folders : list of str
         Output (run) directories to record as the group's members.
     """
-    os.makedirs(group_folder, exist_ok=True)
+    Path(group_folder).mkdir(parents=True, exist_ok=True)
     write_group_members(group_folder=group_folder, member_run_folders=member_run_folders)
     logger.info("Group definition saved at %s with %s member run(s).", group_folder, len(member_run_folders))

--- a/src/guppy/frontend/input_parameters.py
+++ b/src/guppy/frontend/input_parameters.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -83,7 +84,7 @@ class ParameterForm:
 
     def __init__(self, *, template: object, start_path: str | None = None) -> None:
         self.template = template
-        self.folder_path = start_path if start_path and os.path.isdir(start_path) else default_root_path()
+        self.folder_path = start_path if start_path and Path(start_path).is_dir() else default_root_path()
         self.styles = dict(background="WhiteSmoke")
         # Sessions the run selection was last synced against, so a change can tell which
         # sessions are new and should inherit the bulk run-name choice.
@@ -554,7 +555,7 @@ class ParameterForm:
         grouped: dict[str, list[str]] = {}
         for path in self.outputs_selector.value or []:
             _reject_group_folder_selected_as_run(path=path)
-            session = os.path.dirname(path)
+            session = str(Path(path).parent)
             grouped.setdefault(session, []).append(parse_run_name(path))
         return grouped
 
@@ -586,7 +587,7 @@ class ParameterForm:
             candidates = self._prospective_dandi_sessions()
         else:
             candidates = list(self.files_1.value or [])
-        return [session for session in candidates if os.path.isdir(session)]
+        return [session for session in candidates if Path(session).is_dir()]
 
     @staticmethod
     def _run_names_for_sessions(sessions: list[str]) -> list[str]:
@@ -675,7 +676,7 @@ class ParameterForm:
         self._sessions_in_run_selection = sessions
         self._retarget_outputs_selector(sessions)
 
-        selected = [path for path in (self.outputs_selector.value or []) if os.path.dirname(path) in sessions]
+        selected = [path for path in (self.outputs_selector.value or []) if str(Path(path).parent) in sessions]
         selected += self._run_folders_on_disk(sessions=new_sessions, run_names=self.run_names_for_all_sessions.value)
         self._apply_selected_run_folders(selected)
         self._refresh_run_name_options(sessions)
@@ -691,7 +692,7 @@ class ParameterForm:
             run_name for run_name in run_names if run_name in self.run_names_for_all_sessions.options
         ]
         self._suppressing_run_name_propagation = False
-        self._apply_selected_run_folders([path for path in run_folders if os.path.dirname(path) in sessions])
+        self._apply_selected_run_folders([path for path in run_folders if str(Path(path).parent) in sessions])
 
     def _on_run_names_for_all_sessions_change(self, event: object) -> None:
         """Select or deselect the runs matching the bulk choice, leaving hand-picked ones alone."""
@@ -710,7 +711,7 @@ class ParameterForm:
         for session in sessions:
             for run_name in run_names:
                 run_folder = run_folder_for_run(session, run_name)
-                if os.path.isdir(run_folder):
+                if Path(run_folder).is_dir():
                     run_folders.append(run_folder)
         return run_folders
 
@@ -731,8 +732,8 @@ class ParameterForm:
         sessions = []
         for uri in self.dandi_selector.selected_uris:
             asset_path = uri.split("/", 3)[-1]
-            session_stem = os.path.splitext(os.path.basename(asset_path))[0]
-            sessions.append(os.path.join(output_root, session_stem))
+            session_stem = Path(asset_path).stem
+            sessions.append(str(Path(output_root) / session_stem))
         return sessions
 
     def _resolve_dandi_sessions(self) -> tuple[list[str], str, dict[str, str]]:
@@ -764,7 +765,7 @@ class ParameterForm:
 
         folder_names = self._prospective_dandi_sessions()
         for session_directory in folder_names:
-            os.makedirs(session_directory, exist_ok=True)
+            Path(session_directory).mkdir(parents=True, exist_ok=True)
         dandi_uri_map = dict(zip(folder_names, selected_uris, strict=True))
         return folder_names, output_root, dandi_uri_map
 
@@ -1030,9 +1031,9 @@ class ParameterForm:
         """
         saved = []
         for run_folder in event.new or []:
-            json_path = os.path.join(run_folder, "GuPPyParamtersUsed.json")
-            if os.path.exists(json_path):
-                with open(json_path) as parameters_file:
+            json_path = Path(run_folder) / "GuPPyParamtersUsed.json"
+            if json_path.exists():
+                with json_path.open() as parameters_file:
                     saved.append(json.load(parameters_file))
         if not saved:
             return

--- a/src/guppy/utils/utils.py
+++ b/src/guppy/utils/utils.py
@@ -1,8 +1,8 @@
-import glob
 import json
 import logging
 import os
 from collections.abc import Sequence
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -48,7 +48,7 @@ def write_npm_params(*, run_folder: str, npm_params: dict[str, object]) -> None:
     npm_params : dict
         The NPM parameters (keys in :data:`NPM_PARAM_KEYS`) to persist.
     """
-    with open(os.path.join(run_folder, NPM_PARAMS_FILENAME), "w") as file:
+    with (Path(run_folder) / NPM_PARAMS_FILENAME).open("w") as file:
         json.dump(npm_params, file, indent=4)
 
 
@@ -71,10 +71,10 @@ def load_npm_params(run_folder: str) -> dict[str, object]:
         If the file predates the session-wide timestamp unit and so records no
         unit that can be trusted to match the one its data was read with.
     """
-    npm_params_path = os.path.join(run_folder, NPM_PARAMS_FILENAME)
-    if not os.path.exists(npm_params_path):
+    npm_params_path = Path(run_folder) / NPM_PARAMS_FILENAME
+    if not npm_params_path.exists():
         return {}
-    with open(npm_params_path) as file:
+    with npm_params_path.open() as file:
         npm_params = json.load(file)
 
     if "npm_time_unit" not in npm_params:
@@ -99,7 +99,7 @@ def write_group_members(*, group_folder: str, member_run_folders: list[str]) -> 
     member_run_folders : list of str
         Absolute paths of the member run folders, in averaging order.
     """
-    with open(os.path.join(group_folder, GROUP_MEMBERS_FILENAME), "w") as file:
+    with (Path(group_folder) / GROUP_MEMBERS_FILENAME).open("w") as file:
         json.dump({"member_run_folders": list(member_run_folders)}, file, indent=4)
 
 
@@ -121,15 +121,15 @@ def read_group_members(*, group_folder: str) -> list[str]:
     ValueError
         If the group directory holds no manifest.
     """
-    manifest_path = os.path.join(group_folder, GROUP_MEMBERS_FILENAME)
-    if not os.path.exists(manifest_path):
+    manifest_path = Path(group_folder) / GROUP_MEMBERS_FILENAME
+    if not manifest_path.exists():
         message = (
             f"{group_folder!r} holds no {GROUP_MEMBERS_FILENAME}, so it was not created by GuPPy's "
             "Group Analysis step. Re-create the group from the Group Analysis card."
         )
         logger.error(message)
         raise ValueError(message)
-    with open(manifest_path) as file:
+    with manifest_path.open() as file:
         return json.load(file)["member_run_folders"]
 
 
@@ -146,11 +146,7 @@ def takeOnlyDirs(paths: list[str]) -> list[str]:
     list of str
         Subset of ``paths`` containing only directories.
     """
-    removePaths = []
-    for path in paths:
-        if os.path.isfile(path):
-            removePaths.append(path)
-    return list(set(paths) - set(removePaths))
+    return [path for path in paths if not Path(path).is_file()]
 
 
 def parse_run_name(run_folder: str) -> str:
@@ -177,7 +173,7 @@ def parse_run_name(run_folder: str) -> str:
     """
     # Strip both separators so trailing forward slashes are tolerated on Windows
     # (where os.sep is "\\" but paths can still use "/").
-    basename = os.path.basename(run_folder.rstrip("/\\"))
+    basename = Path(run_folder.rstrip("/\\")).name
     index = basename.rfind(_RUN_NAME_MARKER)
     if index < 0:
         raise ValueError(
@@ -202,7 +198,7 @@ def discover_run_folders(session_path: str) -> list[str]:
         deterministically: numeric run names first (sorted numerically), then
         non-numeric run names (sorted case-insensitively).
     """
-    candidates = takeOnlyDirs(glob.glob(os.path.join(session_path, "*" + _RUN_NAME_MARKER + "*")))
+    candidates = [str(path) for path in Path(session_path).glob("*" + _RUN_NAME_MARKER + "*") if path.is_dir()]
     return sorted(candidates, key=_run_name_sort_key_for_path)
 
 
@@ -223,8 +219,8 @@ def run_folder_for_run(session_path: str, run_name: str) -> str:
     str
         Path of the form ``<session_path>/<basename>_output_<run_name>``.
     """
-    basename = os.path.basename(session_path.rstrip(os.sep))
-    return os.path.join(session_path, basename + _RUN_NAME_MARKER + run_name)
+    basename = Path(session_path.rstrip(os.sep)).name
+    return str(Path(session_path) / (basename + _RUN_NAME_MARKER + run_name))
 
 
 def selected_session_runs(*, inputParameters: dict[str, object]) -> list[tuple[str, str]]:
@@ -284,9 +280,7 @@ def select_run_folders(session_path: str, selected_runs: list[str]) -> list[str]
         )
 
     selected = [available_by_name[run] for run in selected_runs]
-    missing_stores = [
-        run_folder for run_folder in selected if not os.path.exists(os.path.join(run_folder, "storesList.csv"))
-    ]
+    missing_stores = [run_folder for run_folder in selected if not (Path(run_folder) / "storesList.csv").exists()]
     if missing_stores:
         raise ValueError(
             f"Selected output directories are missing storesList.csv: {missing_stores!r}. "
@@ -352,7 +346,7 @@ def parse_group_name(group_folder: str) -> str:
     ValueError
         If the basename does not match the expected pattern.
     """
-    basename = os.path.basename(group_folder.rstrip("/\\"))
+    basename = Path(group_folder.rstrip("/\\")).name
     if not basename.endswith(_GROUP_NAME_MARKER) or basename == _GROUP_NAME_MARKER:
         raise ValueError(
             f"Cannot parse group name from {group_folder!r}: basename {basename!r} does not match "
@@ -375,7 +369,7 @@ def common_parent_directory(*, paths: Sequence[str]) -> str:
         The parent directory shared by all ``paths`` when they sit side by side,
         or their nearest common ancestor when they do not.
     """
-    parent_directories = {os.path.dirname(path) for path in paths}
+    parent_directories = {str(Path(path).parent) for path in paths}
     return os.path.commonpath(sorted(parent_directories))
 
 
@@ -393,7 +387,7 @@ def is_group_folder(path: str) -> bool:
         ``True`` when the basename ends with ``_group`` and is not itself a run
         folder (a run named ``group`` would otherwise match both).
     """
-    basename = os.path.basename(path.rstrip("/\\"))
+    basename = Path(path.rstrip("/\\")).name
     if _RUN_NAME_MARKER in basename:
         return False
     return basename.endswith(_GROUP_NAME_MARKER) and basename != _GROUP_NAME_MARKER
@@ -413,7 +407,7 @@ def discover_group_folders(destination_directory: str) -> list[str]:
         Absolute paths of every ``<group_name>_group`` subdirectory, sorted
         case-insensitively by group name.
     """
-    candidates = takeOnlyDirs(glob.glob(os.path.join(destination_directory, "*" + _GROUP_NAME_MARKER)))
+    candidates = [str(path) for path in Path(destination_directory).glob("*" + _GROUP_NAME_MARKER) if path.is_dir()]
     group_folders = [path for path in candidates if is_group_folder(path)]
     return sorted(group_folders, key=lambda path: parse_group_name(path).casefold())
 
@@ -435,7 +429,7 @@ def group_folder_for_group(*, destination_directory: str, group_name: str) -> st
     str
         Path of the group output directory.
     """
-    return os.path.join(destination_directory, group_name + _GROUP_NAME_MARKER)
+    return str(Path(destination_directory) / (group_name + _GROUP_NAME_MARKER))
 
 
 def validate_group_name(group_name: str) -> None:
@@ -493,7 +487,7 @@ def _run_name_sort_key_for_path(path: str) -> tuple[int, int, str]:
     try:
         run_name = parse_run_name(path)
     except ValueError:
-        return (2, 0, os.path.basename(path).casefold())
+        return (2, 0, Path(path).name.casefold())
     return _run_name_sort_key(run_name)
 
 
@@ -598,9 +592,9 @@ def read_Df(filepath: str, event: str, name: str) -> pd.DataFrame:
     event = event.replace("\\", "_")
     event = event.replace("/", "_")
     if name:
-        hdf5_path = os.path.join(filepath, event + f"_{name}.h5")
+        hdf5_path = Path(filepath) / (event + f"_{name}.h5")
     else:
-        hdf5_path = os.path.join(filepath, event + ".h5")
+        hdf5_path = Path(filepath) / (event + ".h5")
     df = pd.read_hdf(hdf5_path, key="df", mode="r")
 
     return df


### PR DESCRIPTION
<!-- summary line goes here -->

<details>
<summary>Details (AI-generated)</summary>

Fifth of the #478 stack. Stacked on #486 → #485 → #484 → #483 → #482 → #481 → #480 — review the last commit.

Converts `utils/utils.py` and the four frontend selector modules (`input_parameters`, `dandi_selector`, `group_labeling`, `frontend_utils`). After this, only `orchestration/`, `testing/` and `tests/` remain in the `PTH` ignore list.

These are the modules whose path values cross into `inputParameters` and out to `GuPPyParamtersUsed.json`, which `json.dump` cannot serialize a `Path` into. So the public signatures here keep returning `str` — `discover_run_folders`, `run_folder_for_run`, `group_folder_for_group`, `_prospective_dandi_sessions` — and only the arithmetic behind them moves to `Path`.

Two small behavior notes:

- `takeOnlyDirs` no longer routes its result through a `set`, which was discarding order for no reason, and `discover_run_folders` / `discover_group_folders` now filter `Path.glob` results with `is_dir()` directly rather than calling it. Both results were already sorted immediately afterwards, so the only change is that the intermediate list is deterministic.
- `os.path.commonpath` stays as-is in `input_parameters`: `pathlib` has no equivalent, and `PTH` does not flag it.

Unit suite (2248) and integration suite (189) both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>
