### PR TITLE
Migrate orchestration/ and testing/ to pathlib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed the README's documentation links, which all carried an `/en/latest/` path prefix that 404s on the single-version Read the Docs project. [PR #469](https://github.com/LernerLab/GuPPy/pull/469)
 
 ## Improvements
+- The pipeline's step orchestration now builds paths with `pathlib.Path`, completing the migration across `src/`. [PR #488](https://github.com/LernerLab/GuPPy/pull/488)
 - GuPPy's run-folder and group-folder helpers and the parameter, DANDI and group-labeling selectors now build paths with `pathlib.Path`. [PR #487](https://github.com/LernerLab/GuPPy/pull/487)
 - The Step-5 dashboard tabs, artifact-window and tonic pages, and the plotter now build paths with `pathlib.Path`. [PR #486](https://github.com/LernerLab/GuPPy/pull/486)
 - The TDT, Doric, NPM and CSV extractors and the acquisition-format detector now build paths with `pathlib.Path`. [PR #485](https://github.com/LernerLab/GuPPy/pull/485)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,8 +152,6 @@ fixable = ["ALL"]
 # The pathlib migration (#478) runs module by module. Every entry below is a module that
 # still uses os.path/glob; each migration PR deletes the entries it converts, so what is
 # left here is the remaining work rather than a permanent exemption.
-"src/guppy/orchestration/*" = ["PTH"]
-"src/guppy/testing/*" = ["PTH"]
 "tests/*" = ["PTH"]
 
 [tool.ruff.lint.isort]

--- a/src/guppy/orchestration/export_nwb.py
+++ b/src/guppy/orchestration/export_nwb.py
@@ -11,6 +11,7 @@ to the standalone :class:`GuppyInterface`, which adds the GuPPy outputs to the f
 import logging
 import os
 from contextlib import closing
+from pathlib import Path
 
 from pynwb import NWBFile
 from pynwb.device import DeviceModel
@@ -62,7 +63,7 @@ def _validate_artifact_removal_methods(*, pairs: list[tuple[str, str]]) -> None:
         guppy_folder_path = run_folder_for_run(session_path, run_name)
         artifacts_removed, removal_method = read_artifact_provenance(destination=guppy_folder_path)
         if artifacts_removed and removal_method == _UNSUPPORTED_ARTIFACT_REMOVAL_METHOD:
-            offending.append(f"{os.path.basename(session_path.rstrip(os.sep))} ({run_name})")
+            offending.append(f"{Path(session_path.rstrip(os.sep)).name} ({run_name})")
 
     if offending:
         raise ValueError(
@@ -90,9 +91,9 @@ def _warn_psth_significance_not_exported(*, pairs: list[tuple[str, str]]) -> Non
         ``(session_path, run_name)`` pairs selected for export.
     """
     tested = [
-        f"{os.path.basename(session_path.rstrip(os.sep))} ({run_name})"
+        f"{Path(session_path.rstrip(os.sep)).name} ({run_name})"
         for session_path, run_name in pairs
-        if os.path.isdir(os.path.join(run_folder_for_run(session_path, run_name), PSTH_SIGNIFICANCE_DIRNAME))
+        if (Path(run_folder_for_run(session_path, run_name)) / PSTH_SIGNIFICANCE_DIRNAME).is_dir()
     ]
     if not tested:
         return
@@ -111,7 +112,7 @@ def _overlay_metadata_yaml(*, metadata: dict, metadata_yaml_path: str | None) ->
     """Apply the session's ``nwb_metadata.yaml`` on top of auto-filled metadata, when it exists."""
     from neuroconv.utils import dict_deep_update, load_dict_from_file
 
-    if metadata_yaml_path and os.path.exists(metadata_yaml_path):
+    if metadata_yaml_path and Path(metadata_yaml_path).exists():
         return dict_deep_update(metadata, load_dict_from_file(metadata_yaml_path))
     return metadata
 
@@ -174,7 +175,7 @@ def _export_session_from_nwb_source(
     nwb_source: str,
     guppy_folder_path: str,
     metadata_yaml_path: str | None,
-    nwbfile_path: str,
+    nwbfile_path: str | Path,
 ) -> str:
     """Add one GuPPy session/run's outputs to the NWB file it was processed out of.
 
@@ -222,7 +223,7 @@ def export_session_to_nwb(
     acquisition_format: str,
     guppy_folder_path: str,
     metadata_yaml_path: str | None,
-    nwbfile_path: str,
+    nwbfile_path: str | Path,
     nwb_source: str | None = None,
 ) -> str:
     """Convert one GuPPy session/run to NWB.
@@ -241,7 +242,7 @@ def export_session_to_nwb(
     metadata_yaml_path : str or None
         The session's metadata overlay (``nwb_metadata.yaml``). Applied, when
         present, on top of the auto-filled metadata.
-    nwbfile_path : str
+    nwbfile_path : str or Path
         Output path for the written ``.nwb`` file.
     nwb_source : str or None, optional
         The NWB file this session was processed out of — a local path or a ``dandi://`` URI. When
@@ -315,12 +316,12 @@ def orchestrate_export_nwb(inputParameters: dict[str, object]) -> None:
     failures = []
     for session_path, run_name in pairs:
         guppy_folder_path = run_folder_for_run(session_path, run_name)
-        session_basename = os.path.basename(session_path.rstrip(os.sep))
-        output_dir_name = os.path.basename(guppy_folder_path.rstrip(os.sep))
-        metadata_yaml_path = os.path.join(guppy_folder_path, METADATA_FILENAME)
+        session_basename = Path(session_path.rstrip(os.sep)).name
+        output_dir_name = Path(guppy_folder_path.rstrip(os.sep)).name
+        metadata_yaml_path = Path(guppy_folder_path) / METADATA_FILENAME
         # Name the file after the full output directory so exports from multiple runs/sessions
         # stay distinct and can be aggregated into one folder without renaming.
-        nwbfile_path = os.path.join(guppy_folder_path, f"{output_dir_name}.nwb")
+        nwbfile_path = Path(guppy_folder_path) / f"{output_dir_name}.nwb"
 
         try:
             acquisition_format, nwb_source = resolve_session_source(

--- a/src/guppy/orchestration/group_analysis.py
+++ b/src/guppy/orchestration/group_analysis.py
@@ -11,8 +11,8 @@ The group directory is run-folder-shaped for the consumers that read PSTH output
 """
 
 import logging
-import os
 import shutil
+from pathlib import Path
 
 import numpy as np
 
@@ -75,8 +75,7 @@ def _validate_fiber_recording_sites_consistent_for_group(*, member_run_folders: 
         return
 
     member_lines = "\n".join(
-        f"  - {os.path.basename(os.path.dirname(run_folder))}: "
-        f"{', '.join(stores) if stores else '(no control/signal store_ids)'}"
+        f"  - {Path(run_folder).parent.name}: " f"{', '.join(stores) if stores else '(no control/signal store_ids)'}"
         for run_folder, stores in per_member_fibers.items()
     )
     raise ValueError(
@@ -150,14 +149,13 @@ def _clear_group_results(*, group_folder: str) -> None:
     group_folder : str
         Group output directory to clear.
     """
-    for entry in os.listdir(group_folder):
-        if entry == GROUP_MEMBERS_FILENAME:
+    for path in Path(group_folder).iterdir():
+        if path.name == GROUP_MEMBERS_FILENAME:
             continue
-        path = os.path.join(group_folder, entry)
-        if os.path.isdir(path):
+        if path.is_dir():
             shutil.rmtree(path)
         else:
-            os.remove(path)
+            path.unlink()
 
 
 def _filter_stores_list_to_averaged_events(*, store_array: np.ndarray, averaged_events: list[str]) -> np.ndarray:

--- a/src/guppy/orchestration/home.py
+++ b/src/guppy/orchestration/home.py
@@ -1,8 +1,8 @@
 import logging
-import os
 from collections.abc import Callable
 from contextvars import copy_context
 from importlib.metadata import version
+from pathlib import Path
 from threading import Thread
 
 import panel as pn
@@ -45,7 +45,7 @@ def build_homepage(*, start_path: str | None = None) -> pn.template.BootstrapTem
         Fully wired Panel template ready to be served or shown.
     """
     pn.extension(notifications=True)
-    current_dir = os.getcwd()
+    current_dir = str(Path.cwd())
     # Guards against launching a second pipeline step while one is still running — the
     # handlers no longer block the IOLoop, so without this a user could start overlapping
     # runs that clobber the shared progress file and output directories.

--- a/src/guppy/orchestration/import_custom_events.py
+++ b/src/guppy/orchestration/import_custom_events.py
@@ -1,5 +1,5 @@
 import logging
-import os
+from pathlib import Path
 
 import panel as pn
 
@@ -27,7 +27,7 @@ def build_custom_events_template(folder_path: str) -> pn.template.BootstrapTempl
     pn.template.BootstrapTemplate
         Fully configured Panel template ready to be served.
     """
-    template = pn.template.BootstrapTemplate(title=f"Import Custom Events - {os.path.basename(folder_path)}")
+    template = pn.template.BootstrapTemplate(title=f"Import Custom Events - {Path(folder_path).name}")
     config = CustomEventsConfig()
 
     def save_button(event: object = None) -> None:
@@ -58,7 +58,7 @@ def build_custom_events_template(folder_path: str) -> pn.template.BootstrapTempl
             except FileExistsError as exc:
                 config.set_alert_message(f"#### Alert !! \n {exc}")
                 return
-            written.append(os.path.basename(csv_path))
+            written.append(Path(csv_path).name)
 
         if not written:
             config.set_alert_message("#### No events to save — continue to the Label Stores GUI.")
@@ -95,7 +95,7 @@ def build_custom_events_page(inputParameters: dict[str, object], folder_path: st
     """
     custom_events_map = inputParameters.get("custom_events_map")
     if isinstance(custom_events_map, dict):
-        events_for_session = custom_events_map.get(os.path.basename(folder_path), {})
+        events_for_session = custom_events_map.get(Path(folder_path).name, {})
         for name, timestamps in events_for_session.items():
             csv_path = write_custom_event_csv(
                 name=name, timestamps=list(timestamps), folder_path=folder_path, overwrite=True

--- a/src/guppy/orchestration/metadata.py
+++ b/src/guppy/orchestration/metadata.py
@@ -9,6 +9,7 @@ saved YAML is a reusable, hand-editable source of truth for the Step 7 export.
 
 import logging
 import os
+from pathlib import Path
 
 import panel as pn
 
@@ -99,7 +100,7 @@ def build_metadata_template(
         if errors:
             selector.set_alert_message(_format_errors(errors), is_error=True)
             return
-        os.makedirs(os.path.dirname(metadata_yaml_path), exist_ok=True)
+        Path(metadata_yaml_path).parent.mkdir(parents=True, exist_ok=True)
         dump_yaml(metadata=to_save, path=metadata_yaml_path)
         selector.set_path(metadata_yaml_path)
         selector.set_alert_message("#### No alerts !!", is_error=False)
@@ -160,10 +161,10 @@ def build_metadata_templates(*, inputParameters: dict[str, object]) -> list[pn.t
     templates = []
     for session_path, run_name in pairs_needing_metadata:
         guppy_folder_path = run_folder_for_run(session_path, run_name)
-        metadata_yaml_path = os.path.join(guppy_folder_path, METADATA_FILENAME)
-        initial_metadata = load_yaml(metadata_yaml_path) if os.path.exists(metadata_yaml_path) else {}
+        metadata_yaml_path = Path(guppy_folder_path) / METADATA_FILENAME
+        initial_metadata = load_yaml(metadata_yaml_path) if Path(metadata_yaml_path).exists() else {}
         channels = derive_channels(output_dir=guppy_folder_path)
-        session_label = f"{os.path.basename(session_path.rstrip(os.sep))} ({run_name})"
+        session_label = f"{Path(session_path.rstrip(os.sep)).name} ({run_name})"
         acquisition_format, _nwb_source = source_by_session[session_path]
         template = build_metadata_template(
             session_label=session_label,

--- a/src/guppy/orchestration/preprocess.py
+++ b/src/guppy/orchestration/preprocess.py
@@ -1,6 +1,5 @@
-import glob
 import logging
-import os
+from pathlib import Path
 
 import numpy as np
 
@@ -307,7 +306,7 @@ def execute_combine_data(
         session_run_folders = select_run_folders(filepath, selected_runs.get(filepath))
         for j in range(len(session_run_folders)):
             filepath = session_run_folders[j]
-            sampling_rate_filepaths.append(glob.glob(os.path.join(filepath, "timeCorrection_*")))
+            sampling_rate_filepaths.append(list(Path(filepath).glob("timeCorrection_*")))
 
     # check if sampling rate is same for both data
     sampling_rate_filepaths = np.concatenate(sampling_rate_filepaths)

--- a/src/guppy/orchestration/psth.py
+++ b/src/guppy/orchestration/psth.py
@@ -453,7 +453,7 @@ def _validate_events_overlap_signal(inputParameters: dict[str, object]) -> None:
     transient_labels = set(transient_event_labels(inputParameters=inputParameters))
 
     for filepath in resolve_run_folders(inputParameters["session_folders"], inputParameters):
-        store_array = np.genfromtxt(os.path.join(filepath, "storesList.csv"), dtype="str", delimiter=",").reshape(2, -1)
+        store_array = read_stores_list(run_folder=filepath)
         events = [
             event.replace("\\", "_").replace("/", "_")
             for event in event_labels_for_analysis(store_array=store_array, inputParameters=inputParameters)
@@ -464,15 +464,13 @@ def _validate_events_overlap_signal(inputParameters: dict[str, object]) -> None:
 
         # Mirror the worker's site resolution so we validate exactly what will be computed.
         if selectForComputePsth == "z_score":
-            preprocessed_paths = glob.glob(os.path.join(filepath, "z_score_*"))
+            preprocessed_paths = list(Path(filepath).glob("z_score_*"))
         elif selectForComputePsth == "dff":
-            preprocessed_paths = glob.glob(os.path.join(filepath, "dff_*"))
+            preprocessed_paths = list(Path(filepath).glob("dff_*"))
         else:
-            preprocessed_paths = glob.glob(os.path.join(filepath, "z_score_*")) + glob.glob(
-                os.path.join(filepath, "dff_*")
-            )
+            preprocessed_paths = list(Path(filepath).glob("z_score_*")) + list(Path(filepath).glob("dff_*"))
         recording_sites = dict.fromkeys(
-            recording_site_from_preprocessed_label(os.path.basename(path).split(".")[0]) for path in preprocessed_paths
+            recording_site_from_preprocessed_label(path.name.split(".")[0]) for path in preprocessed_paths
         )
 
         for name_1 in recording_sites:

--- a/src/guppy/orchestration/psth.py
+++ b/src/guppy/orchestration/psth.py
@@ -1,9 +1,8 @@
-import glob
 import logging
 import multiprocessing as mp
-import os
 import re
 from itertools import repeat
+from pathlib import Path
 
 import numpy as np
 from scipy import signal as ss
@@ -77,22 +76,22 @@ def execute_compute_psth(filepath: str, event: str, inputParameters: dict[str, o
     timeForLightsTurnOn = inputParameters["timeForLightsTurnOn"]
 
     if selectForComputePsth == "z_score":
-        path = glob.glob(os.path.join(filepath, "z_score_*"))
+        path = list(Path(filepath).glob("z_score_*"))
     elif selectForComputePsth == "dff":
-        path = glob.glob(os.path.join(filepath, "dff_*"))
+        path = list(Path(filepath).glob("dff_*"))
     else:
-        path = glob.glob(os.path.join(filepath, "z_score_*")) + glob.glob(os.path.join(filepath, "dff_*"))
+        path = list(Path(filepath).glob("z_score_*")) + list(Path(filepath).glob("dff_*"))
 
     b = np.divide(np.ones((100,)), 100)
     a = 1
 
     for i in range(len(path)):
         logger.info("Computing PSTH for event %s...", event)
-        basename = (os.path.basename(path[i])).split(".")[0]
+        basename = (Path(path[i]).name).split(".")[0]
         name_1 = recording_site_from_preprocessed_label(basename)
-        control = read_hdf5("control_" + name_1, os.path.dirname(path[i]), "data")
+        control = read_hdf5("control_" + name_1, Path(path[i]).parent, "data")
         if (control == 0).all() == True:
-            signal = read_hdf5("signal_" + name_1, os.path.dirname(path[i]), "data")
+            signal = read_hdf5("signal_" + name_1, Path(path[i]).parent, "data")
             z_score = ss.filtfilt(b, a, signal)
             just_use_signal = True
         else:
@@ -161,15 +160,15 @@ def execute_compute_psth_peak_and_area(filepath: str, event: str, inputParameter
     selectForComputePsth = inputParameters["selectForComputePsth"]
 
     if selectForComputePsth == "z_score":
-        path = glob.glob(os.path.join(filepath, "z_score_*"))
+        path = list(Path(filepath).glob("z_score_*"))
     elif selectForComputePsth == "dff":
-        path = glob.glob(os.path.join(filepath, "dff_*"))
+        path = list(Path(filepath).glob("dff_*"))
     else:
-        path = glob.glob(os.path.join(filepath, "z_score_*")) + glob.glob(os.path.join(filepath, "dff_*"))
+        path = list(Path(filepath).glob("z_score_*")) + list(Path(filepath).glob("dff_*"))
 
     for i in range(len(path)):
         logger.info("Computing peak and area for PSTH mean signal for event %s...", event)
-        basename = (os.path.basename(path[i])).split(".")[0]
+        basename = (Path(path[i]).name).split(".")[0]
         name_1 = recording_site_from_preprocessed_label(basename)
         sampling_rate = read_hdf5("timeCorrection_" + name_1, filepath, "sampling_rate")[0]
         psth = read_Df(filepath, event + "_" + name_1, basename)
@@ -184,7 +183,7 @@ def execute_compute_psth_peak_and_area(filepath: str, event: str, inputParameter
         peak_area = compute_psth_peak_and_area(
             psth_mean_bin_mean, timestamps, sampling_rate, peak_startPoint, peak_endPoint, auc_units=auc_units
         )
-        fileName = [os.path.basename(os.path.dirname(filepath))]
+        fileName = [Path(filepath).parent.name]
         index = [fileName[0] + "_" + name for name in psth_mean_bin_names]
         write_peak_and_area_to_hdf5(filepath, peak_area, event + "_" + name_1 + "_" + basename, index=index)
         write_peak_and_area_to_csv(filepath, peak_area, event + "_" + name_1 + "_" + basename, index=index)

--- a/src/guppy/orchestration/psth_significance.py
+++ b/src/guppy/orchestration/psth_significance.py
@@ -13,6 +13,7 @@ import logging
 import multiprocessing as mp
 import os
 from itertools import repeat
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -102,8 +103,8 @@ def read_psth_samples(
         ``(num_samples, num_timepoints)``, or None when the directory holds no PSTH for
         this combination.
     """
-    psth_path = os.path.join(filepath, f"{event}_{recording_site}_{basename}.h5")
-    if not os.path.exists(psth_path):
+    psth_path = Path(filepath) / (f"{event}_{recording_site}_{basename}.h5")
+    if not Path(psth_path).exists():
         return None
 
     psth = read_Df(filepath, f"{event}_{recording_site}", basename)
@@ -374,7 +375,7 @@ def _report_skipped_comparisons(*, filepath: str, outcomes: list[str | None]) ->
     if len(skipped) > len(named):
         detail += f", and {len(skipped) - len(named)} more"
 
-    folder = os.path.basename(os.path.normpath(filepath))
+    folder = Path(os.path.normpath(filepath)).name
     message = (
         f"PSTH significance skipped {len(skipped)} of {len(outcomes)} comparison(s) in {folder}: "
         f"the bootstrap needs at least {MINIMUM_SAMPLES} trials or sessions to resample. "

--- a/src/guppy/orchestration/save_parameters.py
+++ b/src/guppy/orchestration/save_parameters.py
@@ -1,7 +1,7 @@
 import json
 import logging
-import os
 from importlib.metadata import version
+from pathlib import Path
 
 from guppy.utils.utils import discover_run_folders, select_run_folders
 
@@ -26,11 +26,11 @@ def read_artifact_provenance(*, destination: str) -> tuple[bool, str]:
     artifacts_removal_method : str
         The method recorded for this directory.
     """
-    parameters_path = os.path.join(destination, "GuPPyParamtersUsed.json")
-    if not os.path.exists(parameters_path):
+    parameters_path = Path(destination) / "GuPPyParamtersUsed.json"
+    if not parameters_path.exists():
         return False, DEFAULT_ARTIFACTS_REMOVAL_METHOD
 
-    with open(parameters_path) as parameters_file:
+    with parameters_path.open() as parameters_file:
         parameters = json.load(parameters_file)
     return (
         parameters.get("removeArtifacts", False),
@@ -56,8 +56,8 @@ def record_artifact_provenance(
     artifacts_removal_method : str, optional
         New artifact-removal method. When None, the recorded value is kept.
     """
-    parameters_path = os.path.join(destination, "GuPPyParamtersUsed.json")
-    with open(parameters_path) as parameters_file:
+    parameters_path = Path(destination) / "GuPPyParamtersUsed.json"
+    with parameters_path.open() as parameters_file:
         parameters = json.load(parameters_file)
 
     recorded_removal, recorded_method = read_artifact_provenance(destination=destination)
@@ -66,7 +66,7 @@ def record_artifact_provenance(
         recorded_method if artifacts_removal_method is None else artifacts_removal_method
     )
 
-    with open(parameters_path, "w") as parameters_file:
+    with parameters_path.open("w") as parameters_file:
         json.dump(parameters, parameters_file, indent=4)
     logger.info("Artifact provenance updated at %s", destination)
 
@@ -164,7 +164,7 @@ def write_analysis_parameters(
     destinationParameters["artifactsRemovalMethod"] = (
         recorded_method if artifacts_removal_method is None else artifacts_removal_method
     )
-    with open(os.path.join(destination, "GuPPyParamtersUsed.json"), "w") as parameters_file:
+    with (Path(destination) / "GuPPyParamtersUsed.json").open("w") as parameters_file:
         json.dump(destinationParameters, parameters_file, indent=4)
     logger.info("Input Parameters file saved at %s", destination)
 

--- a/src/guppy/orchestration/store_labeling.py
+++ b/src/guppy/orchestration/store_labeling.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 import shutil
 from pathlib import Path
 
@@ -38,6 +37,15 @@ pn.extension()
 logger = logging.getLogger(__name__)
 
 
+def store_label_cache_path() -> Path:
+    """Path of the cache remembering which store labels each raw store id was given.
+
+    The Label Stores page reads it to pre-fill a store id it has seen before. Resolved
+    on each call rather than at import so ``Path.home()`` is looked up when it is used.
+    """
+    return Path.home() / ".storesList.json"
+
+
 def show_dir(filepath: str, run_name: str | None = None) -> str:
     """Return the path of an output directory without creating it.
 
@@ -63,7 +71,7 @@ def show_dir(filepath: str, run_name: str | None = None) -> str:
     i = 1
     while True:
         run_folder = run_folder_for_run(filepath, str(i))
-        if not os.path.exists(run_folder):
+        if not Path(run_folder).exists():
             break
         i += 1
     return run_folder
@@ -224,7 +232,7 @@ def _save(
         logger.error(detail)
         return alert_message
 
-    if not os.path.exists(os.path.join(Path.home(), ".storesList.json")):
+    if not store_label_cache_path().exists():
         store_id_to_store_labels = dict()
 
         for i in range(store_ids_array.shape[0]):
@@ -234,10 +242,10 @@ def _save(
             else:
                 store_id_to_store_labels[store_ids_array[i]] = [store_labels_array[i]]
 
-        with open(os.path.join(Path.home(), ".storesList.json"), "w") as cache_file:
+        with store_label_cache_path().open("w") as cache_file:
             json.dump(store_id_to_store_labels, cache_file, indent=4)
     else:
-        with open(os.path.join(Path.home(), ".storesList.json")) as cache_file:
+        with store_label_cache_path().open() as cache_file:
             store_id_to_store_labels = json.load(cache_file)
 
         for i in range(store_ids_array.shape[0]):
@@ -247,12 +255,12 @@ def _save(
             else:
                 store_id_to_store_labels[store_ids_array[i]] = [store_labels_array[i]]
 
-        with open(os.path.join(Path.home(), ".storesList.json"), "w") as cache_file:
+        with store_label_cache_path().open("w") as cache_file:
             json.dump(store_id_to_store_labels, cache_file, indent=4)
 
     store_array = np.asarray([store_ids_array, store_labels_array])
     logger.info(store_array)
-    if os.path.exists(select_location):
+    if Path(select_location).exists():
         if overwrite_mode != "over_write_file":
             detail = (
                 f"Output directory already exists: {select_location!r}. "
@@ -263,7 +271,7 @@ def _save(
         # Overwrite mode: clear all derived data from the previous run before saving the new store_array.
         shutil.rmtree(select_location)
         logger.info("Cleared output directory for overwrite: %s", select_location)
-    os.mkdir(select_location)
+    Path(select_location).mkdir()
 
     write_stores_list(run_folder=select_location, store_array=store_array)
     if npm_params is not None:
@@ -312,7 +320,7 @@ def build_store_labeling_template(
     """
     allnames = events
 
-    template = pn.template.BootstrapTemplate(title=f"Label Stores GUI - {os.path.basename(folder_path)}")
+    template = pn.template.BootstrapTemplate(title=f"Label Stores GUI - {Path(folder_path).name}")
 
     if npm_interactive is not None:
         store_labeling_instructions = StoreLabelingInstructionsNPM(
@@ -378,8 +386,8 @@ def build_store_labeling_template(
         store_labeling_selector.set_change_widgets(store_ids)
 
         store_id_to_store_labels = dict()
-        if os.path.exists(os.path.join(Path.home(), ".storesList.json")):
-            with open(os.path.join(Path.home(), ".storesList.json")) as f:
+        if store_label_cache_path().exists():
+            with store_label_cache_path().open() as f:
                 store_id_to_store_labels = json.load(f)
 
         store_labeling_selector.configure_store_ids(store_id_to_store_labels=store_id_to_store_labels)
@@ -399,7 +407,7 @@ def build_store_labeling_template(
             npm_params=npm_params,
         )
         store_labeling_selector.set_alert_message(alert_message)
-        store_labeling_selector.set_path(os.path.join(select_location, "storesList.csv"))
+        store_labeling_selector.set_path(str(Path(select_location) / "storesList.csv"))
 
     # on clicking the NPM "Confirm NPM configuration" button, following function is executed
     def confirm_npm_configuration(event: object = None) -> None:

--- a/src/guppy/orchestration/transients.py
+++ b/src/guppy/orchestration/transients.py
@@ -1,7 +1,6 @@
-import glob
 import logging
 import multiprocessing as mp
-import os
+from pathlib import Path
 
 import numpy as np
 
@@ -64,11 +63,11 @@ def findFreqAndAmp(
     useTransientsAsEvents = inputParameters["useTransientsAsEvents"]
 
     if selectForTransientsComputation == "z_score":
-        path = glob.glob(os.path.join(filepath, "z_score_*"))
+        path = list(Path(filepath).glob("z_score_*"))
     elif selectForTransientsComputation == "dff":
-        path = glob.glob(os.path.join(filepath, "dff_*"))
+        path = list(Path(filepath).glob("dff_*"))
     else:
-        path = glob.glob(os.path.join(filepath, "z_score_*")) + glob.glob(os.path.join(filepath, "dff_*"))
+        path = list(Path(filepath).glob("z_score_*")) + list(Path(filepath).glob("dff_*"))
 
     # Occurrence times per recording site per metric, kept for the binned metrics
     # below; with "Both" selected each site is visited twice, so they are
@@ -76,7 +75,7 @@ def findFreqAndAmp(
     site_to_transient_timestamps = {}
 
     for i in range(len(path)):
-        basename = (os.path.basename(path[i])).split(".")[0]
+        basename = (Path(path[i]).name).split(".")[0]
         name_1 = recording_site_from_preprocessed_label(basename)
         sampling_rate = read_hdf5("timeCorrection_" + name_1, filepath, "sampling_rate")[0]
         z_score = read_hdf5("", path[i], "data")
@@ -84,7 +83,7 @@ def findFreqAndAmp(
         z_score, timestamps, peaksInd, peaks_occurrences, freq_and_amp = analyze_transients(
             timestamps, window, numProcesses, highAmpFilt, transientsThresh, sampling_rate, z_score
         )
-        fileName = [os.path.basename(os.path.dirname(filepath))]
+        fileName = [Path(filepath).parent.name]
         write_freq_and_amp_to_hdf5(
             filepath, freq_and_amp, basename, index=fileName, columns=["freq (events/min)", "amplitude"]
         )

--- a/src/guppy/orchestration/visualize.py
+++ b/src/guppy/orchestration/visualize.py
@@ -1,7 +1,6 @@
-import glob
 import logging
-import os
 import re
+from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -45,7 +44,7 @@ def helper_plots(filepath: str, event: list[str], name: list[str], inputParamete
     inputParameters : dict
         Full pipeline input parameters.
     """
-    basename = os.path.basename(filepath)
+    basename = Path(filepath).name
     visualize_zscore_or_dff = inputParameters["visualize_zscore_or_dff"]
 
     # note when there are no behavior event TTLs
@@ -53,14 +52,14 @@ def helper_plots(filepath: str, event: list[str], name: list[str], inputParamete
         logger.warning("There are no behavior event TTLs present to visualize.")
         return 0
 
-    if os.path.exists(os.path.join(filepath, "cross_correlation_output")):
+    if (Path(filepath) / "cross_correlation_output").exists():
         event_corr, frames = [], []
         if visualize_zscore_or_dff == "z_score":
-            corr_fp = glob.glob(os.path.join(filepath, "cross_correlation_output", "*_z_score_*"))
+            corr_fp = list((Path(filepath) / "cross_correlation_output").glob("*_z_score_*"))
         elif visualize_zscore_or_dff == "dff":
-            corr_fp = glob.glob(os.path.join(filepath, "cross_correlation_output", "*_dff_*"))
+            corr_fp = list((Path(filepath) / "cross_correlation_output").glob("*_dff_*"))
         for i in range(len(corr_fp)):
-            filename = os.path.basename(corr_fp[i]).split(".")[0]
+            filename = Path(corr_fp[i]).name.split(".")[0]
             event_corr.append(filename)
             df = pd.read_hdf(corr_fp[i], key="df", mode="r")
             frames.append(df)
@@ -227,7 +226,7 @@ def _validate_metric_against_step4_outputs(inputParameters: dict[str, object]) -
     else:
         pattern = "*_dff_*.h5"
 
-    missing_sessions = [run_folder for run_folder in run_folders if not glob.glob(os.path.join(run_folder, pattern))]
+    missing_sessions = [run_folder for run_folder in run_folders if not any(Path(run_folder).glob(pattern))]
 
     if missing_sessions:
         other_metric = "dff" if visualize_zscore_or_dff == "z_score" else "z_score"

--- a/src/guppy/testing/api.py
+++ b/src/guppy/testing/api.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import Iterable
+from pathlib import Path
 from typing import Literal
 
 import numpy as np
@@ -59,7 +60,7 @@ def _validate_sessions_under_base_dir(*, abs_sessions: list[str], base_dir: str)
         If a session is missing, is not a directory, or lies outside ``base_dir``.
     """
     for session in abs_sessions:
-        if not os.path.isdir(session):
+        if not Path(session).is_dir():
             raise ValueError(f"Session path does not exist or is not a directory: {session}")
         if os.path.commonpath([base_dir, session]) != base_dir:
             raise ValueError(
@@ -86,7 +87,7 @@ def _normalize_selected_runs(
     normalized: dict[str, list[str]] = {}
     abs_sessions_set = set(abs_sessions)
     for session_key, run_names in selected_runs.items():
-        absolute = os.path.abspath(session_key)
+        absolute = str(Path(session_key).resolve())
         if absolute not in abs_sessions_set:
             raise ValueError(
                 f"{parameter_name} key {session_key!r} is not in selected_folders; "
@@ -357,7 +358,7 @@ def _drive_store_labeling_page(
     _raise_on_alert(selector=selector)
 
     target_run_folder = run_folder_for_run(folder_path, run_name) if run_name is not None else None
-    if run_name_policy == "overwrite" and target_run_folder is not None and os.path.isdir(target_run_folder):
+    if run_name_policy == "overwrite" and target_run_folder is not None and Path(target_run_folder).is_dir():
         selector.overwrite_button.clicked = "over_write_file"
         selector.select_location.value = target_run_folder
     else:
@@ -427,15 +428,15 @@ def step1(
     # Validate base_dir
     if not isinstance(base_dir, str) or not base_dir:
         raise ValueError("base_dir must be a non-empty string")
-    base_dir = os.path.abspath(base_dir)
-    if not os.path.isdir(base_dir):
+    base_dir = str(Path(base_dir).resolve())
+    if not Path(base_dir).is_dir():
         raise ValueError(f"base_dir does not exist or is not a directory: {base_dir}")
 
     # Validate selected_folders
     sessions = list(selected_folders or [])
     if not sessions:
         raise ValueError("selected_folders must be a non-empty iterable of session directories")
-    abs_sessions = [os.path.abspath(session) for session in sessions]
+    abs_sessions = [str(Path(session).resolve()) for session in sessions]
     _validate_sessions_under_base_dir(abs_sessions=abs_sessions, base_dir=base_dir)
 
     # Validate store_id_to_store_label
@@ -559,15 +560,15 @@ def step2(
     # Validate base_dir
     if not isinstance(base_dir, str) or not base_dir:
         raise ValueError("base_dir must be a non-empty string")
-    base_dir = os.path.abspath(base_dir)
-    if not os.path.isdir(base_dir):
+    base_dir = str(Path(base_dir).resolve())
+    if not Path(base_dir).is_dir():
         raise ValueError(f"base_dir does not exist or is not a directory: {base_dir}")
 
     # Validate selected_folders
     sessions = list(selected_folders or [])
     if not sessions:
         raise ValueError("selected_folders must be a non-empty iterable of session directories")
-    abs_sessions = [os.path.abspath(session) for session in sessions]
+    abs_sessions = [str(Path(session).resolve()) for session in sessions]
     _validate_sessions_under_base_dir(abs_sessions=abs_sessions, base_dir=base_dir)
 
     # Headless build: construct the template rooted at base_dir
@@ -650,15 +651,15 @@ def _build_preprocess_input_parameters(
     # Validate base_dir
     if not isinstance(base_dir, str) or not base_dir:
         raise ValueError("base_dir must be a non-empty string")
-    base_dir = os.path.abspath(base_dir)
-    if not os.path.isdir(base_dir):
+    base_dir = str(Path(base_dir).resolve())
+    if not Path(base_dir).is_dir():
         raise ValueError(f"base_dir does not exist or is not a directory: {base_dir}")
 
     # Validate selected_folders
     sessions = list(selected_folders or [])
     if not sessions:
         raise ValueError("selected_folders must be a non-empty iterable of session directories")
-    abs_sessions = [os.path.abspath(session) for session in sessions]
+    abs_sessions = [str(Path(session).resolve()) for session in sessions]
     _validate_sessions_under_base_dir(abs_sessions=abs_sessions, base_dir=base_dir)
 
     # Headless build: construct the template rooted at base_dir
@@ -879,7 +880,7 @@ def tonic_analysis(
     for run_folder in resolve_run_folders(abs_sessions, input_params):
         site_traces = load_site_traces(run_folder)
         for recording_site, epochs in tonic_epochs.items():
-            epochs.to_csv(os.path.join(run_folder, f"tonic_epochs_{recording_site}.csv"), index=False)
+            epochs.to_csv(Path(run_folder) / (f"tonic_epochs_{recording_site}.csv"), index=False)
             trace = site_traces[recording_site]
             write_tonic_to_hdf5(
                 run_folder,
@@ -960,7 +961,7 @@ def select_artifact_windows(
 
     for run_folder in resolve_run_folders(abs_sessions, input_params):
         for recording_site, coords in artifact_coords.items():
-            np.save(os.path.join(run_folder, f"coordsForPreProcessing_{recording_site}.npy"), coords)
+            np.save(Path(run_folder) / (f"coordsForPreProcessing_{recording_site}.npy"), coords)
 
     save_parameters(inputParameters=input_params, artifacts_removal_method=artifact_removal_method)
 
@@ -1125,15 +1126,15 @@ def step4(
     # Validate base_dir
     if not isinstance(base_dir, str) or not base_dir:
         raise ValueError("base_dir must be a non-empty string")
-    base_dir = os.path.abspath(base_dir)
-    if not os.path.isdir(base_dir):
+    base_dir = str(Path(base_dir).resolve())
+    if not Path(base_dir).is_dir():
         raise ValueError(f"base_dir does not exist or is not a directory: {base_dir}")
 
     # Validate selected_folders
     sessions = list(selected_folders or [])
     if not sessions:
         raise ValueError("selected_folders must be a non-empty iterable of session directories")
-    abs_sessions = [os.path.abspath(session) for session in sessions]
+    abs_sessions = [str(Path(session).resolve()) for session in sessions]
     _validate_sessions_under_base_dir(abs_sessions=abs_sessions, base_dir=base_dir)
 
     # Headless build: construct the template rooted at base_dir
@@ -1228,11 +1229,11 @@ def label_groups(
         When the page rejects the group name or member selection (raised from
         the page's alert).
     """
-    destination = os.path.abspath(destination_directory)
+    destination = str(Path(destination_directory).resolve())
     page = build_group_labeling_page(inputParameters={"abspath": destination, "selected_group_folders": []})
     page.group_name.value = group_name
     page.destination_selector.value = [destination]
-    page.members_selector.value = [os.path.abspath(run_folder) for run_folder in member_run_folders]
+    page.members_selector.value = [str(Path(run_folder).resolve()) for run_folder in member_run_folders]
     page.save.clicks += 1
     # The page reports validation failures on its alert instead of raising.
     if page.alert.visible:
@@ -1274,7 +1275,7 @@ def group_analysis(
     """
     template = build_homepage(start_path=base_dir)
 
-    absolute_groups = [os.path.abspath(folder) for folder in selected_group_folders]
+    absolute_groups = [str(Path(folder).resolve()) for folder in selected_group_folders]
     template._widgets["group_folders_selector"].value = absolute_groups
     input_params = template._hooks["getInputParameters"]()
 
@@ -1352,15 +1353,15 @@ def step5(
     # Validate base_dir
     if not isinstance(base_dir, str) or not base_dir:
         raise ValueError("base_dir must be a non-empty string")
-    base_dir = os.path.abspath(base_dir)
-    if not os.path.isdir(base_dir):
+    base_dir = str(Path(base_dir).resolve())
+    if not Path(base_dir).is_dir():
         raise ValueError(f"base_dir does not exist or is not a directory: {base_dir}")
 
     # Validate selected_folders
     sessions = list(selected_folders or [])
     if not sessions:
         raise ValueError("selected_folders must be a non-empty iterable of session directories")
-    abs_sessions = [os.path.abspath(session) for session in sessions]
+    abs_sessions = [str(Path(session).resolve()) for session in sessions]
     _validate_sessions_under_base_dir(abs_sessions=abs_sessions, base_dir=base_dir)
 
     # Headless build: construct the template rooted at base_dir
@@ -1391,7 +1392,7 @@ def step5(
 
     # Groups to visualize alongside the selected session runs
     input_params["selected_group_folders"] = (
-        [os.path.abspath(folder) for folder in selected_group_folders] if selected_group_folders else []
+        [str(Path(folder).resolve()) for folder in selected_group_folders] if selected_group_folders else []
     )
 
     # Per-session output-directory subset filter
@@ -1433,14 +1434,14 @@ def _build_headless_input_parameters(
     """
     if not isinstance(base_dir, str) or not base_dir:
         raise ValueError("base_dir must be a non-empty string")
-    base_dir = os.path.abspath(base_dir)
-    if not os.path.isdir(base_dir):
+    base_dir = str(Path(base_dir).resolve())
+    if not Path(base_dir).is_dir():
         raise ValueError(f"base_dir does not exist or is not a directory: {base_dir}")
 
     sessions = list(selected_folders or [])
     if not sessions:
         raise ValueError("selected_folders must be a non-empty iterable of session directories")
-    abs_sessions = [os.path.abspath(session) for session in sessions]
+    abs_sessions = [str(Path(session).resolve()) for session in sessions]
     _validate_sessions_under_base_dir(abs_sessions=abs_sessions, base_dir=base_dir)
 
     template = build_homepage(start_path=base_dir)

--- a/src/guppy/testing/consistency.py
+++ b/src/guppy/testing/consistency.py
@@ -96,8 +96,8 @@ def compare_output_folders(
         of a shared file does not match. The error message lists every
         discrepancy found.
     """
-    actual_dir = os.path.abspath(actual_dir)
-    expected_dir = os.path.abspath(expected_dir)
+    actual_dir = str(Path(actual_dir).resolve())
+    expected_dir = str(Path(expected_dir).resolve())
     name_map = name_map or {}
 
     expected_files = _collect_relative_paths(expected_dir)
@@ -109,17 +109,17 @@ def compare_output_folders(
             mapped = name_map[rel_path]
             if mapped is None:
                 # Intentionally not reproduced by the current code; its absence is required.
-                if os.path.exists(os.path.join(actual_dir, rel_path)):
+                if (Path(actual_dir) / rel_path).exists():
                     mismatches.append(f"UNEXPECTEDLY PRESENT (mapped to None): {rel_path}")
                 continue
             actual_rel = mapped
         else:
             actual_rel = rel_path
 
-        actual_path = os.path.join(actual_dir, actual_rel)
-        expected_path = os.path.join(expected_dir, rel_path)
+        actual_path = Path(actual_dir) / actual_rel
+        expected_path = Path(expected_dir) / rel_path
 
-        if not os.path.exists(actual_path):
+        if not Path(actual_path).exists():
             detail = actual_rel if actual_rel == rel_path else f"{actual_rel} (mapped from {rel_path})"
             mismatches.append(f"MISSING in actual: {detail}")
             continue
@@ -212,7 +212,7 @@ def _collect_relative_paths(root: str) -> list[str]:
         # Prune skipped directories in-place so os.walk does not descend into them.
         dirnames[:] = [dirname for dirname in dirnames if dirname not in _SKIP_DIRS]
         for filename in filenames:
-            full_path = os.path.join(dirpath, filename)
+            full_path = Path(dirpath) / filename
             result.append(os.path.relpath(full_path, root))
     return result
 
@@ -401,9 +401,9 @@ def _compare_json(
     mismatches: list[str],
 ) -> None:
     """Compare two JSON files with NaN-safe value comparison."""
-    with open(actual_path) as actual_file:
+    with Path(actual_path).open() as actual_file:
         actual_data = json.load(actual_file)
-    with open(expected_path) as expected_file:
+    with Path(expected_path).open() as expected_file:
         expected_data = json.load(expected_file)
 
     json_mismatches: list[str] = []

--- a/src/guppy/testing/covariate_session.py
+++ b/src/guppy/testing/covariate_session.py
@@ -6,8 +6,6 @@ tests and the documentation screenshot script need the same four steps run again
 with the same store labels and bin width, so that run lives here.
 """
 
-import glob
-import os
 import shutil
 from pathlib import Path
 
@@ -31,11 +29,11 @@ STORE_ID_TO_STORE_LABEL = {
 
 def locate_output_directory(*, session: str) -> str:
     """Return the run folder Step 1 created inside ``session``."""
-    candidates = sorted(glob.glob(os.path.join(session, f"{os.path.basename(session)}_output_*")))
+    candidates = sorted(Path(session).glob(f"{Path(session).name}_output_*"))
     assert candidates, f"no output directory was created in {session}"
     for candidate in candidates:
-        if os.path.exists(os.path.join(candidate, "storesList.csv")):
-            return candidate
+        if (candidate / "storesList.csv").exists():
+            return str(candidate)
     raise AssertionError(f"no output directory in {session} contains storesList.csv")
 
 

--- a/src/guppy/utils/utils.py
+++ b/src/guppy/utils/utils.py
@@ -173,7 +173,7 @@ def parse_run_name(run_folder: str) -> str:
     """
     # Strip both separators so trailing forward slashes are tolerated on Windows
     # (where os.sep is "\\" but paths can still use "/").
-    basename = Path(run_folder.rstrip("/\\")).name
+    basename = Path(str(run_folder).rstrip("/\\")).name
     index = basename.rfind(_RUN_NAME_MARKER)
     if index < 0:
         raise ValueError(
@@ -219,7 +219,7 @@ def run_folder_for_run(session_path: str, run_name: str) -> str:
     str
         Path of the form ``<session_path>/<basename>_output_<run_name>``.
     """
-    basename = Path(session_path.rstrip(os.sep)).name
+    basename = Path(str(session_path).rstrip(os.sep)).name
     return str(Path(session_path) / (basename + _RUN_NAME_MARKER + run_name))
 
 
@@ -346,7 +346,7 @@ def parse_group_name(group_folder: str) -> str:
     ValueError
         If the basename does not match the expected pattern.
     """
-    basename = Path(group_folder.rstrip("/\\")).name
+    basename = Path(str(group_folder).rstrip("/\\")).name
     if not basename.endswith(_GROUP_NAME_MARKER) or basename == _GROUP_NAME_MARKER:
         raise ValueError(
             f"Cannot parse group name from {group_folder!r}: basename {basename!r} does not match "
@@ -387,7 +387,7 @@ def is_group_folder(path: str) -> bool:
         ``True`` when the basename ends with ``_group`` and is not itself a run
         folder (a run named ``group`` would otherwise match both).
     """
-    basename = Path(path.rstrip("/\\")).name
+    basename = Path(str(path).rstrip("/\\")).name
     if _RUN_NAME_MARKER in basename:
         return False
     return basename.endswith(_GROUP_NAME_MARKER) and basename != _GROUP_NAME_MARKER

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,35 +32,27 @@ def pytest_configure(config: pytest.Config) -> None:
         os.environ.setdefault("COVERAGE_PROCESS_START", str(PYPROJECT_PATH))
 
 
-class FakeHomePath:
-    """``pathlib.Path`` stand-in whose ``home()`` returns a test-controlled directory."""
-
-    _home: Path | None = None
-
-    @classmethod
-    def home(cls) -> Path:
-        return cls._home
-
-
 @pytest.fixture(scope="session", autouse=True)
 def _stores_cache_home_patch(tmp_path_factory: pytest.TempPathFactory):
     """Redirect the Step-1 store-labels cache (``~/.storesList.json``) away from the real home.
 
     Session-scoped so it is live before the session-scoped ``step1_output_*`` integration
     fixtures drive the store-labeling save, which writes the cache via
-    ``guppy.orchestration.store_labeling.Path.home()``.
+    ``store_label_cache_path()``.
     """
-    FakeHomePath._home = tmp_path_factory.mktemp("stores_cache_home")
+    home = tmp_path_factory.mktemp("stores_cache_home")
     patcher = pytest.MonkeyPatch()
-    patcher.setattr("guppy.orchestration.store_labeling.Path", FakeHomePath)
+    patcher.setattr("guppy.orchestration.store_labeling.store_label_cache_path", lambda: home / ".storesList.json")
     yield
     patcher.undo()
 
 
 @pytest.fixture(autouse=True)
-def isolated_stores_cache(tmp_path: Path) -> Path:
+def isolated_stores_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Give each test its own store-labels cache directory so state never leaks across tests."""
-    FakeHomePath._home = tmp_path
+    monkeypatch.setattr(
+        "guppy.orchestration.store_labeling.store_label_cache_path", lambda: tmp_path / ".storesList.json"
+    )
     return tmp_path
 
 

--- a/tests/unit/orchestration/test_export_nwb.py
+++ b/tests/unit/orchestration/test_export_nwb.py
@@ -161,7 +161,7 @@ class TestWarnPsthSignificanceNotExported:
         orchestrate_export_nwb({"selected_runs": {str(session): ["run1"]}, "combine_data": False})
 
         assert [call["nwbfile_path"] for call in exported] == [
-            str(session / "Photo_A_output_run1" / "Photo_A_output_run1.nwb")
+            session / "Photo_A_output_run1" / "Photo_A_output_run1.nwb"
         ]
         assert bound_step.error_message is None
         assert len(bound_step.warnings) == 1
@@ -227,8 +227,8 @@ class TestOrchestrateExportNwb:
         orchestrate_export_nwb(two_sessions)
 
         assert [call["nwbfile_path"] for call in exported] == [
-            str(tmp_path / "Photo_A" / "Photo_A_output_run1" / "Photo_A_output_run1.nwb"),
-            str(tmp_path / "Photo_B" / "Photo_B_output_run1" / "Photo_B_output_run1.nwb"),
+            tmp_path / "Photo_A" / "Photo_A_output_run1" / "Photo_A_output_run1.nwb",
+            tmp_path / "Photo_B" / "Photo_B_output_run1" / "Photo_B_output_run1.nwb",
         ]
         assert bound_step.total == 2
         assert bound_step.value == 2
@@ -238,7 +238,7 @@ class TestOrchestrateExportNwb:
         exported = []
 
         def export(**kwargs):
-            if "Photo_B" in kwargs["nwbfile_path"]:
+            if "Photo_B" in str(kwargs["nwbfile_path"]):
                 raise RuntimeError("converter blew up")
             exported.append(kwargs["nwbfile_path"])
 
@@ -247,7 +247,7 @@ class TestOrchestrateExportNwb:
         # One failure must not abort the batch.
         orchestrate_export_nwb(two_sessions)
 
-        assert exported == [str(tmp_path / "Photo_A" / "Photo_A_output_run1" / "Photo_A_output_run1.nwb")]
+        assert exported == [tmp_path / "Photo_A" / "Photo_A_output_run1" / "Photo_A_output_run1.nwb"]
         # Progress still advances past the failed session, so the bar reaches its total.
         assert bound_step.value == 2
         assert bound_step.error_message == "NWB export failed for 1 of 2 session(s): Photo_B (run1): converter blew up"
@@ -258,8 +258,8 @@ class TestOrchestrateExportNwb:
         orchestrate_export_nwb(two_sessions)
 
         assert [call["nwbfile_path"] for call in exported] == [
-            str(tmp_path / "Photo_A" / "Photo_A_output_run1" / "Photo_A_output_run1.nwb"),
-            str(tmp_path / "Photo_B" / "Photo_B_output_run1" / "Photo_B_output_run1.nwb"),
+            tmp_path / "Photo_A" / "Photo_A_output_run1" / "Photo_A_output_run1.nwb",
+            tmp_path / "Photo_B" / "Photo_B_output_run1" / "Photo_B_output_run1.nwb",
         ]
 
 

--- a/tests/unit/orchestration/test_preprocess.py
+++ b/tests/unit/orchestration/test_preprocess.py
@@ -28,30 +28,22 @@ def test_execute_zscore_raises_for_mismatched_recording_sites(tmp_path, base_inp
     assert "vms" in message
 
 
-def test_execute_combine_data_raises_for_mismatched_sampling_rates(monkeypatch, base_input_parameters):
+def test_execute_combine_data_raises_for_mismatched_sampling_rates(tmp_path, monkeypatch, base_input_parameters):
     """When timeCorrection_*.hdf5 files report different sampling rates, the message
     lists both rates and the offending paths."""
-    folder_names = ["/tmp/session_a", "/tmp/session_b"]
     store_array = np.array([["ctrl0", "sig0"], ["control_dms", "signal_dms"]])
 
-    monkeypatch.setattr(
-        "guppy.orchestration.preprocess.select_run_folders",
-        lambda session, selected: (
-            [folder_names[0] + "/run_folder"] if "session_a" in session else [folder_names[1] + "/run_folder"]
-        ),
-    )
-    monkeypatch.setattr(
-        "guppy.orchestration.preprocess.glob.glob",
-        lambda pattern: (
-            [f"{folder_names[0]}/run_folder/timeCorrection_dms.hdf5"]
-            if "session_a" in pattern
-            else [f"{folder_names[1]}/run_folder/timeCorrection_dms.hdf5"] if "session_b" in pattern else []
-        ),
-    )
+    folder_names = []
+    for session_name in ("session_a", "session_b"):
+        run_folder = tmp_path / session_name / f"{session_name}_output_1"
+        run_folder.mkdir(parents=True)
+        (run_folder / "timeCorrection_dms.hdf5").touch()
+        (run_folder / "storesList.csv").write_text("ctrl0,sig0\ncontrol_dms,signal_dms\n")
+        folder_names.append(str(tmp_path / session_name))
+    base_input_parameters["selected_runs"] = {session: ["1"] for session in folder_names}
 
     rates = iter([np.array([100.0]), np.array([250.0])])
     monkeypatch.setattr("guppy.orchestration.preprocess.read_hdf5", lambda *a, **k: next(rates))
-    monkeypatch.setattr("guppy.orchestration.preprocess.np.genfromtxt", lambda *a, **k: store_array)
 
     with pytest.raises(ValueError, match="sampling rates differ"):
         execute_combine_data(folder_names, base_input_parameters, store_array)

--- a/tests/unit/orchestration/test_store_labeling.py
+++ b/tests/unit/orchestration/test_store_labeling.py
@@ -30,21 +30,12 @@ def make_widget(value):
     return types.SimpleNamespace(value=value)
 
 
-class FakePath:
-    """Replaces pathlib.Path in store_ids so cache writes go to tmp_path."""
-
-    _home = None
-
-    @classmethod
-    def home(cls):
-        return cls._home
-
-
 @pytest.fixture
 def isolated_cache(tmp_path, monkeypatch):
-    """Redirect Path.home() to tmp_path so _save never touches ~/.storesList.json."""
-    FakePath._home = tmp_path
-    monkeypatch.setattr("guppy.orchestration.store_labeling.Path", FakePath)
+    """Redirect the store-label cache to tmp_path so _save never touches ~/.storesList.json."""
+    monkeypatch.setattr(
+        "guppy.orchestration.store_labeling.store_label_cache_path", lambda: tmp_path / ".storesList.json"
+    )
     return tmp_path
 
 
@@ -620,8 +611,9 @@ def store_labeling_closures(tmp_path, monkeypatch, panel_extension):
 
     selector.callbacks maps button names to their on-click closure functions.
     """
-    FakePath._home = tmp_path
-    monkeypatch.setattr("guppy.orchestration.store_labeling.Path", FakePath)
+    monkeypatch.setattr(
+        "guppy.orchestration.store_labeling.store_label_cache_path", lambda: tmp_path / ".storesList.json"
+    )
 
     folder = tmp_path / "my_session"
     folder.mkdir()


### PR DESCRIPTION
<!-- summary line goes here -->

<details>
<summary>Details (AI-generated)</summary>

Sixth of the #478 stack. Stacked on #487 → #486 → #485 → #484 → #483 → #482 → #481 → #480 — review the last commit.

Converts `src/guppy/orchestration/` and `src/guppy/testing/`, 139 findings. After this **`src/` is done** — the only entry left in the `PTH` ignore list is `"tests/*"`.

Three changes go beyond swapping a call:

- `store_labeling` gains `store_label_cache_path()`, naming the `~/.storesList.json` cache that four call sites were rebuilding inline. Deliberately a function rather than a module constant, so `Path.home()` is still resolved when it is used.
- `group_analysis` clears a group folder with `Path.iterdir()` instead of `os.listdir` plus a rejoin.
- `export_session_to_nwb` takes and returns `nwbfile_path` as a `Path`.

`parse_run_name`, `run_folder_for_run`, `parse_group_name` and `is_group_folder` now normalize with `str()` before stripping trailing separators. They are handed both `str` (from `inputParameters`) and `Path` (from `Path.glob`) now that their callers are converted, and the integration suite caught the `AttributeError` when only one of the two worked.

Two test changes that are improvements rather than adjustments:

- The store-label cache is redirected by patching `store_label_cache_path` rather than substituting a fake class for `pathlib.Path` in the module. The fake only implemented `home()`, so it broke as soon as the module used `Path` for anything else — and patching `Path.home` globally instead silently redirected `default_root_path()` too, which broke an unrelated `test_app` assertion.
- `test_execute_combine_data_raises_for_mismatched_sampling_rates` builds real run folders under `tmp_path` instead of patching `glob.glob` over hardcoded `/tmp` paths. That drops two monkeypatches.

Unit suite (2248) and integration suite (189) both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>
