### PR TITLE
Migrate the tests to pathlib and empty the PTH ignore list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed the README's documentation links, which all carried an `/en/latest/` path prefix that 404s on the single-version Read the Docs project. [PR #469](https://github.com/LernerLab/GuPPy/pull/469)
 
 ## Improvements
+- The test suite now builds paths with `pathlib.Path`, completing the `os.path`/`glob` migration and leaving `ruff`'s `PTH` rules enforced everywhere with no exemptions. [PR #490](https://github.com/LernerLab/GuPPy/pull/490)
 - The pipeline's step orchestration now builds paths with `pathlib.Path`, completing the migration across `src/`. [PR #488](https://github.com/LernerLab/GuPPy/pull/488)
 - GuPPy's run-folder and group-folder helpers and the parameter, DANDI and group-labeling selectors now build paths with `pathlib.Path`. [PR #487](https://github.com/LernerLab/GuPPy/pull/487)
 - The Step-5 dashboard tabs, artifact-window and tonic pages, and the plotter now build paths with `pathlib.Path`. [PR #486](https://github.com/LernerLab/GuPPy/pull/486)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,11 +149,6 @@ fixable = ["ALL"]
 "**conftest.py" = ["D1", "ANN", "RUF012"] # conftest.py is test infrastructure; same exemption as test files.
 "**recording_extractor_test_mixin.py" = ["D1", "ANN", "RUF012"] # shared test mixin; test infrastructure, same exemption as test files.
 
-# The pathlib migration (#478) runs module by module. Every entry below is a module that
-# still uses os.path/glob; each migration PR deletes the entries it converts, so what is
-# left here is the remaining work rather than a permanent exemption.
-"tests/*" = ["PTH"]
-
 [tool.ruff.lint.isort]
 relative-imports-order = "closest-to-furthest"
 known-first-party = ["guppy", "guppy_test_data"]

--- a/tests/consistency/test_consistency_artifact_removal.py
+++ b/tests/consistency/test_consistency_artifact_removal.py
@@ -1,6 +1,5 @@
-import glob
-import os
 import shutil
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -97,7 +96,7 @@ def test_consistency(
     session_copy = tmp_base / dest_name
     shutil.copytree(src_session, session_copy)
 
-    for d in glob.glob(os.path.join(session_copy, f"{dest_name}_output_*")):
+    for d in list(Path(session_copy).glob(f"{dest_name}_output_*")):
         shutil.rmtree(d)
     params_fp = session_copy / "GuPPyParamtersUsed.json"
     if params_fp.exists():
@@ -122,7 +121,7 @@ def test_consistency(
     remove_artifacts(**common_kwargs, control_fit_method="OLS", selected_runs=selected_runs)
     step4(**common_kwargs, selected_runs=selected_runs)
 
-    run_folders = sorted(glob.glob(os.path.join(session_copy, f"{dest_name}_output_*")))
+    run_folders = sorted(list(Path(session_copy).glob(f"{dest_name}_output_*")))
     assert run_folders, f"No output directory found under {session_copy}"
     actual_output_dir = run_folders[0]
 

--- a/tests/consistency/test_consistency_combined_data.py
+++ b/tests/consistency/test_consistency_combined_data.py
@@ -1,6 +1,5 @@
-import glob
-import os
 import shutil
+from pathlib import Path
 
 import pytest
 
@@ -51,7 +50,7 @@ def test_consistency(tmp_path):
         dest_name = src.name
         session_copy = tmp_base / dest_name
         shutil.copytree(src, session_copy)
-        for d in glob.glob(os.path.join(session_copy, f"{dest_name}_output_*")):
+        for d in list(Path(session_copy).glob(f"{dest_name}_output_*")):
             shutil.rmtree(d)
         params_fp = session_copy / "GuPPyParamtersUsed.json"
         if params_fp.exists():
@@ -79,7 +78,7 @@ def test_consistency(tmp_path):
 
     for session_copy, standard_output_dir in zip(session_copies, standard_output_dirs, strict=True):
         dest_name = session_copy.name
-        run_folders = sorted(glob.glob(os.path.join(session_copy, f"{dest_name}_output_*")))
+        run_folders = sorted(list(Path(session_copy).glob(f"{dest_name}_output_*")))
         assert run_folders, f"No output directory found under {session_copy}"
         actual_output_dir = run_folders[0]
 

--- a/tests/consistency/test_consistency_csv.py
+++ b/tests/consistency/test_consistency_csv.py
@@ -1,6 +1,5 @@
-import glob
-import os
 import shutil
+from pathlib import Path
 
 import pytest
 
@@ -52,7 +51,7 @@ def test_consistency(
     session_copy = tmp_base / dest_name
     shutil.copytree(src_session, session_copy)
 
-    for d in glob.glob(os.path.join(session_copy, f"{dest_name}_output_*")):
+    for d in list(Path(session_copy).glob(f"{dest_name}_output_*")):
         shutil.rmtree(d)
     params_fp = session_copy / "GuPPyParamtersUsed.json"
     if params_fp.exists():
@@ -69,7 +68,7 @@ def test_consistency(
     step3(**common_kwargs, control_fit_method="OLS", selected_runs=selected_runs)
     step4(**common_kwargs, selected_runs=selected_runs)
 
-    run_folders = sorted(glob.glob(os.path.join(session_copy, f"{dest_name}_output_*")))
+    run_folders = sorted(list(Path(session_copy).glob(f"{dest_name}_output_*")))
     assert run_folders, f"No output directory found under {session_copy}"
     actual_output_dir = run_folders[0]
 

--- a/tests/consistency/test_consistency_dff.py
+++ b/tests/consistency/test_consistency_dff.py
@@ -1,6 +1,5 @@
-import glob
-import os
 import shutil
+from pathlib import Path
 
 import pytest
 
@@ -38,7 +37,7 @@ def test_consistency_dff(tmp_path):
     session_copy = tmp_base / dest_name
     shutil.copytree(src_session, session_copy)
 
-    for d in glob.glob(os.path.join(session_copy, f"{dest_name}_output_*")):
+    for d in list(Path(session_copy).glob(f"{dest_name}_output_*")):
         shutil.rmtree(d)
     params_fp = session_copy / "GuPPyParamtersUsed.json"
     if params_fp.exists():
@@ -55,7 +54,7 @@ def test_consistency_dff(tmp_path):
     step3(**common_kwargs, control_fit_method="OLS", selected_runs=selected_runs)
     step4(**common_kwargs, select_for_compute_psth="dff", select_for_transients="dff", selected_runs=selected_runs)
 
-    run_folders = sorted(glob.glob(os.path.join(session_copy, f"{dest_name}_output_*")))
+    run_folders = sorted(list(Path(session_copy).glob(f"{dest_name}_output_*")))
     assert run_folders, f"No output directory found under {session_copy}"
     actual_output_dir = run_folders[0]
 

--- a/tests/consistency/test_consistency_doric.py
+++ b/tests/consistency/test_consistency_doric.py
@@ -1,6 +1,5 @@
-import glob
-import os
 import shutil
+from pathlib import Path
 
 import pytest
 
@@ -103,7 +102,7 @@ def test_consistency(
     session_copy = tmp_base / dest_name
     shutil.copytree(src_session, session_copy)
 
-    for d in glob.glob(os.path.join(session_copy, f"{dest_name}_output_*")):
+    for d in list(Path(session_copy).glob(f"{dest_name}_output_*")):
         shutil.rmtree(d)
     params_fp = session_copy / "GuPPyParamtersUsed.json"
     if params_fp.exists():
@@ -125,7 +124,7 @@ def test_consistency(
     )
     step4(**common_kwargs, selected_runs=selected_runs, time_for_lights_turn_on=time_for_lights_turn_on)
 
-    run_folders = sorted(glob.glob(os.path.join(session_copy, f"{dest_name}_output_*")))
+    run_folders = sorted(list(Path(session_copy).glob(f"{dest_name}_output_*")))
     assert run_folders, f"No output directory found under {session_copy}"
     actual_output_dir = run_folders[0]
 

--- a/tests/consistency/test_consistency_group_analysis.py
+++ b/tests/consistency/test_consistency_group_analysis.py
@@ -1,6 +1,5 @@
-import glob
-import os
 import shutil
+from pathlib import Path
 
 import pytest
 
@@ -50,7 +49,7 @@ def test_consistency_group_analysis(tmp_path):
         dest_name = src.name
         session_copy = tmp_base / dest_name
         shutil.copytree(src, session_copy)
-        for d in glob.glob(os.path.join(session_copy, f"{dest_name}_output_*")):
+        for d in list(Path(session_copy).glob(f"{dest_name}_output_*")):
             shutil.rmtree(d)
         params_fp = session_copy / "GuPPyParamtersUsed.json"
         if params_fp.exists():
@@ -71,16 +70,14 @@ def test_consistency_group_analysis(tmp_path):
     step4(**common_kwargs, selected_runs=selected_runs)
 
     label_groups(
-        member_run_folders=[
-            os.path.join(folder, f"{os.path.basename(folder)}_output_1") for folder in selected_folders
-        ],
+        member_run_folders=[Path(folder) / (f"{Path(folder).name}_output_1") for folder in selected_folders],
         destination_directory=str(tmp_base),
         group_name="consistency",
     )
     group_analysis(base_dir=str(tmp_base), selected_group_folders=[str(tmp_base / "consistency_group")])
 
     actual_output_dir = str(tmp_base / "consistency_group")
-    assert os.path.isdir(actual_output_dir), f"No group directory found under {tmp_base}"
+    assert Path(actual_output_dir).is_dir(), f"No group directory found under {tmp_base}"
 
     compare_output_folders(
         actual_dir=actual_output_dir,

--- a/tests/consistency/test_consistency_no_isosbestic.py
+++ b/tests/consistency/test_consistency_no_isosbestic.py
@@ -1,6 +1,5 @@
-import glob
-import os
 import shutil
+from pathlib import Path
 
 import pytest
 
@@ -40,7 +39,7 @@ def test_consistency_no_isosbestic(tmp_path):
     session_copy = tmp_base / dest_name
     shutil.copytree(src_session, session_copy)
 
-    for d in glob.glob(os.path.join(session_copy, f"{dest_name}_output_*")):
+    for d in list(Path(session_copy).glob(f"{dest_name}_output_*")):
         shutil.rmtree(d)
     params_fp = session_copy / "GuPPyParamtersUsed.json"
     if params_fp.exists():
@@ -57,7 +56,7 @@ def test_consistency_no_isosbestic(tmp_path):
     step3(**common_kwargs, isosbestic_control=False, control_fit_method="OLS", selected_runs=selected_runs)
     step4(**common_kwargs, selected_runs=selected_runs)
 
-    run_folders = sorted(glob.glob(os.path.join(session_copy, f"{dest_name}_output_*")))
+    run_folders = sorted(list(Path(session_copy).glob(f"{dest_name}_output_*")))
     assert run_folders, f"No output directory found under {session_copy}"
     actual_output_dir = run_folders[0]
 

--- a/tests/consistency/test_consistency_npm.py
+++ b/tests/consistency/test_consistency_npm.py
@@ -1,6 +1,5 @@
-import glob
-import os
 import shutil
+from pathlib import Path
 
 import pytest
 
@@ -94,7 +93,7 @@ def test_consistency(
     session_copy = tmp_base / dest_name
     shutil.copytree(src_session, session_copy)
 
-    for d in glob.glob(os.path.join(session_copy, f"{dest_name}_output_*")):
+    for d in list(Path(session_copy).glob(f"{dest_name}_output_*")):
         shutil.rmtree(d)
     params_fp = session_copy / "GuPPyParamtersUsed.json"
     if params_fp.exists():
@@ -111,7 +110,7 @@ def test_consistency(
     step3(**common_kwargs, control_fit_method="OLS", selected_runs=selected_runs, **extra_kwargs)
     step4(**common_kwargs, selected_runs=selected_runs, **extra_kwargs)
 
-    run_folders = sorted(glob.glob(os.path.join(session_copy, f"{dest_name}_output_*")))
+    run_folders = sorted(list(Path(session_copy).glob(f"{dest_name}_output_*")))
     assert run_folders, f"No output directory found under {session_copy}"
     actual_output_dir = run_folders[0]
 

--- a/tests/consistency/test_consistency_tdt.py
+++ b/tests/consistency/test_consistency_tdt.py
@@ -1,6 +1,5 @@
-import glob
-import os
 import shutil
+from pathlib import Path
 
 import pytest
 
@@ -73,7 +72,7 @@ def test_consistency(
     session_copy = tmp_base / dest_name
     shutil.copytree(src_session, session_copy)
 
-    for d in glob.glob(os.path.join(session_copy, f"{dest_name}_output_*")):
+    for d in list(Path(session_copy).glob(f"{dest_name}_output_*")):
         shutil.rmtree(d)
     params_fp = session_copy / "GuPPyParamtersUsed.json"
     if params_fp.exists():
@@ -90,7 +89,7 @@ def test_consistency(
     step3(**common_kwargs, control_fit_method="OLS", selected_runs=selected_runs)
     step4(**common_kwargs, selected_runs=selected_runs)
 
-    run_folders = sorted(glob.glob(os.path.join(session_copy, f"{dest_name}_output_*")))
+    run_folders = sorted(list(Path(session_copy).glob(f"{dest_name}_output_*")))
     assert run_folders, f"No output directory found under {session_copy}"
     actual_output_dir = run_folders[0]
 

--- a/tests/consistency/test_consistency_zscore_method.py
+++ b/tests/consistency/test_consistency_zscore_method.py
@@ -1,6 +1,5 @@
-import glob
-import os
 import shutil
+from pathlib import Path
 
 import pytest
 
@@ -57,7 +56,7 @@ def test_consistency_zscore_method(
     session_copy = tmp_base / dest_name
     shutil.copytree(src_session, session_copy)
 
-    for d in glob.glob(os.path.join(session_copy, f"{dest_name}_output_*")):
+    for d in list(Path(session_copy).glob(f"{dest_name}_output_*")):
         shutil.rmtree(d)
     params_fp = session_copy / "GuPPyParamtersUsed.json"
     if params_fp.exists():
@@ -74,7 +73,7 @@ def test_consistency_zscore_method(
     step3(**common_kwargs, control_fit_method="OLS", selected_runs=selected_runs, **step3_extra_kwargs)
     step4(**common_kwargs, selected_runs=selected_runs)
 
-    run_folders = sorted(glob.glob(os.path.join(session_copy, f"{dest_name}_output_*")))
+    run_folders = sorted(list(Path(session_copy).glob(f"{dest_name}_output_*")))
     assert run_folders, f"No output directory found under {session_copy}"
     actual_output_dir = run_folders[0]
 

--- a/tests/guppy_test_data.py
+++ b/tests/guppy_test_data.py
@@ -36,7 +36,7 @@ def event_ts_offset_for(base_dir: str | Path) -> float:
     """
     matches = sorted(Path(base_dir).rglob("GuPPyParamtersUsed.json"))
     assert matches, f"No GuPPyParamtersUsed.json found under {base_dir}"
-    with open(matches[0]) as params_file:
+    with Path(matches[0]).open() as params_file:
         time_for_lights_turn_on = json.load(params_file)["timeForLightsTurnOn"]
 
     return recording_start_for(base_dir) + time_for_lights_turn_on

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,6 +1,5 @@
-import glob
-import os
 import shutil
+from pathlib import Path
 from unittest.mock import patch
 
 import holoviews as hv
@@ -18,17 +17,17 @@ def _prepare_pipeline_state(
     *, tmp_path_factory: pytest.TempPathFactory, modality: str
 ) -> dict[str, str | list[bool] | None]:
     representative_config = REPRESENTATIVE_SESSIONS[modality]
-    source_session = os.path.join(str(STUBBED_TESTING_DATA), representative_config["session_subdir"])
-    assert os.path.isdir(source_session), f"Sample data not available at expected path: {source_session}"
+    source_session = Path(str(STUBBED_TESTING_DATA)) / representative_config["session_subdir"]
+    assert Path(source_session).is_dir(), f"Sample data not available at expected path: {source_session}"
 
     temporary_base_directory = tmp_path_factory.mktemp(f"integration_{modality}")
-    session_name = os.path.basename(source_session)
+    session_name = Path(source_session).name
     session_copy_path = temporary_base_directory / session_name
     shutil.copytree(source_session, session_copy_path)
 
-    for output_directory in glob.glob(os.path.join(session_copy_path, f"{session_name}_output_*")):
-        assert os.path.isdir(
-            output_directory
+    for output_directory in list(Path(session_copy_path).glob(f"{session_name}_output_*")):
+        assert (
+            output_directory.is_dir()
         ), f"Expected output directory for cleanup, got non-directory: {output_directory}"
         shutil.rmtree(output_directory)
 

--- a/tests/integration/integration_helpers.py
+++ b/tests/integration/integration_helpers.py
@@ -5,8 +5,6 @@ at import time (``test_integration_step2.py``, ``test_integration_dandi.py``) ca
 directly via a package-relative import, instead of relying on the ambiguous bare ``conftest`` name.
 """
 
-import glob
-import os
 from datetime import datetime
 from pathlib import Path
 
@@ -108,12 +106,12 @@ REPRESENTATIVE_SESSIONS = {
 
 
 def _locate_output_directory(*, session_copy: str) -> str:
-    session_name = os.path.basename(session_copy)
-    output_directories = sorted(glob.glob(os.path.join(session_copy, f"{session_name}_output_*")))
+    session_name = Path(session_copy).name
+    output_directories = sorted(list(Path(session_copy).glob(f"{session_name}_output_*")))
     assert output_directories, f"No output directories found in {session_copy}"
 
     for output_directory in output_directories:
-        if os.path.exists(os.path.join(output_directory, "storesList.csv")):
+        if (Path(output_directory) / "storesList.csv").exists():
             return output_directory
 
     raise AssertionError(f"No storesList.csv found in any output directory under {session_copy}")

--- a/tests/integration/test_baseline_epoch_fit.py
+++ b/tests/integration/test_baseline_epoch_fit.py
@@ -8,8 +8,7 @@ relationship and preserves the step in dF/F. One test also enables artifact remo
 chunking x baseline-epoch interaction is exercised through the real pipeline.
 """
 
-import glob
-import os
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -36,11 +35,11 @@ FIT_WINDOW = (2, 55)  # pre-injection; starts after timeForLightsTurnOn trims t 
 
 
 def _stubbed_data_root():
-    return os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "stubbed_testing_data")
+    return Path((Path(__file__).parent).parent.parent) / "stubbed_testing_data"
 
 
 def _output_directory(session):
-    return sorted(glob.glob(os.path.join(session, f"{SESSION_NAME}_output_*")))[0]
+    return sorted(list(Path(session).glob(f"{SESSION_NAME}_output_*")))[0]
 
 
 @pytest.fixture
@@ -48,9 +47,9 @@ def injection_session(tmp_path):
     """Copy the injection session and run step1 + step2; return locators for step3."""
     import shutil
 
-    source = os.path.join(_stubbed_data_root(), SESSION_SUBDIR)
+    source = Path(_stubbed_data_root()) / SESSION_SUBDIR
     base_dir = str(tmp_path)
-    session = os.path.join(base_dir, SESSION_NAME)
+    session = Path(base_dir) / SESSION_NAME
     shutil.copytree(source, session)
 
     step1(base_dir=base_dir, selected_folders=[session], store_id_to_store_label=STORE_ID_TO_STORE_LABEL)

--- a/tests/integration/test_binned_metrics.py
+++ b/tests/integration/test_binned_metrics.py
@@ -1,5 +1,5 @@
-import os
 import shutil
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -22,9 +22,9 @@ RECORDING_SITE = "region"
 @pytest.fixture(scope="module")
 def preprocessed_session(tmp_path_factory):
     representative_config = REPRESENTATIVE_SESSIONS["csv"]
-    source_session = os.path.join(str(STUBBED_TESTING_DATA), representative_config["session_subdir"])
+    source_session = Path(str(STUBBED_TESTING_DATA)) / representative_config["session_subdir"]
     base_directory = tmp_path_factory.mktemp("integration_binned_metrics")
-    session = base_directory / os.path.basename(source_session)
+    session = base_directory / Path(source_session).name
     # Output directories are gitignored, so a stale one from a previous local run
     # would otherwise seed this session.
     shutil.copytree(source_session, session, ignore=shutil.ignore_patterns("*_output_*"))
@@ -63,8 +63,8 @@ def binned_output(preprocessed_session):
 @pytest.mark.filterwarnings("ignore::UserWarning")
 class TestBinnedMetrics:
     def test_writes_both_formats(self, binned_output):
-        assert os.path.exists(os.path.join(binned_output, f"binned_metrics_{RECORDING_SITE}.h5"))
-        assert os.path.exists(os.path.join(binned_output, f"binned_metrics_{RECORDING_SITE}.csv"))
+        assert (Path(binned_output) / (f"binned_metrics_{RECORDING_SITE}.h5")).exists()
+        assert (Path(binned_output) / (f"binned_metrics_{RECORDING_SITE}.csv")).exists()
 
     def test_schema(self, binned_output):
         binned = read_binned_metrics_from_hdf5(binned_output, RECORDING_SITE)
@@ -122,13 +122,13 @@ class TestBinnedMetrics:
     def test_transient_counts_account_for_every_detected_transient(self, binned_output):
         binned = read_binned_metrics_from_hdf5(binned_output, RECORDING_SITE)
         occurrences = pd.read_csv(
-            os.path.join(binned_output, f"transientsOccurrences_z_score_{RECORDING_SITE}.csv"), index_col=0
+            Path(binned_output) / (f"transientsOccurrences_z_score_{RECORDING_SITE}.csv"), index_col=0
         )
 
         assert binned["transient_count_z_score"].sum() == occurrences.shape[0]
 
     def test_csv_matches_the_hdf5(self, binned_output):
         from_hdf5 = read_binned_metrics_from_hdf5(binned_output, RECORDING_SITE)
-        from_csv = pd.read_csv(os.path.join(binned_output, f"binned_metrics_{RECORDING_SITE}.csv"), index_col="bin")
+        from_csv = pd.read_csv(Path(binned_output) / (f"binned_metrics_{RECORDING_SITE}.csv"), index_col="bin")
 
         pd.testing.assert_frame_equal(from_csv, from_hdf5, check_dtype=False)

--- a/tests/integration/test_covariate_correlations.py
+++ b/tests/integration/test_covariate_correlations.py
@@ -1,5 +1,4 @@
-import glob
-import os
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -52,12 +51,7 @@ class TestCovariateIngestion:
     def test_step2_preserves_values_and_timestamps(self, covariate_session):
         values = np.asarray(read_hdf5(DRIVING_COVARIATE, covariate_session, "data")).ravel()
         timestamps = np.asarray(read_hdf5(DRIVING_COVARIATE, covariate_session, "timestamps")).ravel()
-        scored = pd.read_csv(
-            os.path.join(
-                os.path.dirname(covariate_session),
-                DRIVING_COVARIATE + ".csv",
-            )
-        )
+        scored = pd.read_csv(Path(Path(covariate_session).parent) / (DRIVING_COVARIATE + ".csv"))
 
         np.testing.assert_allclose(values, scored["data"].to_numpy())
         np.testing.assert_allclose(timestamps, np.arange(0.0, COVARIATE_CSV_DURATION, COVARIATE_SCORING_CADENCE))
@@ -65,12 +59,12 @@ class TestCovariateIngestion:
     def test_step3_does_not_treat_the_covariate_as_an_event(self, covariate_session):
         # Regression guard: a covariate must not go down the event-correction path,
         # which keeps only timestamps and drops the scored values.
-        assert glob.glob(os.path.join(covariate_session, "covariate_*_" + RECORDING_SITE + ".hdf5")) == []
+        assert list(Path(covariate_session).glob("covariate_*_" + RECORDING_SITE + ".hdf5")) == []
 
     def test_step4_computes_no_psth_for_the_covariate(self, covariate_session):
-        psth_files = glob.glob(os.path.join(covariate_session, "*covariate*psth*"))
+        psth_files = list(Path(covariate_session).glob("*covariate*psth*"))
         for name in COVARIATE_NAMES:
-            psth_files += glob.glob(os.path.join(covariate_session, "*" + name + "*_z_score*"))
+            psth_files += list(Path(covariate_session).glob("*" + name + "*_z_score*"))
 
         assert psth_files == []
 
@@ -83,7 +77,7 @@ class TestCovariateOutputs:
             "covariate_correlations_" + RECORDING_SITE + ".h5",
             "covariate_correlations_" + RECORDING_SITE + ".csv",
         ]:
-            assert os.path.exists(os.path.join(covariate_session, name)), name
+            assert (Path(covariate_session) / name).exists(), name
 
     def test_binned_covariates_schema(self, covariate_session):
         binned = read_binned_covariates_from_hdf5(filepath=covariate_session, recording_site=RECORDING_SITE)
@@ -148,7 +142,7 @@ class TestCovariateOutputs:
     def test_csv_matches_hdf5(self, covariate_session):
         from_hdf5 = read_binned_covariates_from_hdf5(filepath=covariate_session, recording_site=RECORDING_SITE)
         from_csv = pd.read_csv(
-            os.path.join(covariate_session, "binned_covariates_" + RECORDING_SITE + ".csv"), index_col="bin"
+            Path(covariate_session) / ("binned_covariates_" + RECORDING_SITE + ".csv"), index_col="bin"
         )
 
         pd.testing.assert_frame_equal(from_hdf5, from_csv, check_dtype=False)

--- a/tests/integration/test_export_nwb_optional_outputs.py
+++ b/tests/integration/test_export_nwb_optional_outputs.py
@@ -14,8 +14,8 @@ Every assertion compares the NWB objects against the GuPPy files on disk they we
 so a version of the export that silently omits one of them fails here.
 """
 
-import os
 import shutil
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -84,15 +84,15 @@ def export_run(*, session: str, output_directory: str, acquisition_format: str) 
         session_folder_path=session,
         output_directory=output_directory,
         acquisition_format=acquisition_format,
-        path=os.path.join(output_directory, METADATA_FILENAME),
+        path=Path(output_directory) / METADATA_FILENAME,
     )
-    base_dir = os.path.dirname(session)
+    base_dir = str(Path(session).parent)
     step7(
         base_dir=base_dir,
         selected_folders=[session],
         selected_runs={session: [parse_run_name(output_directory)]},
     )
-    return os.path.join(output_directory, f"{os.path.basename(output_directory)}.nwb")
+    return Path(output_directory) / (f"{Path(output_directory).name}.nwb")
 
 
 class TestCovariateAndWholeSessionOutputs:
@@ -105,7 +105,7 @@ class TestCovariateAndWholeSessionOutputs:
             session_path=STUBBED_TESTING_DATA / "csv" / SESSION_NAME,
             base_directory=base_directory,
         )
-        session = os.path.dirname(output_directory)
+        session = Path(output_directory).parent
         tonic_analysis(
             base_dir=str(base_directory),
             selected_folders=[session],
@@ -137,7 +137,7 @@ class TestCovariateAndWholeSessionOutputs:
     def test_covariate_series_carry_the_scored_values(self, guppy_module, exported):
         for covariate_name in COVARIATE_NAMES:
             series = guppy_module[covariate_name]
-            scored = pd.read_csv(os.path.join(os.path.dirname(exported["output_directory"]), f"{covariate_name}.csv"))
+            scored = pd.read_csv(Path(Path(exported["output_directory"]).parent) / (f"{covariate_name}.csv"))
 
             np.testing.assert_allclose(series.data[:], scored["data"].to_numpy())
             np.testing.assert_allclose(series.timestamps[:], scored["timestamps"].to_numpy())
@@ -212,7 +212,7 @@ class TestCovariateAndWholeSessionOutputs:
             assert exported_coefficients[key] == pytest.approx((row.pearson_r, row.spearman_rho))
 
     def test_tonic_epochs_match_the_hdf5(self, guppy_module, exported):
-        means = pd.read_hdf(os.path.join(exported["output_directory"], f"tonic_{RECORDING_SITE}.h5"), key="df")
+        means = pd.read_hdf(Path(exported["output_directory"]) / (f"tonic_{RECORDING_SITE}.h5"), key="df")
         table = guppy_module["tonic_epochs"].to_dataframe()
 
         assert len(table) == len(TONIC_EPOCHS) * len(TRACE_TYPES)
@@ -240,7 +240,7 @@ class TestSpontaneousModeOutputs:
 
         common = dict(base_dir=str(base_directory), selected_folders=[session])
         step1(**common, store_id_to_store_label=SPONTANEOUS_STORE_ID_TO_STORE_LABEL)
-        output_directory = os.path.join(session, f"{SPONTANEOUS_SESSION_NAME}_output_1")
+        output_directory = Path(session) / (f"{SPONTANEOUS_SESSION_NAME}_output_1")
         selected_runs = {session: ["1"]}
         step2(**common, selected_runs=selected_runs)
         step3(**common, selected_runs=selected_runs)
@@ -272,5 +272,5 @@ class TestSpontaneousModeOutputs:
 
         # Against the event train Step 4 actually aligned to, which is the subset of detected
         # transients it kept after dropping the ones too close to the recording start or each other.
-        event_timestamps = np.asarray(read_hdf5(TRANSIENT_EVENT, os.path.dirname(exported), "ts")).ravel()
+        event_timestamps = np.asarray(read_hdf5(TRANSIENT_EVENT, Path(exported).parent, "ts")).ravel()
         np.testing.assert_allclose(np.sort(occurrences["timestamp"].to_numpy()), np.sort(event_timestamps))

--- a/tests/integration/test_integration_artifact_removal.py
+++ b/tests/integration/test_integration_artifact_removal.py
@@ -1,6 +1,5 @@
-import glob
-import os
 import shutil
+from pathlib import Path
 
 import h5py
 import numpy as np
@@ -82,8 +81,8 @@ def test_artifact_removal(tmp_path, artifact_removal_method, coords):
     session_copy = tmp_base / dest_name
     shutil.copytree(src_session, session_copy)
 
-    for d in glob.glob(os.path.join(session_copy, f"{dest_name}_output_*")):
-        assert os.path.isdir(d), f"Expected output directory for cleanup, got non-directory: {d}"
+    for d in list(Path(session_copy).glob(f"{dest_name}_output_*")):
+        assert Path(d).is_dir(), f"Expected output directory for cleanup, got non-directory: {d}"
         shutil.rmtree(d)
     params_fp = session_copy / "GuPPyParamtersUsed.json"
     if params_fp.exists():
@@ -107,26 +106,26 @@ def test_artifact_removal(tmp_path, artifact_removal_method, coords):
     remove_artifacts(**common_kwargs, selected_runs=selected_runs)
     step4(**common_kwargs, selected_runs=selected_runs)
 
-    run_folders = sorted(glob.glob(os.path.join(session_copy, f"{dest_name}_output_*")))
+    run_folders = sorted(list(Path(session_copy).glob(f"{dest_name}_output_*")))
     assert run_folders, f"No output directories found in {session_copy}"
     out_dir = None
     for d in run_folders:
-        if os.path.exists(os.path.join(d, "storesList.csv")):
+        if (Path(d) / "storesList.csv").exists():
             out_dir = d
             break
     assert out_dir is not None, f"No storesList.csv found in any output directory under {session_copy}"
 
-    assert os.path.exists(os.path.join(out_dir, "storesList.csv")), "Missing storesList.csv"
+    assert (Path(out_dir) / "storesList.csv").exists(), "Missing storesList.csv"
 
-    timecorr = os.path.join(out_dir, "timeCorrection_dms.hdf5")
-    assert os.path.exists(timecorr), f"Missing {timecorr}"
+    timecorr = Path(out_dir) / "timeCorrection_dms.hdf5"
+    assert Path(timecorr).exists(), f"Missing {timecorr}"
     with h5py.File(timecorr, "r") as f:
         assert "timestampNew" in f, f"Expected 'timestampNew' dataset in {timecorr}"
 
-    ttl_fp = os.path.join(out_dir, "port_entries_dms_dms.hdf5")
-    assert os.path.exists(ttl_fp), f"Missing TTL-aligned file {ttl_fp}"
+    ttl_fp = Path(out_dir) / "port_entries_dms_dms.hdf5"
+    assert Path(ttl_fp).exists(), f"Missing TTL-aligned file {ttl_fp}"
     with h5py.File(ttl_fp, "r") as f:
         assert "ts" in f, f"Expected 'ts' dataset in {ttl_fp}"
 
-    zscore_fp = os.path.join(out_dir, "z_score_dms.hdf5")
-    assert os.path.exists(zscore_fp), f"Missing processed signal file {zscore_fp}"
+    zscore_fp = Path(out_dir) / "z_score_dms.hdf5"
+    assert Path(zscore_fp).exists(), f"Missing processed signal file {zscore_fp}"

--- a/tests/integration/test_integration_bin_psth_trials.py
+++ b/tests/integration/test_integration_bin_psth_trials.py
@@ -1,6 +1,5 @@
-import glob
-import os
 import shutil
+from pathlib import Path
 
 import pandas as pd
 import pytest
@@ -27,17 +26,17 @@ def test_bin_psth_trials_by_number_of_trials(tmp_path):
     expected_recording_site = "region"
     expected_ttl = "ttl"
 
-    source_session = os.path.join(str(STUBBED_TESTING_DATA), session_subdir)
-    assert os.path.isdir(source_session), f"Sample data not available at expected path: {source_session}"
+    source_session = Path(str(STUBBED_TESTING_DATA)) / session_subdir
+    assert Path(source_session).is_dir(), f"Sample data not available at expected path: {source_session}"
 
     temporary_base = tmp_path / "data_root"
     temporary_base.mkdir(parents=True, exist_ok=True)
-    session_name = os.path.basename(source_session)
+    session_name = Path(source_session).name
     session_copy = temporary_base / session_name
     shutil.copytree(source_session, session_copy)
 
-    for output_directory in glob.glob(os.path.join(session_copy, f"{session_name}_output_*")):
-        assert os.path.isdir(output_directory)
+    for output_directory in list(Path(session_copy).glob(f"{session_name}_output_*")):
+        assert Path(output_directory).is_dir()
         shutil.rmtree(output_directory)
     parameters_path = session_copy / "GuPPyParamtersUsed.json"
     if parameters_path.exists():
@@ -82,15 +81,14 @@ def test_bin_psth_trials_by_number_of_trials(tmp_path):
         selected_runs=selected_runs,
     )
 
-    output_directories = sorted(glob.glob(os.path.join(str(session_copy), f"{session_name}_output_*")))
+    output_directories = sorted(Path(session_copy).glob(f"{session_name}_output_*"))
     assert output_directories, f"No output directories found in {session_copy}"
     output_directory = output_directories[0]
 
-    psth_file_path = os.path.join(
-        output_directory,
-        f"{expected_ttl}_{expected_recording_site}_z_score_{expected_recording_site}.h5",
+    psth_file_path = Path(output_directory) / (
+        f"{expected_ttl}_{expected_recording_site}_z_score_{expected_recording_site}.h5"
     )
-    assert os.path.exists(psth_file_path), f"Missing PSTH HDF5: {psth_file_path}"
+    assert Path(psth_file_path).exists(), f"Missing PSTH HDF5: {psth_file_path}"
 
     psth_dataframe = pd.read_hdf(psth_file_path, key="df")
     bin_columns = [column for column in psth_dataframe.columns if column.startswith("bin_(")]
@@ -103,22 +101,19 @@ def test_bin_psth_trials_by_number_of_trials(tmp_path):
     # `if len(bin_columns) > 0:` branch inside psth_average.average_psth_for_group, which
     # concatenates and aggregates bin columns across the member runs.
     label_groups(
-        member_run_folders=[
-            os.path.join(folder, f"{os.path.basename(folder)}_output_1") for folder in selected_folders
-        ],
+        member_run_folders=[Path(folder) / (f"{Path(folder).name}_output_1") for folder in selected_folders],
         destination_directory=base_dir,
         group_name="binned",
     )
-    group_analysis(base_dir=base_dir, selected_group_folders=[os.path.join(base_dir, "binned_group")])
+    group_analysis(base_dir=base_dir, selected_group_folders=[Path(base_dir) / "binned_group"])
 
-    average_directory = os.path.join(base_dir, "binned_group")
-    assert os.path.isdir(average_directory), f"No group directory found under {base_dir}"
+    average_directory = Path(base_dir) / "binned_group"
+    assert Path(average_directory).is_dir(), f"No group directory found under {base_dir}"
 
-    average_psth_file_path = os.path.join(
-        average_directory,
-        f"{expected_ttl}_{expected_recording_site}_z_score_{expected_recording_site}.h5",
+    average_psth_file_path = Path(average_directory) / (
+        f"{expected_ttl}_{expected_recording_site}_z_score_{expected_recording_site}.h5"
     )
-    assert os.path.exists(average_psth_file_path), f"Missing averaged PSTH HDF5: {average_psth_file_path}"
+    assert Path(average_psth_file_path).exists(), f"Missing averaged PSTH HDF5: {average_psth_file_path}"
 
     average_psth_dataframe = pd.read_hdf(average_psth_file_path, key="df")
     average_bin_columns = [column for column in average_psth_dataframe.columns if column.startswith("bin_(")]

--- a/tests/integration/test_integration_combine_data.py
+++ b/tests/integration/test_integration_combine_data.py
@@ -1,6 +1,5 @@
-import glob
-import os
 import shutil
+from pathlib import Path
 from unittest.mock import patch
 
 import h5py
@@ -32,24 +31,24 @@ def test_combine_data(tmp_path):
 
     # Use the CSV sample session
     src_base_dir = str(STUBBED_TESTING_DATA)
-    src_sessions = [os.path.join(src_base_dir, session_subdir) for session_subdir in session_subdirs]
+    src_sessions = [Path(src_base_dir) / session_subdir for session_subdir in session_subdirs]
     for src_session in src_sessions:
-        assert os.path.isdir(src_session), f"Sample data not available at expected path: {src_session}"
+        assert Path(src_session).is_dir(), f"Sample data not available at expected path: {src_session}"
 
     # Stage a clean copy of the session into a temporary workspace
     tmp_base = tmp_path / "data_root"
     tmp_base.mkdir(parents=True, exist_ok=True)
     session_copies = []
     for src_session in src_sessions:
-        dest_name = os.path.basename(src_session)
+        dest_name = Path(src_session).name
         session_copy = tmp_base / dest_name
         shutil.copytree(src_session, session_copy)
         session_copies.append(session_copy)
 
     for session_copy in session_copies:
         # Remove any copied artifacts in the temp session (match only this session's output dirs)
-        for d in glob.glob(os.path.join(session_copy, f"{dest_name}_output_*")):
-            assert os.path.isdir(d), f"Expected output directory for cleanup, got non-directory: {d}"
+        for d in list(Path(session_copy).glob(f"{dest_name}_output_*")):
+            assert Path(d).is_dir(), f"Expected output directory for cleanup, got non-directory: {d}"
             shutil.rmtree(d)
         params_fp = session_copy / "GuPPyParamtersUsed.json"
         if params_fp.exists():
@@ -104,21 +103,21 @@ def test_combine_data(tmp_path):
 
     # Validate outputs exist in the temp copy
     session_copy = selected_folders[0]  # Outputs are written to the first session folder
-    basename = os.path.basename(session_copy)
-    run_folders = sorted(glob.glob(os.path.join(session_copy, f"{basename}_output_*")))
+    basename = Path(session_copy).name
+    run_folders = sorted(list(Path(session_copy).glob(f"{basename}_output_*")))
     assert run_folders, f"No output directories found in {session_copy}"
     out_dir = None
     for d in run_folders:
-        if os.path.exists(os.path.join(d, "storesList.csv")):
+        if (Path(d) / "storesList.csv").exists():
             out_dir = d
             break
     assert out_dir is not None, f"No storesList.csv found in any output directory under {session_copy}"
-    stores_fp = os.path.join(out_dir, "storesList.csv")
-    assert os.path.exists(stores_fp), "Missing storesList.csv after Step 1/2/3"
+    stores_fp = Path(out_dir) / "storesList.csv"
+    assert Path(stores_fp).exists(), "Missing storesList.csv after Step 1/2/3"
 
     # Ensure timeCorrection_<recording_site>.hdf5 exists with 'timestampNew'
-    timecorr = os.path.join(out_dir, f"timeCorrection_{expected_recording_site}.hdf5")
-    assert os.path.exists(timecorr), f"Missing {timecorr}"
+    timecorr = Path(out_dir) / (f"timeCorrection_{expected_recording_site}.hdf5")
+    assert Path(timecorr).exists(), f"Missing {timecorr}"
     with h5py.File(timecorr, "r") as f:
         assert "timestampNew" in f, f"Expected 'timestampNew' dataset in {timecorr}"
 
@@ -130,8 +129,8 @@ def test_combine_data(tmp_path):
     else:
         expected_ttls = expected_ttl
     for expected_ttl in expected_ttls:
-        ttl_fp = os.path.join(out_dir, f"{expected_ttl}_{expected_recording_site}.hdf5")
-        assert os.path.exists(ttl_fp), f"Missing TTL-aligned file {ttl_fp}"
+        ttl_fp = Path(out_dir) / (f"{expected_ttl}_{expected_recording_site}.hdf5")
+        assert Path(ttl_fp).exists(), f"Missing TTL-aligned file {ttl_fp}"
         with h5py.File(ttl_fp, "r") as f:
             assert "ts" in f, f"Expected 'ts' dataset in {ttl_fp}"
 

--- a/tests/integration/test_integration_cross_correlation.py
+++ b/tests/integration/test_integration_cross_correlation.py
@@ -1,6 +1,5 @@
-import glob
-import os
 import shutil
+from pathlib import Path
 from unittest.mock import patch
 
 import holoviews as hv
@@ -40,19 +39,19 @@ def test_cross_correlation(tmp_path):
         "PrtN": "port_entries",
     }
     src_base_dir = str(STUBBED_TESTING_DATA)
-    src_session = os.path.join(src_base_dir, session_subdir)
-    assert os.path.isdir(src_session), f"Sample data not available at expected path: {src_session}"
+    src_session = Path(src_base_dir) / session_subdir
+    assert Path(src_session).is_dir(), f"Sample data not available at expected path: {src_session}"
 
     # Stage a clean copy of the session into a temporary workspace
     tmp_base = tmp_path / "data_root"
     tmp_base.mkdir(parents=True, exist_ok=True)
-    dest_name = os.path.basename(src_session)
+    dest_name = Path(src_session).name
     session_copy = tmp_base / dest_name
     shutil.copytree(src_session, session_copy)
 
     # Remove any copied artifacts in the temp session
-    for d in glob.glob(os.path.join(session_copy, f"{dest_name}_output_*")):
-        assert os.path.isdir(d), f"Expected output directory for cleanup, got non-directory: {d}"
+    for d in list(Path(session_copy).glob(f"{dest_name}_output_*")):
+        assert Path(d).is_dir(), f"Expected output directory for cleanup, got non-directory: {d}"
         shutil.rmtree(d)
     params_fp = session_copy / "GuPPyParamtersUsed.json"
     if params_fp.exists():
@@ -82,30 +81,30 @@ def test_cross_correlation(tmp_path):
     )
 
     # Locate output directory
-    basename = os.path.basename(session_copy)
-    run_folders = sorted(glob.glob(os.path.join(session_copy, f"{basename}_output_*")))
+    basename = Path(session_copy).name
+    run_folders = sorted(list(Path(session_copy).glob(f"{basename}_output_*")))
     assert run_folders, f"No output directories found in {session_copy}"
     out_dir = None
     for d in run_folders:
-        if os.path.exists(os.path.join(d, "storesList.csv")):
+        if (Path(d) / "storesList.csv").exists():
             out_dir = d
             break
     assert out_dir is not None, f"No storesList.csv found in any output directory under {session_copy}"
 
     # Standard PSTH outputs for both recording sites
     for recording_site in ("dms", "dls"):
-        freq_amp_h5 = os.path.join(out_dir, f"freqAndAmp_z_score_{recording_site}.h5")
-        freq_amp_csv = os.path.join(out_dir, f"freqAndAmp_z_score_{recording_site}.csv")
-        trans_occ_csv = os.path.join(out_dir, f"transientsOccurrences_z_score_{recording_site}.csv")
-        assert os.path.exists(freq_amp_h5), f"Missing freq/amp HDF5: {freq_amp_h5}"
-        assert os.path.exists(freq_amp_csv), f"Missing freq/amp CSV: {freq_amp_csv}"
-        assert os.path.exists(trans_occ_csv), f"Missing transients occurrences CSV: {trans_occ_csv}"
+        freq_amp_h5 = Path(out_dir) / (f"freqAndAmp_z_score_{recording_site}.h5")
+        freq_amp_csv = Path(out_dir) / (f"freqAndAmp_z_score_{recording_site}.csv")
+        trans_occ_csv = Path(out_dir) / (f"transientsOccurrences_z_score_{recording_site}.csv")
+        assert Path(freq_amp_h5).exists(), f"Missing freq/amp HDF5: {freq_amp_h5}"
+        assert Path(freq_amp_csv).exists(), f"Missing freq/amp CSV: {freq_amp_csv}"
+        assert Path(trans_occ_csv).exists(), f"Missing transients occurrences CSV: {trans_occ_csv}"
 
     # Cross-correlation outputs
-    corr_dir = os.path.join(out_dir, "cross_correlation_output")
-    assert os.path.isdir(corr_dir), f"Missing cross_correlation_output directory: {corr_dir}"
-    corr_h5 = os.path.join(corr_dir, "corr_port_entries_z_score_dls_dms.h5")
-    assert os.path.exists(corr_h5), f"Missing cross-correlation HDF5: {corr_h5}"
+    corr_dir = Path(out_dir) / "cross_correlation_output"
+    assert Path(corr_dir).is_dir(), f"Missing cross_correlation_output directory: {corr_dir}"
+    corr_h5 = Path(corr_dir) / "corr_port_entries_z_score_dls_dms.h5"
+    assert Path(corr_h5).exists(), f"Missing cross-correlation HDF5: {corr_h5}"
     df = pd.read_hdf(corr_h5, key="df")
     assert "timestamps" in df.columns, f"'timestamps' column missing in {corr_h5}"
     assert "mean" in df.columns, f"'mean' column missing in {corr_h5}"

--- a/tests/integration/test_integration_cross_parent_sessions.py
+++ b/tests/integration/test_integration_cross_parent_sessions.py
@@ -1,6 +1,5 @@
-import glob
-import os
 import shutil
+from pathlib import Path
 
 import pandas as pd
 import pytest
@@ -11,16 +10,16 @@ from guppy_test_data import STUBBED_TESTING_DATA
 
 def _stage_session(*, session_subdir: str, destination_parent) -> str:
     """Copy a stubbed session into its own parent directory and clear prior outputs."""
-    source_session = os.path.join(str(STUBBED_TESTING_DATA), session_subdir)
-    assert os.path.isdir(source_session), f"Sample data not available at expected path: {source_session}"
+    source_session = Path(str(STUBBED_TESTING_DATA)) / session_subdir
+    assert Path(source_session).is_dir(), f"Sample data not available at expected path: {source_session}"
 
     destination_parent.mkdir(parents=True, exist_ok=True)
-    session_name = os.path.basename(source_session)
+    session_name = Path(source_session).name
     session_copy = destination_parent / session_name
     shutil.copytree(source_session, session_copy)
 
-    for output_directory in glob.glob(os.path.join(session_copy, f"{session_name}_output_*")):
-        assert os.path.isdir(output_directory)
+    for output_directory in list(Path(session_copy).glob(f"{session_name}_output_*")):
+        assert Path(output_directory).is_dir()
         shutil.rmtree(output_directory)
     parameters_path = session_copy / "GuPPyParamtersUsed.json"
     if parameters_path.exists():
@@ -29,15 +28,15 @@ def _stage_session(*, session_subdir: str, destination_parent) -> str:
 
 
 def _assert_psth_outputs(*, session_copy: str, recording_site: str, ttl: str) -> None:
-    session_name = os.path.basename(session_copy)
-    output_directories = sorted(glob.glob(os.path.join(session_copy, f"{session_name}_output_*")))
+    session_name = Path(session_copy).name
+    output_directories = sorted(list(Path(session_copy).glob(f"{session_name}_output_*")))
     assert output_directories, f"No output directories found in {session_copy}"
     output_directory = output_directories[0]
 
-    assert os.path.exists(os.path.join(output_directory, "storesList.csv")), "Missing storesList.csv"
+    assert (Path(output_directory) / "storesList.csv").exists(), "Missing storesList.csv"
 
-    psth_file_path = os.path.join(output_directory, f"{ttl}_{recording_site}_z_score_{recording_site}.h5")
-    assert os.path.exists(psth_file_path), f"Missing PSTH HDF5: {psth_file_path}"
+    psth_file_path = Path(output_directory) / (f"{ttl}_{recording_site}_z_score_{recording_site}.h5")
+    assert Path(psth_file_path).exists(), f"Missing PSTH HDF5: {psth_file_path}"
     psth_dataframe = pd.read_hdf(psth_file_path, key="df")
     assert "timestamps" in psth_dataframe.columns
     assert "mean" in psth_dataframe.columns
@@ -56,7 +55,7 @@ def test_sessions_from_different_parent_directories(tmp_path):
         session_subdir="tdt/Photo_63_207-181030-103332", destination_parent=tmp_path / "SampleData_Clean"
     )
     csv_session = _stage_session(session_subdir="csv/sample_data_csv_1", destination_parent=tmp_path / "SampleData_csv")
-    assert os.path.dirname(tdt_session) != os.path.dirname(csv_session)
+    assert Path(tdt_session).parent != Path(csv_session).parent
 
     base_dir = str(tmp_path)
 

--- a/tests/integration/test_integration_dandi.py
+++ b/tests/integration/test_integration_dandi.py
@@ -11,7 +11,7 @@ chain in conftest.py, so it lives in its own self-contained file.
 """
 
 import csv
-import os
+from pathlib import Path
 
 import h5py
 import pytest
@@ -103,10 +103,10 @@ class TestDandiIntegration:
     """Exercises the DANDI orchestration branches for step1 and step2."""
 
     def test_step1_writes_stores_list(self, step1_dandi_output):
-        stores_file_path = os.path.join(step1_dandi_output["output_directory"], "storesList.csv")
-        assert os.path.exists(stores_file_path)
+        stores_file_path = Path(step1_dandi_output["output_directory"]) / "storesList.csv"
+        assert Path(stores_file_path).exists()
 
-        with open(stores_file_path, newline="") as stores_file:
+        with Path(stores_file_path).open(newline="") as stores_file:
             stores_rows = list(csv.reader(stores_file))
 
         assert len(stores_rows) == 2
@@ -116,8 +116,8 @@ class TestDandiIntegration:
     def test_step2_writes_hdf5_per_event(self, step2_dandi_output):
         output_directory = step2_dandi_output["output_directory"]
         for store_id in STORE_ID_TO_STORE_LABEL.keys():
-            store_id_file_path = os.path.join(output_directory, f"{store_id}.hdf5")
-            assert os.path.exists(store_id_file_path), f"Missing HDF5 for store_id {store_id!r} at {store_id_file_path}"
+            store_id_file_path = Path(output_directory) / (f"{store_id}.hdf5")
+            assert Path(store_id_file_path).exists(), f"Missing HDF5 for store_id {store_id!r} at {store_id_file_path}"
 
             with h5py.File(store_id_file_path, "r") as store_id_file:
                 assert "timestamps" in store_id_file
@@ -149,5 +149,5 @@ class TestDandiIntegrationMultiAsset:
 
         for session_directory in (session_a, session_b):
             output_directory = _locate_output_directory(session_copy=str(session_directory))
-            stores_file_path = os.path.join(output_directory, "storesList.csv")
-            assert os.path.exists(stores_file_path), f"Missing storesList.csv under {session_directory}"
+            stores_file_path = Path(output_directory) / "storesList.csv"
+            assert Path(stores_file_path).exists(), f"Missing storesList.csv under {session_directory}"

--- a/tests/integration/test_integration_dff.py
+++ b/tests/integration/test_integration_dff.py
@@ -1,6 +1,5 @@
-import glob
-import os
 import shutil
+from pathlib import Path
 
 import pandas as pd
 import pytest
@@ -34,8 +33,8 @@ def test_dff(tmp_path):
     session_copy = temporary_base_directory / session_name
     shutil.copytree(source_session, session_copy)
 
-    for output_directory in glob.glob(os.path.join(session_copy, f"{session_name}_output_*")):
-        assert os.path.isdir(output_directory)
+    for output_directory in list(Path(session_copy).glob(f"{session_name}_output_*")):
+        assert Path(output_directory).is_dir()
         shutil.rmtree(output_directory)
     parameters_path = session_copy / "GuPPyParamtersUsed.json"
     if parameters_path.exists():
@@ -57,61 +56,53 @@ def test_dff(tmp_path):
         selected_runs=selected_runs,
     )
 
-    output_directories = sorted(glob.glob(os.path.join(session_copy, f"{session_name}_output_*")))
+    output_directories = sorted(list(Path(session_copy).glob(f"{session_name}_output_*")))
     assert output_directories, f"No output directories found in {session_copy}"
     output_directory = None
     for candidate in output_directories:
-        if os.path.exists(os.path.join(candidate, "storesList.csv")):
+        if (Path(candidate) / "storesList.csv").exists():
             output_directory = candidate
             break
     assert output_directory is not None, f"No storesList.csv found in any output directory under {session_copy}"
 
     # PSTH outputs with dff naming
-    psth_file_path = os.path.join(
-        output_directory,
-        f"{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_dff_{EXPECTED_RECORDING_SITE}.h5",
+    psth_file_path = Path(output_directory) / (
+        f"{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_dff_{EXPECTED_RECORDING_SITE}.h5"
     )
-    baseline_uncorrected_file_path = os.path.join(
-        output_directory,
-        f"{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_baselineUncorrected_dff_{EXPECTED_RECORDING_SITE}.h5",
+    baseline_uncorrected_file_path = Path(output_directory) / (
+        f"{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_baselineUncorrected_dff_{EXPECTED_RECORDING_SITE}.h5"
     )
-    peak_auc_h5_file_path = os.path.join(
-        output_directory,
-        f"peak_AUC_{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_dff_{EXPECTED_RECORDING_SITE}.h5",
+    peak_auc_h5_file_path = Path(output_directory) / (
+        f"peak_AUC_{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_dff_{EXPECTED_RECORDING_SITE}.h5"
     )
-    peak_auc_csv_file_path = os.path.join(
-        output_directory,
-        f"peak_AUC_{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_dff_{EXPECTED_RECORDING_SITE}.csv",
+    peak_auc_csv_file_path = Path(output_directory) / (
+        f"peak_AUC_{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_dff_{EXPECTED_RECORDING_SITE}.csv"
     )
 
-    assert os.path.exists(psth_file_path), f"Missing DFF PSTH HDF5: {psth_file_path}"
-    assert os.path.exists(
+    assert Path(psth_file_path).exists(), f"Missing DFF PSTH HDF5: {psth_file_path}"
+    assert Path(
         baseline_uncorrected_file_path
-    ), f"Missing baseline-uncorrected DFF PSTH HDF5: {baseline_uncorrected_file_path}"
-    assert os.path.exists(peak_auc_h5_file_path), f"Missing DFF peak/AUC HDF5: {peak_auc_h5_file_path}"
-    assert os.path.exists(peak_auc_csv_file_path), f"Missing DFF peak/AUC CSV: {peak_auc_csv_file_path}"
+    ).exists(), f"Missing baseline-uncorrected DFF PSTH HDF5: {baseline_uncorrected_file_path}"
+    assert Path(peak_auc_h5_file_path).exists(), f"Missing DFF peak/AUC HDF5: {peak_auc_h5_file_path}"
+    assert Path(peak_auc_csv_file_path).exists(), f"Missing DFF peak/AUC CSV: {peak_auc_csv_file_path}"
 
     psth_dataframe = pd.read_hdf(psth_file_path, key="df")
     assert "timestamps" in psth_dataframe.columns, f"'timestamps' column missing in {psth_file_path}"
     assert "mean" in psth_dataframe.columns, f"'mean' column missing in {psth_file_path}"
 
     # Transient outputs with dff naming
-    frequency_and_amplitude_h5_file_path = os.path.join(
-        output_directory, f"freqAndAmp_dff_{EXPECTED_RECORDING_SITE}.h5"
-    )
-    frequency_and_amplitude_csv_file_path = os.path.join(
-        output_directory, f"freqAndAmp_dff_{EXPECTED_RECORDING_SITE}.csv"
-    )
-    transients_occurrences_csv_file_path = os.path.join(
-        output_directory, f"transientsOccurrences_dff_{EXPECTED_RECORDING_SITE}.csv"
+    frequency_and_amplitude_h5_file_path = Path(output_directory) / (f"freqAndAmp_dff_{EXPECTED_RECORDING_SITE}.h5")
+    frequency_and_amplitude_csv_file_path = Path(output_directory) / (f"freqAndAmp_dff_{EXPECTED_RECORDING_SITE}.csv")
+    transients_occurrences_csv_file_path = Path(output_directory) / (
+        f"transientsOccurrences_dff_{EXPECTED_RECORDING_SITE}.csv"
     )
 
-    assert os.path.exists(
+    assert Path(
         frequency_and_amplitude_h5_file_path
-    ), f"Missing DFF freq/amp HDF5: {frequency_and_amplitude_h5_file_path}"
-    assert os.path.exists(
+    ).exists(), f"Missing DFF freq/amp HDF5: {frequency_and_amplitude_h5_file_path}"
+    assert Path(
         frequency_and_amplitude_csv_file_path
-    ), f"Missing DFF freq/amp CSV: {frequency_and_amplitude_csv_file_path}"
-    assert os.path.exists(
+    ).exists(), f"Missing DFF freq/amp CSV: {frequency_and_amplitude_csv_file_path}"
+    assert Path(
         transients_occurrences_csv_file_path
-    ), f"Missing DFF transients occurrences CSV: {transients_occurrences_csv_file_path}"
+    ).exists(), f"Missing DFF transients occurrences CSV: {transients_occurrences_csv_file_path}"

--- a/tests/integration/test_integration_group_analysis.py
+++ b/tests/integration/test_integration_group_analysis.py
@@ -1,6 +1,4 @@
-import glob
 import json
-import os
 import shutil
 from pathlib import Path
 from unittest.mock import patch
@@ -71,8 +69,8 @@ def copied_sessions(tmp_path):
         session_name = source_session.name
         session_copy = temporary_base_directory / session_name
         shutil.copytree(source_session, session_copy)
-        for output_directory in glob.glob(os.path.join(session_copy, f"{session_name}_output_*")):
-            assert os.path.isdir(output_directory)
+        for output_directory in list(Path(session_copy).glob(f"{session_name}_output_*")):
+            assert Path(output_directory).is_dir()
             shutil.rmtree(output_directory)
         parameters_path = session_copy / "GuPPyParamtersUsed.json"
         if parameters_path.exists():
@@ -102,22 +100,19 @@ def test_group_analysis(copied_sessions):
 
     # Run group averaging pass
     label_groups(
-        member_run_folders=[
-            os.path.join(folder, f"{os.path.basename(folder)}_output_1") for folder in selected_folders
-        ],
+        member_run_folders=[str(Path(folder) / f"{Path(folder).name}_output_1") for folder in selected_folders],
         destination_directory=base_dir,
         group_name="saline",
     )
-    group_analysis(base_dir=base_dir, selected_group_folders=[os.path.join(base_dir, "saline_group")])
+    group_analysis(base_dir=base_dir, selected_group_folders=[Path(base_dir) / "saline_group"])
 
     group_directory = temporary_base_directory / "saline_group"
     assert group_directory.is_dir(), f"No group directory found under {temporary_base_directory}"
 
-    group_psth_file_path = os.path.join(
-        group_directory,
-        f"{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_z_score_{EXPECTED_RECORDING_SITE}.h5",
+    group_psth_file_path = Path(group_directory) / (
+        f"{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_z_score_{EXPECTED_RECORDING_SITE}.h5"
     )
-    assert os.path.exists(group_psth_file_path), f"Missing group PSTH HDF5: {group_psth_file_path}"
+    assert Path(group_psth_file_path).exists(), f"Missing group PSTH HDF5: {group_psth_file_path}"
 
     group_psth_dataframe = pd.read_hdf(group_psth_file_path, key="df")
     assert "timestamps" in group_psth_dataframe.columns, f"'timestamps' column missing in {group_psth_file_path}"
@@ -170,13 +165,13 @@ def test_group_analysis_different_event_names_per_session(copied_sessions):
     step2(**common_kwargs, selected_runs=selected_runs)
     step3(**common_kwargs, selected_runs=selected_runs)
     step4(**common_kwargs, selected_runs=selected_runs)
-    member_run_folders = [os.path.join(folder, f"{os.path.basename(folder)}_output_1") for folder in selected_folders]
+    member_run_folders = [str(Path(folder) / f"{Path(folder).name}_output_1") for folder in selected_folders]
     label_groups(
         member_run_folders=member_run_folders,
         destination_directory=base_dir,
         group_name="cross_condition",
     )
-    group_analysis(base_dir=base_dir, selected_group_folders=[os.path.join(base_dir, "cross_condition_group")])
+    group_analysis(base_dir=base_dir, selected_group_folders=[Path(base_dir) / "cross_condition_group"])
 
     # Both events must be averaged even though no session has both -- cross-condition
     # averaging that the pre-#368 validation rejected outright.
@@ -249,20 +244,20 @@ def test_group_analysis_step_writes_a_named_group_directory(copied_sessions):
     step3(**common_kwargs, selected_runs=selected_runs)
     step4(**common_kwargs, selected_runs=selected_runs)
 
-    member_run_folders = [os.path.join(folder, f"{os.path.basename(folder)}_output_1") for folder in selected_folders]
+    member_run_folders = [str(Path(folder) / f"{Path(folder).name}_output_1") for folder in selected_folders]
     label_groups(
         member_run_folders=member_run_folders,
         destination_directory=base_dir,
         group_name="saline",
     )
-    group_analysis(base_dir=base_dir, selected_group_folders=[os.path.join(base_dir, "saline_group")])
+    group_analysis(base_dir=base_dir, selected_group_folders=[Path(base_dir) / "saline_group"])
 
     group_folder = Path(base_dir) / "saline_group"
     assert group_folder.is_dir(), f"No 'saline_group' directory under {base_dir}"
     # The legacy, location-derived output directory is not written any more.
     assert not (Path(base_dir) / "average").exists()
 
-    with open(group_folder / "group_members.json") as manifest_file:
+    with (group_folder / "group_members.json").open() as manifest_file:
         assert json.load(manifest_file) == {"member_run_folders": member_run_folders}
 
     assert (group_folder / "GuPPyParamtersUsed.json").exists()
@@ -274,7 +269,7 @@ def test_group_analysis_step_writes_a_named_group_directory(copied_sessions):
     group_psth = pd.read_hdf(group_psth_path, key="df")
     # One column per member run, named by the run folder's basename, plus mean/err/timestamps.
     for run_folder in member_run_folders:
-        assert os.path.basename(run_folder) in group_psth.columns
+        assert Path(run_folder).name in group_psth.columns
     assert list(group_psth.columns[-3:]) == ["timestamps", "mean", "err"]
 
 
@@ -290,13 +285,13 @@ def test_group_analysis_step_rebuilds_the_group_when_a_member_is_dropped(copied_
     step3(**common_kwargs, selected_runs=selected_runs)
     step4(**common_kwargs, selected_runs=selected_runs)
 
-    member_run_folders = [os.path.join(folder, f"{os.path.basename(folder)}_output_1") for folder in selected_folders]
+    member_run_folders = [str(Path(folder) / f"{Path(folder).name}_output_1") for folder in selected_folders]
     label_groups(
         member_run_folders=member_run_folders,
         destination_directory=base_dir,
         group_name="saline",
     )
-    group_analysis(base_dir=base_dir, selected_group_folders=[os.path.join(base_dir, "saline_group")])
+    group_analysis(base_dir=base_dir, selected_group_folders=[Path(base_dir) / "saline_group"])
     group_folder = Path(base_dir) / "saline_group"
     psth_path = group_folder / f"{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_z_score_{EXPECTED_RECORDING_SITE}.h5"
     assert len(pd.read_hdf(psth_path, key="df").columns) == 5  # 2 members + timestamps/mean/err
@@ -306,10 +301,10 @@ def test_group_analysis_step_rebuilds_the_group_when_a_member_is_dropped(copied_
         destination_directory=base_dir,
         group_name="saline",
     )
-    group_analysis(base_dir=base_dir, selected_group_folders=[os.path.join(base_dir, "saline_group")])
+    group_analysis(base_dir=base_dir, selected_group_folders=[Path(base_dir) / "saline_group"])
 
-    with open(group_folder / "group_members.json") as manifest_file:
+    with (group_folder / "group_members.json").open() as manifest_file:
         assert json.load(manifest_file) == {"member_run_folders": member_run_folders[:1]}
     remaining = pd.read_hdf(psth_path, key="df")
-    assert os.path.basename(member_run_folders[0]) in remaining.columns
-    assert os.path.basename(member_run_folders[1]) not in remaining.columns
+    assert Path(member_run_folders[0]).name in remaining.columns
+    assert Path(member_run_folders[1]).name not in remaining.columns

--- a/tests/integration/test_integration_home.py
+++ b/tests/integration/test_integration_home.py
@@ -78,7 +78,7 @@ def test_parameters_json_contains_expected_keys(homepage, tmp_path):
     session_directory.mkdir()
     homepage._widgets["files_1"].value = [str(session_directory)]
     save_parameters(homepage._hooks["getInputParameters"]())
-    with open(session_directory / "GuPPyParamtersUsed.json") as json_file:
+    with (session_directory / "GuPPyParamtersUsed.json").open() as json_file:
         saved_parameters = json.load(json_file)
     assert set(saved_parameters.keys()) == EXPECTED_JSON_KEYS
 
@@ -88,7 +88,7 @@ def test_get_input_parameters_keys_include_saved_keys(homepage, tmp_path):
     session_directory.mkdir()
     homepage._widgets["files_1"].value = [str(session_directory)]
     save_parameters(homepage._hooks["getInputParameters"]())
-    with open(session_directory / "GuPPyParamtersUsed.json") as json_file:
+    with (session_directory / "GuPPyParamtersUsed.json").open() as json_file:
         saved_parameters = json.load(json_file)
     in_memory_parameters = homepage._hooks["getInputParameters"]()
     for key in saved_parameters:
@@ -103,7 +103,7 @@ def test_derived_keys_are_recorded_but_absent_from_the_form(homepage, tmp_path):
     session_directory.mkdir()
     homepage._widgets["files_1"].value = [str(session_directory)]
     save_parameters(homepage._hooks["getInputParameters"]())
-    with open(session_directory / "GuPPyParamtersUsed.json") as json_file:
+    with (session_directory / "GuPPyParamtersUsed.json").open() as json_file:
         saved_parameters = json.load(json_file)
 
     in_memory_parameters = homepage._hooks["getInputParameters"]()

--- a/tests/integration/test_integration_import_custom_events.py
+++ b/tests/integration/test_integration_import_custom_events.py
@@ -1,5 +1,5 @@
-import os
 import shutil
+from pathlib import Path
 
 import pandas as pd
 import pytest
@@ -8,8 +8,8 @@ from guppy.extractors.csv_recording_extractor import CsvRecordingExtractor
 from guppy.extractors.detect_acquisition_formats import detect_acquisition_formats
 from guppy.testing.api import import_custom_events
 
-PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-STUBBED_CSV_SESSION = os.path.join(PROJECT_ROOT, "stubbed_testing_data", "csv", "sample_data_csv_1")
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+STUBBED_CSV_SESSION = PROJECT_ROOT / "stubbed_testing_data" / "csv" / "sample_data_csv_1"
 
 
 @pytest.fixture
@@ -31,8 +31,8 @@ def test_pasted_event_surfaces_as_store(base_dir_with_session):
     )
 
     # The CSV is written into the session folder in GuPPy-compatible form.
-    csv_path = os.path.join(session, "movement_onset.csv")
-    assert os.path.exists(csv_path)
+    csv_path = Path(session) / "movement_onset.csv"
+    assert Path(csv_path).exists()
     df = pd.read_csv(csv_path)
     assert list(df.columns) == ["timestamps"]
     assert df["timestamps"].tolist() == [0.5, 1.5, 2.5]

--- a/tests/integration/test_integration_inter_session_mixed_modality.py
+++ b/tests/integration/test_integration_inter_session_mixed_modality.py
@@ -1,6 +1,5 @@
-import glob
-import os
 import shutil
+from pathlib import Path
 
 import h5py
 import pytest
@@ -37,8 +36,8 @@ def test_mixed_modality(tmp_path):
     }
 
     src_base_dir = str(STUBBED_TESTING_DATA)
-    npm_src = os.path.join(src_base_dir, npm_session_subdir)
-    doric_src = os.path.join(src_base_dir, doric_session_subdir)
+    npm_src = Path(src_base_dir) / npm_session_subdir
+    doric_src = Path(src_base_dir) / doric_session_subdir
 
     # Stage a clean copy of each session into a shared temporary workspace
     tmp_base = tmp_path / "data_root"
@@ -50,9 +49,9 @@ def test_mixed_modality(tmp_path):
     shutil.copytree(doric_src, doric_dest)
 
     for session_copy in [npm_dest, doric_dest]:
-        dest_name = os.path.basename(session_copy)
-        for d in glob.glob(os.path.join(session_copy, f"{dest_name}_output_*")):
-            assert os.path.isdir(d), f"Expected output directory for cleanup, got non-directory: {d}"
+        dest_name = Path(session_copy).name
+        for d in list(Path(session_copy).glob(f"{dest_name}_output_*")):
+            assert Path(d).is_dir(), f"Expected output directory for cleanup, got non-directory: {d}"
             shutil.rmtree(d)
         params_fp = session_copy / "GuPPyParamtersUsed.json"
         if params_fp.exists():
@@ -107,13 +106,13 @@ def test_mixed_modality(tmp_path):
 
 def _stage_session(src_base_dir, session_subdir, tmp_base):
     """Copy a session to a temp workspace, clean output dirs and param files."""
-    src_session = os.path.join(src_base_dir, session_subdir)
-    assert os.path.isdir(src_session), f"Sample data not available at expected path: {src_session}"
-    dest_name = os.path.basename(src_session)
+    src_session = Path(src_base_dir) / session_subdir
+    assert Path(src_session).is_dir(), f"Sample data not available at expected path: {src_session}"
+    dest_name = Path(src_session).name
     session_copy = tmp_base / dest_name
     shutil.copytree(src_session, session_copy)
-    for d in glob.glob(os.path.join(session_copy, f"{dest_name}_output_*")):
-        assert os.path.isdir(d)
+    for d in list(Path(session_copy).glob(f"{dest_name}_output_*")):
+        assert Path(d).is_dir()
         shutil.rmtree(d)
     params_fp = session_copy / "GuPPyParamtersUsed.json"
     if params_fp.exists():
@@ -444,23 +443,23 @@ def test_mixed_modality_nwb_npm(tmp_path):
 
 
 def _assert_pipeline_outputs(session_copy, expected_recording_site, expected_ttl):
-    basename = os.path.basename(session_copy)
-    run_folders = sorted(glob.glob(os.path.join(session_copy, f"{basename}_output_*")))
+    basename = Path(session_copy).name
+    run_folders = sorted(list(Path(session_copy).glob(f"{basename}_output_*")))
     assert run_folders, f"No output directories found in {session_copy}"
     out_dir = None
     for d in run_folders:
-        if os.path.exists(os.path.join(d, "storesList.csv")):
+        if (Path(d) / "storesList.csv").exists():
             out_dir = d
             break
     assert out_dir is not None, f"No storesList.csv found in any output directory under {session_copy}"
-    assert os.path.exists(os.path.join(out_dir, "storesList.csv")), "Missing storesList.csv"
+    assert (Path(out_dir) / "storesList.csv").exists(), "Missing storesList.csv"
 
-    timecorr = os.path.join(out_dir, f"timeCorrection_{expected_recording_site}.hdf5")
-    assert os.path.exists(timecorr), f"Missing {timecorr}"
+    timecorr = Path(out_dir) / (f"timeCorrection_{expected_recording_site}.hdf5")
+    assert Path(timecorr).exists(), f"Missing {timecorr}"
     with h5py.File(timecorr, "r") as f:
         assert "timestampNew" in f, f"Expected 'timestampNew' dataset in {timecorr}"
 
-    ttl_fp = os.path.join(out_dir, f"{expected_ttl}_{expected_recording_site}.hdf5")
-    assert os.path.exists(ttl_fp), f"Missing TTL-aligned file {ttl_fp}"
+    ttl_fp = Path(out_dir) / (f"{expected_ttl}_{expected_recording_site}.hdf5")
+    assert Path(ttl_fp).exists(), f"Missing TTL-aligned file {ttl_fp}"
     with h5py.File(ttl_fp, "r") as f:
         assert "ts" in f, f"Expected 'ts' dataset in {ttl_fp}"

--- a/tests/integration/test_integration_intra_session_mixed_modality.py
+++ b/tests/integration/test_integration_intra_session_mixed_modality.py
@@ -1,6 +1,5 @@
-import glob
-import os
 import shutil
+from pathlib import Path
 
 import h5py
 import numpy as np
@@ -22,13 +21,13 @@ def _is_float_label(column):
 
 def _stage_session(src_base_dir, session_subdir, tmp_base):
     """Copy a session to a temp workspace, clean output dirs and param files."""
-    src_session = os.path.join(src_base_dir, session_subdir)
-    assert os.path.isdir(src_session), f"Sample data not available at expected path: {src_session}"
-    dest_name = os.path.basename(src_session)
+    src_session = Path(src_base_dir) / session_subdir
+    assert Path(src_session).is_dir(), f"Sample data not available at expected path: {src_session}"
+    dest_name = Path(src_session).name
     session_copy = tmp_base / dest_name
     shutil.copytree(src_session, session_copy)
-    for d in glob.glob(os.path.join(session_copy, f"{dest_name}_output_*")):
-        assert os.path.isdir(d)
+    for d in list(Path(session_copy).glob(f"{dest_name}_output_*")):
+        assert Path(d).is_dir()
         shutil.rmtree(d)
     params_fp = session_copy / "GuPPyParamtersUsed.json"
     if params_fp.exists():
@@ -37,23 +36,23 @@ def _stage_session(src_base_dir, session_subdir, tmp_base):
 
 
 def _assert_intra_session_outputs(session_copy, expected_recording_site, expected_ttl):
-    dest_name = os.path.basename(session_copy)
-    run_folders = sorted(glob.glob(os.path.join(session_copy, f"{dest_name}_output_*")))
+    dest_name = Path(session_copy).name
+    run_folders = sorted(list(Path(session_copy).glob(f"{dest_name}_output_*")))
     assert run_folders, f"No output directories found in {session_copy}"
     out_dir = None
     for d in run_folders:
-        if os.path.exists(os.path.join(d, "storesList.csv")):
+        if (Path(d) / "storesList.csv").exists():
             out_dir = d
             break
     assert out_dir is not None, f"No storesList.csv found under {session_copy}"
 
-    timecorr = os.path.join(out_dir, f"timeCorrection_{expected_recording_site}.hdf5")
-    assert os.path.exists(timecorr), f"Missing {timecorr}"
+    timecorr = Path(out_dir) / (f"timeCorrection_{expected_recording_site}.hdf5")
+    assert Path(timecorr).exists(), f"Missing {timecorr}"
     with h5py.File(timecorr, "r") as f:
         assert "timestampNew" in f
 
-    ttl_fp = os.path.join(out_dir, f"{expected_ttl}_{expected_recording_site}.hdf5")
-    assert os.path.exists(ttl_fp), f"Missing TTL-aligned file {ttl_fp}"
+    ttl_fp = Path(out_dir) / (f"{expected_ttl}_{expected_recording_site}.hdf5")
+    assert Path(ttl_fp).exists(), f"Missing TTL-aligned file {ttl_fp}"
     with h5py.File(ttl_fp, "r") as f:
         assert "ts" in f
 
@@ -202,8 +201,8 @@ def test_mixed_modality_npm_csv_ttl(tmp_path):
 
     # The TTLs must land inside the NPM recording, not merely be written out: an event
     # outside the signal span yields an empty PSTH that the checks above still accept.
-    run_folder = sorted(glob.glob(os.path.join(session_copy, f"{os.path.basename(session_copy)}_output_*")))[0]
-    psth = pd.read_hdf(os.path.join(run_folder, "ttl_region_region_z_score_region.h5"))
+    run_folder = sorted(list(Path(session_copy).glob(f"{Path(session_copy).name}_output_*")))[0]
+    psth = pd.read_hdf(Path(run_folder) / "ttl_region_region_z_score_region.h5")
     trial_times = sorted(float(column) for column in psth.columns if _is_float_label(column))
     np.testing.assert_allclose(trial_times, csv_ttl_timestamps)
 

--- a/tests/integration/test_integration_no_isosbestic.py
+++ b/tests/integration/test_integration_no_isosbestic.py
@@ -1,6 +1,5 @@
-import glob
-import os
 import shutil
+from pathlib import Path
 
 import pandas as pd
 import pytest
@@ -37,8 +36,8 @@ def test_no_isosbestic(tmp_path):
     session_copy = temporary_base_directory / session_name
     shutil.copytree(source_session, session_copy)
 
-    for output_directory in glob.glob(os.path.join(session_copy, f"{session_name}_output_*")):
-        assert os.path.isdir(output_directory)
+    for output_directory in list(Path(session_copy).glob(f"{session_name}_output_*")):
+        assert Path(output_directory).is_dir()
         shutil.rmtree(output_directory)
     parameters_path = session_copy / "GuPPyParamtersUsed.json"
     if parameters_path.exists():
@@ -55,60 +54,54 @@ def test_no_isosbestic(tmp_path):
     step3(**common_kwargs, isosbestic_control=False, selected_runs=selected_runs)
     step4(**common_kwargs, selected_runs=selected_runs)
 
-    output_directories = sorted(glob.glob(os.path.join(session_copy, f"{session_name}_output_*")))
+    output_directories = sorted(list(Path(session_copy).glob(f"{session_name}_output_*")))
     assert output_directories, f"No output directories found in {session_copy}"
     output_directory = None
     for candidate in output_directories:
-        if os.path.exists(os.path.join(candidate, "storesList.csv")):
+        if (Path(candidate) / "storesList.csv").exists():
             output_directory = candidate
             break
     assert output_directory is not None, f"No storesList.csv found in any output directory under {session_copy}"
 
     # PSTH outputs use z_score naming (no-isosbestic only changes how the control is synthesized)
-    psth_file_path = os.path.join(
-        output_directory,
-        f"{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_z_score_{EXPECTED_RECORDING_SITE}.h5",
+    psth_file_path = Path(output_directory) / (
+        f"{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_z_score_{EXPECTED_RECORDING_SITE}.h5"
     )
-    baseline_uncorrected_file_path = os.path.join(
-        output_directory,
-        f"{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_baselineUncorrected_z_score_{EXPECTED_RECORDING_SITE}.h5",
+    baseline_uncorrected_file_path = Path(output_directory) / (
+        f"{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_baselineUncorrected_z_score_{EXPECTED_RECORDING_SITE}.h5"
     )
-    peak_auc_h5_file_path = os.path.join(
-        output_directory,
-        f"peak_AUC_{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_z_score_{EXPECTED_RECORDING_SITE}.h5",
+    peak_auc_h5_file_path = Path(output_directory) / (
+        f"peak_AUC_{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_z_score_{EXPECTED_RECORDING_SITE}.h5"
     )
-    peak_auc_csv_file_path = os.path.join(
-        output_directory,
-        f"peak_AUC_{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_z_score_{EXPECTED_RECORDING_SITE}.csv",
+    peak_auc_csv_file_path = Path(output_directory) / (
+        f"peak_AUC_{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_z_score_{EXPECTED_RECORDING_SITE}.csv"
     )
 
-    assert os.path.exists(psth_file_path), f"Missing PSTH HDF5: {psth_file_path}"
-    assert os.path.exists(
+    assert Path(psth_file_path).exists(), f"Missing PSTH HDF5: {psth_file_path}"
+    assert Path(
         baseline_uncorrected_file_path
-    ), f"Missing baseline-uncorrected PSTH HDF5: {baseline_uncorrected_file_path}"
-    assert os.path.exists(peak_auc_h5_file_path), f"Missing peak/AUC HDF5: {peak_auc_h5_file_path}"
-    assert os.path.exists(peak_auc_csv_file_path), f"Missing peak/AUC CSV: {peak_auc_csv_file_path}"
+    ).exists(), f"Missing baseline-uncorrected PSTH HDF5: {baseline_uncorrected_file_path}"
+    assert Path(peak_auc_h5_file_path).exists(), f"Missing peak/AUC HDF5: {peak_auc_h5_file_path}"
+    assert Path(peak_auc_csv_file_path).exists(), f"Missing peak/AUC CSV: {peak_auc_csv_file_path}"
 
     psth_dataframe = pd.read_hdf(psth_file_path, key="df")
     assert "timestamps" in psth_dataframe.columns, f"'timestamps' column missing in {psth_file_path}"
     assert "mean" in psth_dataframe.columns, f"'mean' column missing in {psth_file_path}"
 
-    frequency_and_amplitude_h5_file_path = os.path.join(
-        output_directory, f"freqAndAmp_z_score_{EXPECTED_RECORDING_SITE}.h5"
+    frequency_and_amplitude_h5_file_path = Path(output_directory) / (f"freqAndAmp_z_score_{EXPECTED_RECORDING_SITE}.h5")
+    frequency_and_amplitude_csv_file_path = Path(output_directory) / (
+        f"freqAndAmp_z_score_{EXPECTED_RECORDING_SITE}.csv"
     )
-    frequency_and_amplitude_csv_file_path = os.path.join(
-        output_directory, f"freqAndAmp_z_score_{EXPECTED_RECORDING_SITE}.csv"
-    )
-    transients_occurrences_csv_file_path = os.path.join(
-        output_directory, f"transientsOccurrences_z_score_{EXPECTED_RECORDING_SITE}.csv"
+    transients_occurrences_csv_file_path = Path(output_directory) / (
+        f"transientsOccurrences_z_score_{EXPECTED_RECORDING_SITE}.csv"
     )
 
-    assert os.path.exists(
+    assert Path(
         frequency_and_amplitude_h5_file_path
-    ), f"Missing freq/amp HDF5: {frequency_and_amplitude_h5_file_path}"
-    assert os.path.exists(
+    ).exists(), f"Missing freq/amp HDF5: {frequency_and_amplitude_h5_file_path}"
+    assert Path(
         frequency_and_amplitude_csv_file_path
-    ), f"Missing freq/amp CSV: {frequency_and_amplitude_csv_file_path}"
-    assert os.path.exists(
+    ).exists(), f"Missing freq/amp CSV: {frequency_and_amplitude_csv_file_path}"
+    assert Path(
         transients_occurrences_csv_file_path
-    ), f"Missing transients occurrences CSV: {transients_occurrences_csv_file_path}"
+    ).exists(), f"Missing transients occurrences CSV: {transients_occurrences_csv_file_path}"

--- a/tests/integration/test_integration_npm_params_persistence.py
+++ b/tests/integration/test_integration_npm_params_persistence.py
@@ -7,10 +7,9 @@ reproduce the split-event streams, and read the timestamps on the recorded clock
 persisted file alone.
 """
 
-import glob
 import json
-import os
 import shutil
+from pathlib import Path
 
 import h5py
 import numpy as np
@@ -20,7 +19,7 @@ from guppy_test_data import STUBBED_TESTING_DATA
 
 
 def test_step2_reproduces_split_events_from_persisted_params(tmp_path):
-    src_session = os.path.join(str(STUBBED_TESTING_DATA), "npm", "sampleData_NPM_4")
+    src_session = Path(str(STUBBED_TESTING_DATA)) / "npm" / "sampleData_NPM_4"
     tmp_base = tmp_path / "data_root"
     tmp_base.mkdir(parents=True, exist_ok=True)
     session_copy = tmp_base / "sampleData_NPM_4"
@@ -40,10 +39,10 @@ def test_step2_reproduces_split_events_from_persisted_params(tmp_path):
         npm_split_events=[False, True],
     )
 
-    run_folders = sorted(glob.glob(os.path.join(session_copy, "sampleData_NPM_4_output_*")))
+    run_folders = sorted(list(Path(session_copy).glob("sampleData_NPM_4_output_*")))
     assert run_folders, "Step 1 did not create an output directory"
     run_folder = run_folders[0]
-    assert os.path.exists(os.path.join(run_folder, ".npm_params.json")), "Step 1 did not persist .npm_params.json"
+    assert (Path(run_folder) / ".npm_params.json").exists(), "Step 1 did not persist .npm_params.json"
 
     # Step 2 WITHOUT npm_split_events (as in the GUI, where Step 2 has no access to the
     # interactive choice) must still reproduce the split-event stream from the persisted file.
@@ -54,14 +53,14 @@ def test_step2_reproduces_split_events_from_persisted_params(tmp_path):
     )
 
     for store_id in store_id_to_store_label:
-        hdf5_path = os.path.join(run_folder, f"{store_id}.hdf5")
-        assert os.path.exists(hdf5_path), f"Missing HDF5 for split-event store_id {store_id!r}: {hdf5_path}"
+        hdf5_path = Path(run_folder) / (f"{store_id}.hdf5")
+        assert Path(hdf5_path).exists(), f"Missing HDF5 for split-event store_id {store_id!r}: {hdf5_path}"
 
 
 def test_step2_reads_timestamps_on_the_unit_recorded_by_step1(tmp_path):
     # sampleData_NPM_5 is header-less: nothing in the file says its clock is in
     # milliseconds, so .npm_params.json is the only record of it (issue #411).
-    src_session = os.path.join(str(STUBBED_TESTING_DATA), "npm", "sampleData_NPM_5")
+    src_session = Path(str(STUBBED_TESTING_DATA)) / "npm" / "sampleData_NPM_5"
     tmp_base = tmp_path / "data_root"
     tmp_base.mkdir(parents=True, exist_ok=True)
     session_copy = tmp_base / "sampleData_NPM_5"
@@ -74,8 +73,8 @@ def test_step2_reads_timestamps_on_the_unit_recorded_by_step1(tmp_path):
         npm_time_unit="milliseconds",
     )
 
-    run_folder = sorted(glob.glob(os.path.join(session_copy, "sampleData_NPM_5_output_*")))[0]
-    with open(os.path.join(run_folder, ".npm_params.json")) as npm_params_file:
+    run_folder = sorted(list(Path(session_copy).glob("sampleData_NPM_5_output_*")))[0]
+    with (Path(run_folder) / ".npm_params.json").open() as npm_params_file:
         npm_params = json.load(npm_params_file)
     assert npm_params["npm_time_unit"] == "milliseconds"
 
@@ -89,6 +88,6 @@ def test_step2_reads_timestamps_on_the_unit_recorded_by_step1(tmp_path):
     # chev takes every other row from row 0, whose raw timestamp in
     # PagCeAVgatFear_1512_1.csv is 40263510.4768 ms → 40263.5104768 s. Read as seconds it
     # would have stayed at 40263510.4768.
-    with h5py.File(os.path.join(run_folder, "file0_chev1.hdf5"), "r") as hdf5_file:
+    with h5py.File(Path(run_folder) / "file0_chev1.hdf5", "r") as hdf5_file:
         first_timestamp = np.asarray(hdf5_file["timestamps"])[0]
     np.testing.assert_allclose(first_timestamp, 40263.5104768, atol=1e-6)

--- a/tests/integration/test_integration_parallel.py
+++ b/tests/integration/test_integration_parallel.py
@@ -8,9 +8,8 @@ from nested worker pools. Run these tests independently without ``-n auto``.
 """
 
 import csv
-import glob
-import os
 import shutil
+from pathlib import Path
 
 import h5py
 import pandas as pd
@@ -32,17 +31,17 @@ EXPECTED_TTL = "ttl"
 
 def _stage_session(tmp_path):
     """Copy the CSV sample session into a clean temporary workspace."""
-    src_session = os.path.join(str(STUBBED_TESTING_DATA), SESSION_SUBDIR)
-    assert os.path.isdir(src_session), f"Sample data not found: {src_session}"
+    src_session = Path(str(STUBBED_TESTING_DATA)) / SESSION_SUBDIR
+    assert Path(src_session).is_dir(), f"Sample data not found: {src_session}"
 
     tmp_base = tmp_path / "data_root"
     tmp_base.mkdir(parents=True, exist_ok=True)
-    dest_name = os.path.basename(src_session)
+    dest_name = Path(src_session).name
     session_copy = tmp_base / dest_name
     shutil.copytree(src_session, session_copy)
 
     # Remove any pre-existing output dirs and parameter file from the copy
-    for run_folder in glob.glob(os.path.join(session_copy, f"{dest_name}_output_*")):
+    for run_folder in list(Path(session_copy).glob(f"{dest_name}_output_*")):
         shutil.rmtree(run_folder)
     params_filepath = session_copy / "GuPPyParamtersUsed.json"
     if params_filepath.exists():
@@ -75,22 +74,22 @@ def test_parallel_step3(tmp_path):
     )
 
     # Locate the output directory
-    basename = os.path.basename(session_copy)
-    run_folders = sorted(glob.glob(os.path.join(session_copy, f"{basename}_output_*")))
+    basename = Path(session_copy).name
+    run_folders = sorted(list(Path(session_copy).glob(f"{basename}_output_*")))
     assert run_folders, f"No output directories found under {session_copy}"
-    out_dir = next((d for d in run_folders if os.path.exists(os.path.join(d, "storesList.csv"))), None)
+    out_dir = next((d for d in run_folders if (Path(d) / "storesList.csv").exists()), None)
     assert out_dir is not None, "No storesList.csv found in any output directory"
 
     # Verify that per-store_id HDF5 files were written for each raw store_id
-    stores_filepath = os.path.join(out_dir, "storesList.csv")
-    with open(stores_filepath, newline="") as stores_file:
+    stores_filepath = Path(out_dir) / "storesList.csv"
+    with Path(stores_filepath).open(newline="") as stores_file:
         rows = list(csv.reader(stores_file))
     assert len(rows) == 2, "storesList.csv should have 2 rows"
     store_ids = rows[0]
     for store_id in store_ids:
         safe_name = store_id.replace("\\", "_").replace("/", "_")
-        h5_path = os.path.join(out_dir, f"{safe_name}.hdf5")
-        assert os.path.exists(h5_path), f"Missing HDF5 for store_id {store_id!r}: {h5_path}"
+        h5_path = Path(out_dir) / (f"{safe_name}.hdf5")
+        assert Path(h5_path).exists(), f"Missing HDF5 for store_id {store_id!r}: {h5_path}"
         with h5py.File(h5_path, "r") as h5_file:
             assert "timestamps" in h5_file, f"Missing 'timestamps' dataset in {h5_path}"
 
@@ -133,28 +132,28 @@ def test_parallel_step5(tmp_path):
     )
 
     # Locate output directory
-    basename = os.path.basename(session_copy)
-    run_folders = sorted(glob.glob(os.path.join(session_copy, f"{basename}_output_*")))
+    basename = Path(session_copy).name
+    run_folders = sorted(list(Path(session_copy).glob(f"{basename}_output_*")))
     assert run_folders, f"No output directories found under {session_copy}"
-    out_dir = next((d for d in run_folders if os.path.exists(os.path.join(d, "storesList.csv"))), None)
+    out_dir = next((d for d in run_folders if (Path(d) / "storesList.csv").exists()), None)
     assert out_dir is not None, "No storesList.csv found in any output directory"
 
     # PSTH and peak/AUC outputs
-    psth_h5 = os.path.join(out_dir, f"{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_z_score_{EXPECTED_RECORDING_SITE}.h5")
-    psth_baseline_uncorr_h5 = os.path.join(
-        out_dir, f"{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_baselineUncorrected_z_score_{EXPECTED_RECORDING_SITE}.h5"
+    psth_h5 = Path(out_dir) / (f"{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_z_score_{EXPECTED_RECORDING_SITE}.h5")
+    psth_baseline_uncorr_h5 = Path(out_dir) / (
+        f"{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_baselineUncorrected_z_score_{EXPECTED_RECORDING_SITE}.h5"
     )
-    peak_auc_h5 = os.path.join(
-        out_dir, f"peak_AUC_{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_z_score_{EXPECTED_RECORDING_SITE}.h5"
+    peak_auc_h5 = Path(out_dir) / (
+        f"peak_AUC_{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_z_score_{EXPECTED_RECORDING_SITE}.h5"
     )
-    peak_auc_csv = os.path.join(
-        out_dir, f"peak_AUC_{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_z_score_{EXPECTED_RECORDING_SITE}.csv"
+    peak_auc_csv = Path(out_dir) / (
+        f"peak_AUC_{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_z_score_{EXPECTED_RECORDING_SITE}.csv"
     )
 
-    assert os.path.exists(psth_h5), f"Missing PSTH HDF5: {psth_h5}"
-    assert os.path.exists(psth_baseline_uncorr_h5), f"Missing baseline-uncorrected PSTH HDF5: {psth_baseline_uncorr_h5}"
-    assert os.path.exists(peak_auc_h5), f"Missing Peak/AUC HDF5: {peak_auc_h5}"
-    assert os.path.exists(peak_auc_csv), f"Missing Peak/AUC CSV: {peak_auc_csv}"
+    assert Path(psth_h5).exists(), f"Missing PSTH HDF5: {psth_h5}"
+    assert Path(psth_baseline_uncorr_h5).exists(), f"Missing baseline-uncorrected PSTH HDF5: {psth_baseline_uncorr_h5}"
+    assert Path(peak_auc_h5).exists(), f"Missing Peak/AUC HDF5: {peak_auc_h5}"
+    assert Path(peak_auc_csv).exists(), f"Missing Peak/AUC CSV: {peak_auc_csv}"
 
     # PSTH HDF5 content check
     dataframe = pd.read_hdf(psth_h5, key="df")
@@ -162,9 +161,9 @@ def test_parallel_step5(tmp_path):
     assert "mean" in dataframe.columns, f"'mean' column missing in {psth_h5}"
 
     # Transients outputs
-    freq_amp_h5 = os.path.join(out_dir, f"freqAndAmp_z_score_{EXPECTED_RECORDING_SITE}.h5")
-    freq_amp_csv = os.path.join(out_dir, f"freqAndAmp_z_score_{EXPECTED_RECORDING_SITE}.csv")
-    trans_occ_csv = os.path.join(out_dir, f"transientsOccurrences_z_score_{EXPECTED_RECORDING_SITE}.csv")
-    assert os.path.exists(freq_amp_h5), f"Missing freq/amp HDF5: {freq_amp_h5}"
-    assert os.path.exists(freq_amp_csv), f"Missing freq/amp CSV: {freq_amp_csv}"
-    assert os.path.exists(trans_occ_csv), f"Missing transients occurrences CSV: {trans_occ_csv}"
+    freq_amp_h5 = Path(out_dir) / (f"freqAndAmp_z_score_{EXPECTED_RECORDING_SITE}.h5")
+    freq_amp_csv = Path(out_dir) / (f"freqAndAmp_z_score_{EXPECTED_RECORDING_SITE}.csv")
+    trans_occ_csv = Path(out_dir) / (f"transientsOccurrences_z_score_{EXPECTED_RECORDING_SITE}.csv")
+    assert Path(freq_amp_h5).exists(), f"Missing freq/amp HDF5: {freq_amp_h5}"
+    assert Path(freq_amp_csv).exists(), f"Missing freq/amp CSV: {freq_amp_csv}"
+    assert Path(trans_occ_csv).exists(), f"Missing transients occurrences CSV: {trans_occ_csv}"

--- a/tests/integration/test_integration_parametrized_outputs.py
+++ b/tests/integration/test_integration_parametrized_outputs.py
@@ -5,9 +5,8 @@ steps respect ``selected_runs`` so multiple parameter sets can coexist for the
 same session without overwriting each other.
 """
 
-import glob
-import os
 import shutil
+from pathlib import Path
 
 import pytest
 
@@ -32,7 +31,7 @@ def csv_session_copy(tmp_path):
     shutil.copytree(source, destination)
 
     session_name = destination.name
-    for stale in glob.glob(os.path.join(destination, f"{session_name}_output_*")):
+    for stale in list(Path(destination).glob(f"{session_name}_output_*")):
         shutil.rmtree(stale)
     parameters = destination / "GuPPyParamtersUsed.json"
     if parameters.exists():
@@ -50,9 +49,9 @@ class TestStep1RunName:
             store_id_to_store_label=CSV_STORE_ID_TO_STORE_LABEL,
             run_name="baseline",
         )
-        expected = os.path.join(session, f"{os.path.basename(session)}_output_baseline")
-        assert os.path.isdir(expected)
-        assert os.path.exists(os.path.join(expected, "storesList.csv"))
+        expected = Path(session) / (f"{Path(session).name}_output_baseline")
+        assert Path(expected).is_dir()
+        assert (Path(expected) / "storesList.csv").exists()
 
     def test_two_run_names_coexist(self, csv_session_copy):
         base, session = csv_session_copy
@@ -68,9 +67,9 @@ class TestStep1RunName:
             store_id_to_store_label=CSV_STORE_ID_TO_STORE_LABEL,
             run_name="strict",
         )
-        session_basename = os.path.basename(session)
-        assert os.path.isdir(os.path.join(session, f"{session_basename}_output_baseline"))
-        assert os.path.isdir(os.path.join(session, f"{session_basename}_output_strict"))
+        session_basename = Path(session).name
+        assert (Path(session) / (f"{session_basename}_output_baseline")).is_dir()
+        assert (Path(session) / (f"{session_basename}_output_strict")).is_dir()
 
     def test_create_policy_raises_on_existing_run_name(self, csv_session_copy):
         base, session = csv_session_copy
@@ -97,9 +96,9 @@ class TestStep1RunName:
             store_id_to_store_label=CSV_STORE_ID_TO_STORE_LABEL,
             run_name="baseline",
         )
-        existing = os.path.join(session, f"{os.path.basename(session)}_output_baseline")
-        marker = os.path.join(existing, "stale_marker.txt")
-        with open(marker, "w") as marker_file:
+        existing = Path(session) / (f"{Path(session).name}_output_baseline")
+        marker = Path(existing) / "stale_marker.txt"
+        with Path(marker).open("w") as marker_file:
             marker_file.write("stale")
 
         step1(
@@ -110,14 +109,14 @@ class TestStep1RunName:
             run_name_policy="overwrite",
         )
 
-        assert os.path.isdir(existing)
-        assert not os.path.exists(marker)
+        assert Path(existing).is_dir()
+        assert not Path(marker).exists()
 
     def test_legacy_unspecified_run_name_uses_integer_suffix(self, csv_session_copy):
         base, session = csv_session_copy
         step1(base_dir=base, selected_folders=[session], store_id_to_store_label=CSV_STORE_ID_TO_STORE_LABEL)
-        expected = os.path.join(session, f"{os.path.basename(session)}_output_1")
-        assert os.path.isdir(expected)
+        expected = Path(session) / (f"{Path(session).name}_output_1")
+        assert Path(expected).is_dir()
 
 
 class TestStep2SelectedRuns:
@@ -137,12 +136,12 @@ class TestStep2SelectedRuns:
             selected_runs={session: ["baseline"]},
         )
 
-        baseline_dir = os.path.join(session, f"{os.path.basename(session)}_output_baseline")
-        strict_dir = os.path.join(session, f"{os.path.basename(session)}_output_strict")
+        baseline_dir = Path(session) / (f"{Path(session).name}_output_baseline")
+        strict_dir = Path(session) / (f"{Path(session).name}_output_strict")
         # Step 2 writes raw store HDF5 files alongside storesList.csv. The selected
         # baseline dir should have those files; the unselected strict dir should not.
-        baseline_hdf5_files = glob.glob(os.path.join(baseline_dir, "*.hdf5"))
-        strict_hdf5_files = glob.glob(os.path.join(strict_dir, "*.hdf5"))
+        baseline_hdf5_files = list(Path(baseline_dir).glob("*.hdf5"))
+        strict_hdf5_files = list(Path(strict_dir).glob("*.hdf5"))
         assert baseline_hdf5_files, "Step 2 produced no HDF5 outputs in the selected run"
         assert not strict_hdf5_files, "Step 2 wrote into the unselected run directory"
 
@@ -185,9 +184,9 @@ class TestStep3SelectedRuns:
             selected_runs={session: ["baseline"]},
         )
 
-        baseline_dir = os.path.join(session, f"{os.path.basename(session)}_output_baseline")
-        strict_dir = os.path.join(session, f"{os.path.basename(session)}_output_strict")
-        baseline_zscore = glob.glob(os.path.join(baseline_dir, "z_score_*.hdf5"))
-        strict_zscore = glob.glob(os.path.join(strict_dir, "z_score_*.hdf5"))
+        baseline_dir = Path(session) / (f"{Path(session).name}_output_baseline")
+        strict_dir = Path(session) / (f"{Path(session).name}_output_strict")
+        baseline_zscore = list(Path(baseline_dir).glob("z_score_*.hdf5"))
+        strict_zscore = list(Path(strict_dir).glob("z_score_*.hdf5"))
         assert baseline_zscore, "Step 3 produced no z-score outputs in the selected run"
         assert not strict_zscore, "Step 3 wrote z-score outputs to the unselected run directory"

--- a/tests/integration/test_integration_photobleaching_detrend.py
+++ b/tests/integration/test_integration_photobleaching_detrend.py
@@ -1,7 +1,6 @@
-import glob
 import json
-import os
 import shutil
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -36,7 +35,7 @@ def run_preprocessing(tmp_path):
         session_copy = temporary_base_directory / session_name
         shutil.copytree(source_session, session_copy)
 
-        for output_directory in glob.glob(os.path.join(session_copy, f"{session_name}_output_*")):
+        for output_directory in list(Path(session_copy).glob(f"{session_name}_output_*")):
             shutil.rmtree(output_directory)
         parameters_path = session_copy / "GuPPyParamtersUsed.json"
         if parameters_path.exists():
@@ -49,9 +48,9 @@ def run_preprocessing(tmp_path):
         step2(**common_kwargs, selected_runs=selected_runs)
         step3(**common_kwargs, selected_runs=selected_runs, **step3_kwargs)
 
-        output_directories = sorted(glob.glob(os.path.join(session_copy, f"{session_name}_output_*")))
+        output_directories = sorted(list(Path(session_copy).glob(f"{session_name}_output_*")))
         for candidate in output_directories:
-            if os.path.exists(os.path.join(candidate, "storesList.csv")):
+            if (Path(candidate) / "storesList.csv").exists():
                 return candidate
         raise AssertionError(f"No storesList.csv found in any output directory under {session_copy}")
 
@@ -72,7 +71,7 @@ def test_detrending_changes_the_fitted_control_and_the_dff(run_preprocessing):
 
     assert plain_fit.shape == detrended_fit.shape
     # No separate trend file: the bleaching lives inside the control fit.
-    assert not os.path.exists(os.path.join(detrended_output, f"photobleaching_trend_{EXPECTED_RECORDING_SITE}.hdf5"))
+    assert not (Path(detrended_output) / (f"photobleaching_trend_{EXPECTED_RECORDING_SITE}.hdf5")).exists()
     assert np.abs(detrended_fit - plain_fit).max() > 0.0
     assert np.abs(detrended_dff - plain_dff).max() > 0.0
 
@@ -81,7 +80,7 @@ def test_detrending_changes_the_fitted_control_and_the_dff(run_preprocessing):
 def test_detrending_choice_is_recorded_in_the_parameter_snapshot(run_preprocessing):
     output_directory = run_preprocessing("recorded", control_fit_method="OLS", photobleaching_detrend=True)
 
-    with open(os.path.join(output_directory, "GuPPyParamtersUsed.json")) as parameters_file:
+    with (Path(output_directory) / "GuPPyParamtersUsed.json").open() as parameters_file:
         parameters = json.load(parameters_file)
     assert parameters["photobleaching_detrend"] is True
 
@@ -113,4 +112,4 @@ def test_detrending_composes_with_baseline_epoch_fitting(run_preprocessing):
         control_fit_window_end=60,
     )
 
-    assert os.path.exists(os.path.join(output_directory, f"dff_{EXPECTED_RECORDING_SITE}.hdf5"))
+    assert (Path(output_directory) / (f"dff_{EXPECTED_RECORDING_SITE}.hdf5")).exists()

--- a/tests/integration/test_integration_save_parameters.py
+++ b/tests/integration/test_integration_save_parameters.py
@@ -1,6 +1,6 @@
 import json
-import os
 from importlib.metadata import version
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -67,9 +67,9 @@ def test_save_parameters(tmp_path, default_parameters):
 
     # Assert: JSON written for each session with key defaults
     for s in sessions:
-        out_fp = os.path.join(s, "GuPPyParamtersUsed.json")
-        assert os.path.exists(out_fp), f"Missing file: {out_fp}"
-        with open(out_fp) as f:
+        out_fp = Path(s) / "GuPPyParamtersUsed.json"
+        assert Path(out_fp).exists(), f"Missing file: {out_fp}"
+        with Path(out_fp).open() as f:
             data = json.load(f)
 
         assert data["guppy_version"] == version("guppy-neuro")

--- a/tests/integration/test_integration_spontaneous_mode.py
+++ b/tests/integration/test_integration_spontaneous_mode.py
@@ -1,7 +1,6 @@
-import glob
 import json
-import os
 import shutil
+from pathlib import Path
 from unittest.mock import patch
 
 import holoviews as hv
@@ -44,7 +43,7 @@ def run_pipeline(tmp_path):
         session_copy = temporary_base_directory / session_name
         shutil.copytree(source_session, session_copy)
 
-        for output_directory in glob.glob(os.path.join(session_copy, f"{session_name}_output_*")):
+        for output_directory in list(Path(session_copy).glob(f"{session_name}_output_*")):
             shutil.rmtree(output_directory)
         parameters_path = session_copy / "GuPPyParamtersUsed.json"
         if parameters_path.exists():
@@ -59,7 +58,7 @@ def run_pipeline(tmp_path):
         step4(**common_kwargs, selected_runs=selected_runs, **step4_kwargs)
 
         return {
-            "output_directory": os.path.join(session_copy, f"{session_name}_output_1"),
+            "output_directory": Path(session_copy) / (f"{session_name}_output_1"),
             "common_kwargs": common_kwargs,
             "selected_runs": selected_runs,
         }
@@ -113,17 +112,17 @@ def test_transient_event_train_is_written_and_drives_the_psth(run_pipeline):
     trial_labels = [column for column in psth.columns if column not in ("timestamps", "mean", "err")]
     np.testing.assert_allclose(np.asarray(trial_labels, dtype=float), event_timestamps, atol=1e-6)
 
-    assert os.path.exists(os.path.join(output_directory, f"peak_AUC_{TRANSIENT_EVENT}_{METRIC_BASENAME}.csv"))
+    assert (Path(output_directory) / (f"peak_AUC_{TRANSIENT_EVENT}_{METRIC_BASENAME}.csv")).exists()
 
 
 @pytest.mark.filterwarnings("ignore::UserWarning")
 def test_no_transient_event_train_when_the_toggle_is_off(run_pipeline):
     output_directory = run_pipeline("ttl_only")["output_directory"]
 
-    assert not os.path.exists(os.path.join(output_directory, f"{TRANSIENT_EVENT}.hdf5"))
-    assert not os.path.exists(os.path.join(output_directory, f"{TRANSIENT_EVENT}_{METRIC_BASENAME}.h5"))
+    assert not (Path(output_directory) / (f"{TRANSIENT_EVENT}.hdf5")).exists()
+    assert not (Path(output_directory) / (f"{TRANSIENT_EVENT}_{METRIC_BASENAME}.h5")).exists()
     # The external TTL event is unaffected.
-    assert os.path.exists(os.path.join(output_directory, f"ttl_{EXPECTED_RECORDING_SITE}.hdf5"))
+    assert (Path(output_directory) / (f"ttl_{EXPECTED_RECORDING_SITE}.hdf5")).exists()
 
 
 @pytest.mark.filterwarnings("ignore::UserWarning")
@@ -139,14 +138,14 @@ def test_both_metrics_produce_two_independent_event_trains(run_pipeline):
     assert from_z_score.size > 0
     assert from_dff.size > 0
     for event in (TRANSIENT_EVENT, f"transients_dff_{EXPECTED_RECORDING_SITE}"):
-        assert os.path.exists(os.path.join(output_directory, f"{event}_{METRIC_BASENAME}.h5"))
+        assert (Path(output_directory) / (f"{event}_{METRIC_BASENAME}.h5")).exists()
 
 
 @pytest.mark.filterwarnings("ignore::UserWarning")
 def test_spontaneous_mode_choice_is_recorded_in_the_parameter_snapshot(run_pipeline):
     output_directory = run_pipeline("recorded", use_transients_as_events=True)["output_directory"]
 
-    with open(os.path.join(output_directory, "GuPPyParamtersUsed.json")) as parameters_file:
+    with (Path(output_directory) / "GuPPyParamtersUsed.json").open() as parameters_file:
         parameters = json.load(parameters_file)
     assert parameters["useTransientsAsEvents"] is True
 

--- a/tests/integration/test_integration_step1.py
+++ b/tests/integration/test_integration_step1.py
@@ -1,8 +1,7 @@
 import csv
-import glob
 import json
-import os
 import shutil
+from pathlib import Path
 
 import pytest
 
@@ -176,19 +175,19 @@ def test_step1(tmp_path, session_subdir, store_id_to_store_label):
         npm_time_unit = "milliseconds"
     # Source sample data
     src_base_dir = str(STUBBED_TESTING_DATA)
-    src_session = os.path.join(src_base_dir, session_subdir)
-    assert os.path.isdir(src_session), f"Sample data not available at expected path: {src_session}"
+    src_session = Path(src_base_dir) / session_subdir
+    assert Path(src_session).is_dir(), f"Sample data not available at expected path: {src_session}"
 
     # Stage a clean copy of the session into a temporary workspace
     tmp_base = tmp_path / "data_root"
     tmp_base.mkdir(parents=True, exist_ok=True)
-    dest_name = os.path.basename(src_session)
+    dest_name = Path(src_session).name
     session_copy = tmp_base / dest_name
     shutil.copytree(src_session, session_copy)
 
     # Remove any copied artifacts in the temp session; match only this session's output directory(ies)
-    for d in glob.glob(os.path.join(session_copy, f"{dest_name}_output_*")):
-        assert os.path.isdir(d), f"Expected output directory for cleanup, got non-directory: {d}"
+    for d in list(Path(session_copy).glob(f"{dest_name}_output_*")):
+        assert Path(d).is_dir(), f"Expected output directory for cleanup, got non-directory: {d}"
         shutil.rmtree(d)
 
     # Remove any copied GuPPyParamtersUsed.json to ensure a fresh run
@@ -207,21 +206,21 @@ def test_step1(tmp_path, session_subdir, store_id_to_store_label):
     )
 
     # Validate storesList.csv exists and matches the mapping exactly (order-preserved)
-    basename = os.path.basename(session_copy)
-    run_folders = sorted(glob.glob(os.path.join(session_copy, f"{basename}_output_*")))
+    basename = Path(session_copy).name
+    run_folders = sorted(list(Path(session_copy).glob(f"{basename}_output_*")))
     assert run_folders, f"No output directories found in {session_copy}"
 
     out_dir = None
     for d in run_folders:
-        if os.path.exists(os.path.join(d, "storesList.csv")):
+        if (Path(d) / "storesList.csv").exists():
             out_dir = d
             break
     assert out_dir is not None, f"No storesList.csv found in any output directory under {session_copy}"
 
-    out_fp = os.path.join(out_dir, "storesList.csv")
-    assert os.path.exists(out_fp), f"Missing storesList.csv: {out_fp}"
+    out_fp = Path(out_dir) / "storesList.csv"
+    assert Path(out_fp).exists(), f"Missing storesList.csv: {out_fp}"
 
-    with open(out_fp, newline="") as f:
+    with Path(out_fp).open(newline="") as f:
         reader = csv.reader(f)
         rows = list(reader)
 
@@ -233,20 +232,20 @@ def test_step1(tmp_path, session_subdir, store_id_to_store_label):
     # source session folder, and must persist the decomposition params next to storesList.csv.
     if session_subdir.startswith("npm/"):
         intermediates = (
-            glob.glob(os.path.join(session_copy, "file*_chev*.csv"))
-            + glob.glob(os.path.join(session_copy, "file*_chod*.csv"))
-            + glob.glob(os.path.join(session_copy, "file*_chpr*.csv"))
-            + glob.glob(os.path.join(session_copy, "event*.csv"))
+            list(Path(session_copy).glob("file*_chev*.csv"))
+            + list(Path(session_copy).glob("file*_chod*.csv"))
+            + list(Path(session_copy).glob("file*_chpr*.csv"))
+            + list(Path(session_copy).glob("event*.csv"))
         )
         assert intermediates == [], f"NPM Step 1 wrote intermediate CSVs into the source folder: {intermediates}"
 
-        npm_params_fp = os.path.join(out_dir, ".npm_params.json")
-        assert os.path.exists(npm_params_fp), f"Missing persisted NPM params at Step 1: {npm_params_fp}"
+        npm_params_fp = Path(out_dir) / ".npm_params.json"
+        assert Path(npm_params_fp).exists(), f"Missing persisted NPM params at Step 1: {npm_params_fp}"
 
         # The persisted unit is the only record of the clock a run was read with, so it must
         # state the unit that was actually applied — not a default the extractor overrode
         # (issue #411). "seconds" is what an unset unit resolves to.
-        with open(npm_params_fp) as npm_params_file:
+        with Path(npm_params_fp).open() as npm_params_file:
             npm_params = json.load(npm_params_file)
         assert npm_params["npm_time_unit"] == (npm_time_unit or "seconds")
         # Sessions offering more than one timestamp column persist the confirmed selection

--- a/tests/integration/test_integration_step1_idempotent.py
+++ b/tests/integration/test_integration_step1_idempotent.py
@@ -1,7 +1,6 @@
 import csv
-import glob
-import os
 import shutil
+from pathlib import Path
 
 from guppy.testing.api import step1
 from guppy_test_data import STUBBED_TESTING_DATA
@@ -24,12 +23,12 @@ def test_step1_npm_idempotent(tmp_path):
     }
 
     src_base_dir = str(STUBBED_TESTING_DATA)
-    src_session = os.path.join(src_base_dir, session_subdir)
-    assert os.path.isdir(src_session), f"Sample data not available at expected path: {src_session}"
+    src_session = Path(src_base_dir) / session_subdir
+    assert Path(src_session).is_dir(), f"Sample data not available at expected path: {src_session}"
 
     tmp_base = tmp_path / "data_root"
     tmp_base.mkdir(parents=True, exist_ok=True)
-    session_copy = tmp_base / os.path.basename(src_session)
+    session_copy = tmp_base / Path(src_session).name
     shutil.copytree(src_session, session_copy)
 
     step1_kwargs = dict(
@@ -46,13 +45,13 @@ def test_step1_npm_idempotent(tmp_path):
     step1(**step1_kwargs)
 
     # Validate storesList.csv exists and matches the mapping after the second run
-    basename = os.path.basename(session_copy)
-    run_folders = sorted(glob.glob(os.path.join(session_copy, f"{basename}_output_*")))
+    basename = Path(session_copy).name
+    run_folders = sorted(list(Path(session_copy).glob(f"{basename}_output_*")))
     assert run_folders, f"No output directories found in {session_copy}"
-    out_dir = next((d for d in run_folders if os.path.exists(os.path.join(d, "storesList.csv"))), None)
+    out_dir = next((d for d in run_folders if (Path(d) / "storesList.csv").exists()), None)
     assert out_dir is not None, f"No storesList.csv found under {session_copy}"
 
-    with open(os.path.join(out_dir, "storesList.csv"), newline="") as f:
+    with (Path(out_dir) / "storesList.csv").open(newline="") as f:
         rows = list(csv.reader(f))
     assert len(rows) == 2
     assert rows[0] == list(store_id_to_store_label.keys())

--- a/tests/integration/test_integration_step2.py
+++ b/tests/integration/test_integration_step2.py
@@ -1,6 +1,6 @@
 import csv
-import os
 import shutil
+from pathlib import Path
 
 import h5py
 import numpy as np
@@ -28,9 +28,9 @@ def test_step2(step2_fixture_name, request):
     """Validate Step 2 outputs for the representative integration sessions."""
     pipeline_state = request.getfixturevalue(step2_fixture_name)
     output_directory = str(pipeline_state["output_directory"])
-    stores_file_path = os.path.join(output_directory, "storesList.csv")
+    stores_file_path = Path(output_directory) / "storesList.csv"
 
-    with open(stores_file_path, newline="") as stores_file:
+    with Path(stores_file_path).open(newline="") as stores_file:
         stores_rows = list(csv.reader(stores_file))
 
     assert len(stores_rows) == 2, "storesList.csv should be 2 rows (store_ids, store_labels)"
@@ -38,14 +38,14 @@ def test_step2(step2_fixture_name, request):
     assert store_ids, "Expected at least one store_id in storesList.csv"
 
     # Step 2 auto-writes the parameter snapshot into the selected output directory.
-    assert os.path.exists(
-        os.path.join(output_directory, "GuPPyParamtersUsed.json")
-    ), "step 2 should write GuPPyParamtersUsed.json into the output directory"
+    assert (
+        Path(output_directory) / "GuPPyParamtersUsed.json"
+    ).exists(), "step 2 should write GuPPyParamtersUsed.json into the output directory"
 
     for store_id in store_ids:
         safe_store_id = store_id.replace("\\", "_").replace("/", "_")
-        store_id_file_path = os.path.join(output_directory, f"{safe_store_id}.hdf5")
-        assert os.path.exists(store_id_file_path), f"Missing HDF5 for store_id {store_id!r} at {store_id_file_path}"
+        store_id_file_path = Path(output_directory) / (f"{safe_store_id}.hdf5")
+        assert Path(store_id_file_path).exists(), f"Missing HDF5 for store_id {store_id!r} at {store_id_file_path}"
 
         with h5py.File(store_id_file_path, "r") as store_id_file:
             assert "timestamps" in store_id_file, "Expected 'timestamps' dataset in HDF5"
@@ -64,10 +64,10 @@ class TestStep2ProgressAccounting:
         token = _current_step.set(step)
 
         config = REPRESENTATIVE_SESSIONS["tdt"]
-        source = os.path.join(str(STUBBED_TESTING_DATA), config["session_subdir"])
+        source = Path(str(STUBBED_TESTING_DATA)) / config["session_subdir"]
         base_directory = tmp_path / "base"
         base_directory.mkdir()
-        session_copy = base_directory / os.path.basename(source)
+        session_copy = base_directory / Path(source).name
         shutil.copytree(source, session_copy)
 
         step1(
@@ -79,9 +79,9 @@ class TestStep2ProgressAccounting:
 
         from guppy.extractors.tdt_recording_extractor import TdtRecordingExtractor
 
-        stores_list = np.genfromtxt(
-            os.path.join(output_directory, "storesList.csv"), dtype="str", delimiter=","
-        ).reshape(2, -1)
+        stores_list = np.genfromtxt(Path(output_directory) / "storesList.csv", dtype="str", delimiter=",").reshape(
+            2, -1
+        )
         extractor = TdtRecordingExtractor(str(session_copy))
         expected_total_samples = sum(extractor.count_samples(event=event) for event in np.unique(stores_list[0, :]))
 
@@ -89,7 +89,7 @@ class TestStep2ProgressAccounting:
             step2(
                 base_dir=str(base_directory),
                 selected_folders=[str(session_copy)],
-                selected_runs={str(session_copy): [os.path.basename(output_directory).rsplit("_", 1)[-1]]},
+                selected_runs={str(session_copy): [Path(output_directory).name.rsplit("_", 1)[-1]]},
             )
         finally:
             _current_step.reset(token)

--- a/tests/integration/test_integration_step3.py
+++ b/tests/integration/test_integration_step3.py
@@ -1,5 +1,5 @@
 import json
-import os
+from pathlib import Path
 
 import h5py
 import pytest
@@ -43,13 +43,13 @@ def test_step3(step3_fixture_name, expected_recording_site, expected_ttl, reques
     """
     pipeline_state = request.getfixturevalue(step3_fixture_name)
     output_directory = str(pipeline_state["output_directory"])
-    stores_file_path = os.path.join(output_directory, "storesList.csv")
-    assert os.path.exists(stores_file_path), "Missing storesList.csv after Step 1/3/4"
+    stores_file_path = Path(output_directory) / "storesList.csv"
+    assert Path(stores_file_path).exists(), "Missing storesList.csv after Step 1/3/4"
 
     # Step 3 auto-writes the executed parameters into the output directory.
-    parameters_file_path = os.path.join(output_directory, "GuPPyParamtersUsed.json")
-    assert os.path.exists(parameters_file_path), "step 3 should write GuPPyParamtersUsed.json into the output directory"
-    with open(parameters_file_path) as parameters_file:
+    parameters_file_path = Path(output_directory) / "GuPPyParamtersUsed.json"
+    assert Path(parameters_file_path).exists(), "step 3 should write GuPPyParamtersUsed.json into the output directory"
+    with Path(parameters_file_path).open() as parameters_file:
         saved_parameters = json.load(parameters_file)
     # The step-3 fixtures run with removeArtifacts disabled; the snapshot must reflect it.
     assert saved_parameters["removeArtifacts"] is False
@@ -57,8 +57,8 @@ def test_step3(step3_fixture_name, expected_recording_site, expected_ttl, reques
     assert saved_parameters["control_fit_method"] == "IRWLS"
 
     # Ensure timeCorrection_<recording_site>.hdf5 exists with 'timestampNew'
-    time_correction_file_path = os.path.join(output_directory, f"timeCorrection_{expected_recording_site}.hdf5")
-    assert os.path.exists(time_correction_file_path), f"Missing {time_correction_file_path}"
+    time_correction_file_path = Path(output_directory) / (f"timeCorrection_{expected_recording_site}.hdf5")
+    assert Path(time_correction_file_path).exists(), f"Missing {time_correction_file_path}"
     with h5py.File(time_correction_file_path, "r") as time_correction_file:
         assert "timestampNew" in time_correction_file, f"Expected 'timestampNew' dataset in {time_correction_file_path}"
 
@@ -71,7 +71,7 @@ def test_step3(step3_fixture_name, expected_recording_site, expected_ttl, reques
         expected_ttl_names = expected_ttl
 
     for expected_ttl_name in expected_ttl_names:
-        ttl_file_path = os.path.join(output_directory, f"{expected_ttl_name}_{expected_recording_site}.hdf5")
-        assert os.path.exists(ttl_file_path), f"Missing TTL-aligned file {ttl_file_path}"
+        ttl_file_path = Path(output_directory) / (f"{expected_ttl_name}_{expected_recording_site}.hdf5")
+        assert Path(ttl_file_path).exists(), f"Missing TTL-aligned file {ttl_file_path}"
         with h5py.File(ttl_file_path, "r") as ttl_file:
             assert "ts" in ttl_file, f"Expected 'ts' dataset in {ttl_file_path}"

--- a/tests/integration/test_integration_step4.py
+++ b/tests/integration/test_integration_step4.py
@@ -1,6 +1,5 @@
-import glob
-import os
 import shutil
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -60,8 +59,8 @@ def test_step4(step3_fixture_name, expected_recording_site, expected_ttl, reques
     )
 
     output_directory = str(pipeline_state["output_directory"])
-    stores_file_path = os.path.join(output_directory, "storesList.csv")
-    assert os.path.exists(stores_file_path), "Missing storesList.csv after Steps 2-5"
+    stores_file_path = Path(output_directory) / "storesList.csv"
+    assert Path(stores_file_path).exists(), "Missing storesList.csv after Steps 2-5"
 
     # Expected PSTH outputs (defaults compute z_score PSTH) - only for datasets with TTLs
     if expected_ttl is None:
@@ -72,30 +71,26 @@ def test_step4(step3_fixture_name, expected_recording_site, expected_ttl, reques
         expected_ttl_names = expected_ttl
 
     for expected_ttl_name in expected_ttl_names:
-        psth_file_path = os.path.join(
-            output_directory,
-            f"{expected_ttl_name}_{expected_recording_site}_z_score_{expected_recording_site}.h5",
+        psth_file_path = Path(output_directory) / (
+            f"{expected_ttl_name}_{expected_recording_site}_z_score_{expected_recording_site}.h5"
         )
-        baseline_uncorrected_psth_file_path = os.path.join(
-            output_directory,
-            f"{expected_ttl_name}_{expected_recording_site}_baselineUncorrected_z_score_{expected_recording_site}.h5",
+        baseline_uncorrected_psth_file_path = Path(output_directory) / (
+            f"{expected_ttl_name}_{expected_recording_site}_baselineUncorrected_z_score_{expected_recording_site}.h5"
         )
-        peak_auc_h5_file_path = os.path.join(
-            output_directory,
-            f"peak_AUC_{expected_ttl_name}_{expected_recording_site}_z_score_{expected_recording_site}.h5",
+        peak_auc_h5_file_path = Path(output_directory) / (
+            f"peak_AUC_{expected_ttl_name}_{expected_recording_site}_z_score_{expected_recording_site}.h5"
         )
-        peak_auc_csv_file_path = os.path.join(
-            output_directory,
-            f"peak_AUC_{expected_ttl_name}_{expected_recording_site}_z_score_{expected_recording_site}.csv",
+        peak_auc_csv_file_path = Path(output_directory) / (
+            f"peak_AUC_{expected_ttl_name}_{expected_recording_site}_z_score_{expected_recording_site}.csv"
         )
 
         # Assert file creation
-        assert os.path.exists(psth_file_path), f"Missing PSTH HDF5: {psth_file_path}"
-        assert os.path.exists(
+        assert Path(psth_file_path).exists(), f"Missing PSTH HDF5: {psth_file_path}"
+        assert Path(
             baseline_uncorrected_psth_file_path
-        ), f"Missing baseline-uncorrected PSTH HDF5: {baseline_uncorrected_psth_file_path}"
-        assert os.path.exists(peak_auc_h5_file_path), f"Missing PSTH Peak/AUC HDF5: {peak_auc_h5_file_path}"
-        assert os.path.exists(peak_auc_csv_file_path), f"Missing PSTH Peak/AUC CSV: {peak_auc_csv_file_path}"
+        ).exists(), f"Missing baseline-uncorrected PSTH HDF5: {baseline_uncorrected_psth_file_path}"
+        assert Path(peak_auc_h5_file_path).exists(), f"Missing PSTH Peak/AUC HDF5: {peak_auc_h5_file_path}"
+        assert Path(peak_auc_csv_file_path).exists(), f"Missing PSTH Peak/AUC CSV: {peak_auc_csv_file_path}"
 
         # Basic readability checks: PSTH HDF5 contains a DataFrame with expected columns
         psth_dataframe = pd.read_hdf(psth_file_path, key="df")
@@ -104,28 +99,25 @@ def test_step4(step3_fixture_name, expected_recording_site, expected_ttl, reques
         assert "mean" in psth_dataframe.columns, f"'mean' column missing in {psth_file_path}"
 
     # Additional artifacts from transients frequency/amplitude computation (Step 4 side-effect)
-    frequency_and_amplitude_h5_file_path = os.path.join(
-        output_directory, f"freqAndAmp_z_score_{expected_recording_site}.h5"
+    frequency_and_amplitude_h5_file_path = Path(output_directory) / (f"freqAndAmp_z_score_{expected_recording_site}.h5")
+    frequency_and_amplitude_csv_file_path = Path(output_directory) / (
+        f"freqAndAmp_z_score_{expected_recording_site}.csv"
     )
-    frequency_and_amplitude_csv_file_path = os.path.join(
-        output_directory, f"freqAndAmp_z_score_{expected_recording_site}.csv"
+    transients_occurrences_csv_file_path = Path(output_directory) / (
+        f"transientsOccurrences_z_score_{expected_recording_site}.csv"
     )
-    transients_occurrences_csv_file_path = os.path.join(
-        output_directory,
-        f"transientsOccurrences_z_score_{expected_recording_site}.csv",
-    )
-    assert os.path.exists(
+    assert Path(
         frequency_and_amplitude_h5_file_path
-    ), f"Missing freq/amp HDF5: {frequency_and_amplitude_h5_file_path}"
-    assert os.path.exists(
+    ).exists(), f"Missing freq/amp HDF5: {frequency_and_amplitude_h5_file_path}"
+    assert Path(
         frequency_and_amplitude_csv_file_path
-    ), f"Missing freq/amp CSV: {frequency_and_amplitude_csv_file_path}"
-    assert os.path.exists(
+    ).exists(), f"Missing freq/amp CSV: {frequency_and_amplitude_csv_file_path}"
+    assert Path(
         transients_occurrences_csv_file_path
-    ), f"Missing transients occurrences CSV: {transients_occurrences_csv_file_path}"
+    ).exists(), f"Missing transients occurrences CSV: {transients_occurrences_csv_file_path}"
 
     # Binned metrics are opt-in, so a default Step 4 must not produce them.
-    binned_metrics_file_paths = glob.glob(os.path.join(output_directory, "binned_metrics_*"))
+    binned_metrics_file_paths = list(Path(output_directory).glob("binned_metrics_*"))
     assert binned_metrics_file_paths == [], f"Unexpected binned metrics outputs: {binned_metrics_file_paths}"
 
 
@@ -140,8 +132,8 @@ def test_step4_rejects_events_that_share_no_timeline_with_the_signal(tmp_path):
     base_directory = tmp_path / "data_root"
     base_directory.mkdir()
     session_copy = base_directory / "sample_data_csv_1"
-    shutil.copytree(os.path.join(STUBBED_TESTING_DATA, "csv", "sample_data_csv_1"), session_copy)
-    for stale_output in glob.glob(os.path.join(session_copy, "sample_data_csv_1_output_*")):
+    shutil.copytree(Path(STUBBED_TESTING_DATA) / "csv" / "sample_data_csv_1", session_copy)
+    for stale_output in session_copy.glob("sample_data_csv_1_output_*"):
         shutil.rmtree(stale_output)
 
     # The session's photometry spans [0, 411]s; these sit ~50000s away, as an unconverted
@@ -170,5 +162,5 @@ def test_step4_rejects_events_that_share_no_timeline_with_the_signal(tmp_path):
     with pytest.raises(ValueError, match=r"no trial overlaps the 'region' signal"):
         step4(base_dir=base_dir, selected_folders=selected_folders, selected_runs=selected_runs)
 
-    output_directory = glob.glob(os.path.join(session_copy, "sample_data_csv_1_output_*"))[0]
-    assert glob.glob(os.path.join(output_directory, "ttl_region_z_score_region.h5")) == []
+    output_directory = next(session_copy.glob("sample_data_csv_1_output_*"))
+    assert list(output_directory.glob("ttl_region_z_score_region.h5")) == []

--- a/tests/integration/test_integration_step5.py
+++ b/tests/integration/test_integration_step5.py
@@ -1,6 +1,5 @@
-import glob
-import os
 import shutil
+from pathlib import Path
 from unittest.mock import patch
 
 import holoviews as hv
@@ -90,8 +89,8 @@ def test_step5_raises_when_visualization_metric_not_computed_in_step4(tmp_path):
     session_copy = temporary_base_directory / session_name
     shutil.copytree(source_session, session_copy)
 
-    for output_directory in glob.glob(os.path.join(session_copy, f"{session_name}_output_*")):
-        assert os.path.isdir(output_directory)
+    for output_directory in list(Path(session_copy).glob(f"{session_name}_output_*")):
+        assert Path(output_directory).is_dir()
         shutil.rmtree(output_directory)
     parameters_path = session_copy / "GuPPyParamtersUsed.json"
     if parameters_path.exists():

--- a/tests/integration/test_integration_underscore_recording_site.py
+++ b/tests/integration/test_integration_underscore_recording_site.py
@@ -1,6 +1,5 @@
-import glob
-import os
 import shutil
+from pathlib import Path
 
 import pandas as pd
 import pytest
@@ -51,8 +50,8 @@ def test_underscore_recording_site_runs_end_to_end(tmp_path, isosbestic_control,
     session_copy = temporary_base_directory / session_name
     shutil.copytree(source_session, session_copy)
 
-    for output_directory in glob.glob(os.path.join(session_copy, f"{session_name}_output_*")):
-        assert os.path.isdir(output_directory)
+    for output_directory in list(Path(session_copy).glob(f"{session_name}_output_*")):
+        assert Path(output_directory).is_dir()
         shutil.rmtree(output_directory)
     parameters_path = session_copy / "GuPPyParamtersUsed.json"
     if parameters_path.exists():
@@ -69,31 +68,29 @@ def test_underscore_recording_site_runs_end_to_end(tmp_path, isosbestic_control,
     step3(**common_kwargs, isosbestic_control=isosbestic_control, selected_runs=selected_runs)
     step4(**common_kwargs, selected_runs=selected_runs)
 
-    output_directories = sorted(glob.glob(os.path.join(session_copy, f"{session_name}_output_*")))
+    output_directories = sorted(list(Path(session_copy).glob(f"{session_name}_output_*")))
     assert output_directories, f"No output directories found in {session_copy}"
     output_directory = None
     for candidate in output_directories:
-        if os.path.exists(os.path.join(candidate, "storesList.csv")):
+        if (Path(candidate) / "storesList.csv").exists():
             output_directory = candidate
             break
     assert output_directory is not None, f"No storesList.csv found in any output directory under {session_copy}"
 
     # The full underscore recording site must appear intact in every derived artifact name.
-    psth_file_path = os.path.join(
-        output_directory, f"{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_z_score_{EXPECTED_RECORDING_SITE}.h5"
+    psth_file_path = Path(output_directory) / (
+        f"{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_z_score_{EXPECTED_RECORDING_SITE}.h5"
     )
-    peak_auc_h5_file_path = os.path.join(
-        output_directory, f"peak_AUC_{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_z_score_{EXPECTED_RECORDING_SITE}.h5"
+    peak_auc_h5_file_path = Path(output_directory) / (
+        f"peak_AUC_{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_z_score_{EXPECTED_RECORDING_SITE}.h5"
     )
-    frequency_and_amplitude_h5_file_path = os.path.join(
-        output_directory, f"freqAndAmp_z_score_{EXPECTED_RECORDING_SITE}.h5"
-    )
+    frequency_and_amplitude_h5_file_path = Path(output_directory) / (f"freqAndAmp_z_score_{EXPECTED_RECORDING_SITE}.h5")
 
-    assert os.path.exists(psth_file_path), f"Missing PSTH HDF5: {psth_file_path}"
-    assert os.path.exists(peak_auc_h5_file_path), f"Missing peak/AUC HDF5: {peak_auc_h5_file_path}"
-    assert os.path.exists(
+    assert Path(psth_file_path).exists(), f"Missing PSTH HDF5: {psth_file_path}"
+    assert Path(peak_auc_h5_file_path).exists(), f"Missing peak/AUC HDF5: {peak_auc_h5_file_path}"
+    assert Path(
         frequency_and_amplitude_h5_file_path
-    ), f"Missing freq/amp HDF5: {frequency_and_amplitude_h5_file_path}"
+    ).exists(), f"Missing freq/amp HDF5: {frequency_and_amplitude_h5_file_path}"
 
     psth_dataframe = pd.read_hdf(psth_file_path, key="df")
     assert "timestamps" in psth_dataframe.columns, f"'timestamps' column missing in {psth_file_path}"

--- a/tests/integration/test_integration_zscore_method.py
+++ b/tests/integration/test_integration_zscore_method.py
@@ -1,6 +1,5 @@
-import glob
-import os
 import shutil
+from pathlib import Path
 
 import pandas as pd
 import pytest
@@ -45,8 +44,8 @@ def test_zscore_method(tmp_path, zscore_method, step3_extra_kwargs):
     session_copy = temporary_base_directory / session_name
     shutil.copytree(source_session, session_copy)
 
-    for output_directory in glob.glob(os.path.join(session_copy, f"{session_name}_output_*")):
-        assert os.path.isdir(output_directory)
+    for output_directory in list(Path(session_copy).glob(f"{session_name}_output_*")):
+        assert Path(output_directory).is_dir()
         shutil.rmtree(output_directory)
     parameters_path = session_copy / "GuPPyParamtersUsed.json"
     if parameters_path.exists():
@@ -63,59 +62,53 @@ def test_zscore_method(tmp_path, zscore_method, step3_extra_kwargs):
     step3(**common_kwargs, zscore_method=zscore_method, selected_runs=selected_runs, **step3_extra_kwargs)
     step4(**common_kwargs, selected_runs=selected_runs)
 
-    output_directories = sorted(glob.glob(os.path.join(session_copy, f"{session_name}_output_*")))
+    output_directories = sorted(list(Path(session_copy).glob(f"{session_name}_output_*")))
     assert output_directories, f"No output directories found in {session_copy}"
     output_directory = None
     for candidate in output_directories:
-        if os.path.exists(os.path.join(candidate, "storesList.csv")):
+        if (Path(candidate) / "storesList.csv").exists():
             output_directory = candidate
             break
     assert output_directory is not None, f"No storesList.csv found in any output directory under {session_copy}"
 
-    psth_file_path = os.path.join(
-        output_directory,
-        f"{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_z_score_{EXPECTED_RECORDING_SITE}.h5",
+    psth_file_path = Path(output_directory) / (
+        f"{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_z_score_{EXPECTED_RECORDING_SITE}.h5"
     )
-    baseline_uncorrected_file_path = os.path.join(
-        output_directory,
-        f"{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_baselineUncorrected_z_score_{EXPECTED_RECORDING_SITE}.h5",
+    baseline_uncorrected_file_path = Path(output_directory) / (
+        f"{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_baselineUncorrected_z_score_{EXPECTED_RECORDING_SITE}.h5"
     )
-    peak_auc_h5_file_path = os.path.join(
-        output_directory,
-        f"peak_AUC_{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_z_score_{EXPECTED_RECORDING_SITE}.h5",
+    peak_auc_h5_file_path = Path(output_directory) / (
+        f"peak_AUC_{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_z_score_{EXPECTED_RECORDING_SITE}.h5"
     )
-    peak_auc_csv_file_path = os.path.join(
-        output_directory,
-        f"peak_AUC_{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_z_score_{EXPECTED_RECORDING_SITE}.csv",
+    peak_auc_csv_file_path = Path(output_directory) / (
+        f"peak_AUC_{EXPECTED_TTL}_{EXPECTED_RECORDING_SITE}_z_score_{EXPECTED_RECORDING_SITE}.csv"
     )
 
-    assert os.path.exists(psth_file_path), f"Missing PSTH HDF5: {psth_file_path}"
-    assert os.path.exists(
+    assert Path(psth_file_path).exists(), f"Missing PSTH HDF5: {psth_file_path}"
+    assert Path(
         baseline_uncorrected_file_path
-    ), f"Missing baseline-uncorrected PSTH HDF5: {baseline_uncorrected_file_path}"
-    assert os.path.exists(peak_auc_h5_file_path), f"Missing peak/AUC HDF5: {peak_auc_h5_file_path}"
-    assert os.path.exists(peak_auc_csv_file_path), f"Missing peak/AUC CSV: {peak_auc_csv_file_path}"
+    ).exists(), f"Missing baseline-uncorrected PSTH HDF5: {baseline_uncorrected_file_path}"
+    assert Path(peak_auc_h5_file_path).exists(), f"Missing peak/AUC HDF5: {peak_auc_h5_file_path}"
+    assert Path(peak_auc_csv_file_path).exists(), f"Missing peak/AUC CSV: {peak_auc_csv_file_path}"
 
     psth_dataframe = pd.read_hdf(psth_file_path, key="df")
     assert "timestamps" in psth_dataframe.columns, f"'timestamps' column missing in {psth_file_path}"
     assert "mean" in psth_dataframe.columns, f"'mean' column missing in {psth_file_path}"
 
-    frequency_and_amplitude_h5_file_path = os.path.join(
-        output_directory, f"freqAndAmp_z_score_{EXPECTED_RECORDING_SITE}.h5"
+    frequency_and_amplitude_h5_file_path = Path(output_directory) / (f"freqAndAmp_z_score_{EXPECTED_RECORDING_SITE}.h5")
+    frequency_and_amplitude_csv_file_path = Path(output_directory) / (
+        f"freqAndAmp_z_score_{EXPECTED_RECORDING_SITE}.csv"
     )
-    frequency_and_amplitude_csv_file_path = os.path.join(
-        output_directory, f"freqAndAmp_z_score_{EXPECTED_RECORDING_SITE}.csv"
-    )
-    transients_occurrences_csv_file_path = os.path.join(
-        output_directory, f"transientsOccurrences_z_score_{EXPECTED_RECORDING_SITE}.csv"
+    transients_occurrences_csv_file_path = Path(output_directory) / (
+        f"transientsOccurrences_z_score_{EXPECTED_RECORDING_SITE}.csv"
     )
 
-    assert os.path.exists(
+    assert Path(
         frequency_and_amplitude_h5_file_path
-    ), f"Missing freq/amp HDF5: {frequency_and_amplitude_h5_file_path}"
-    assert os.path.exists(
+    ).exists(), f"Missing freq/amp HDF5: {frequency_and_amplitude_h5_file_path}"
+    assert Path(
         frequency_and_amplitude_csv_file_path
-    ), f"Missing freq/amp CSV: {frequency_and_amplitude_csv_file_path}"
-    assert os.path.exists(
+    ).exists(), f"Missing freq/amp CSV: {frequency_and_amplitude_csv_file_path}"
+    assert Path(
         transients_occurrences_csv_file_path
-    ), f"Missing transients occurrences CSV: {transients_occurrences_csv_file_path}"
+    ).exists(), f"Missing transients occurrences CSV: {transients_occurrences_csv_file_path}"

--- a/tests/integration/test_psth_significance.py
+++ b/tests/integration/test_psth_significance.py
@@ -1,5 +1,5 @@
-import os
 import shutil
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -33,14 +33,14 @@ EXPECTED_TWO_SAMPLE_COLUMNS = EXPECTED_ONE_SAMPLE_COLUMNS + ["n_b"]
 
 
 def results_path(output_directory):
-    return os.path.join(output_directory, PSTH_SIGNIFICANCE_DIRNAME)
+    return Path(output_directory) / PSTH_SIGNIFICANCE_DIRNAME
 
 
 @pytest.fixture(scope="module")
 def preprocessed_session(tmp_path_factory):
-    source_session = os.path.join(str(STUBBED_TESTING_DATA), SESSION_SUBDIR)
+    source_session = Path(str(STUBBED_TESTING_DATA)) / SESSION_SUBDIR
     base_directory = tmp_path_factory.mktemp("integration_psth_significance")
-    session = base_directory / os.path.basename(source_session)
+    session = base_directory / Path(source_session).name
     # Output directories are gitignored, so a stale one from a previous local run
     # would otherwise seed this session.
     shutil.copytree(source_session, session, ignore=shutil.ignore_patterns("*_output_*"))
@@ -79,7 +79,7 @@ def significance_output(preprocessed_session):
 
 class TestSessionScopeSignificance:
     def test_writes_a_file_for_every_planned_comparison(self, significance_output):
-        written = sorted(os.listdir(results_path(significance_output)))
+        written = sorted([entry.name for entry in Path(results_path(significance_output)).iterdir()])
 
         assert written == [
             "significance_port_entries_dms_z_score_dms.csv",
@@ -93,7 +93,7 @@ class TestSessionScopeSignificance:
     def test_an_event_with_too_few_trials_is_skipped(self, significance_output):
         # rewarded_nose_pokes fires twice, below the three the bootstrap needs. It is
         # skipped rather than written with a meaningless interval.
-        written = os.listdir(results_path(significance_output))
+        written = [entry.name for entry in Path(results_path(significance_output)).iterdir()]
 
         assert not any(name.startswith("significance_" + UNDERPOWERED_EVENT) for name in written)
 
@@ -113,7 +113,7 @@ class TestSessionScopeSignificance:
         assert list(significance.columns) == EXPECTED_TWO_SAMPLE_COLUMNS
 
     def test_sample_counts_match_the_psth_trials(self, significance_output):
-        psth = pd.read_hdf(os.path.join(significance_output, "port_entries_dms_z_score_dms.h5"), key="df", mode="r")
+        psth = pd.read_hdf(Path(significance_output) / "port_entries_dms_z_score_dms.h5", key="df", mode="r")
         num_trials = len([column for column in psth.columns if column not in ("timestamps", "mean", "err")])
 
         significance = read_psth_significance_from_hdf5(
@@ -123,7 +123,7 @@ class TestSessionScopeSignificance:
         assert significance["n"].iloc[0] == num_trials
 
     def test_time_axis_matches_the_psth(self, significance_output):
-        psth = pd.read_hdf(os.path.join(significance_output, "port_entries_dms_z_score_dms.h5"), key="df", mode="r")
+        psth = pd.read_hdf(Path(significance_output) / "port_entries_dms_z_score_dms.h5", key="df", mode="r")
         significance = read_psth_significance_from_hdf5(
             filepath=results_path(significance_output), name="port_entries_dms_z_score_dms"
         )
@@ -168,7 +168,7 @@ class TestSessionScopeSignificance:
             filepath=results_path(significance_output), name="port_entries_dms_z_score_dms"
         )
         from_csv = pd.read_csv(
-            os.path.join(results_path(significance_output), "significance_port_entries_dms_z_score_dms.csv")
+            Path(results_path(significance_output)) / "significance_port_entries_dms_z_score_dms.csv"
         )
 
         pd.testing.assert_frame_equal(significance.reset_index(drop=True), from_csv, check_dtype=False)
@@ -185,7 +185,7 @@ class TestSessionScopeSignificance:
     def test_parameters_are_recorded_in_the_snapshot(self, significance_output):
         import json
 
-        with open(os.path.join(significance_output, "GuPPyParamtersUsed.json")) as parameters_file:
+        with (Path(significance_output) / "GuPPyParamtersUsed.json").open() as parameters_file:
             saved = json.load(parameters_file)
 
         assert saved["computePsthSignificance"] is True
@@ -196,9 +196,9 @@ class TestSessionScopeSignificance:
 
 class TestSignificanceIsOptional:
     def test_step4_without_the_flag_writes_no_results(self, tmp_path_factory):
-        source_session = os.path.join(str(STUBBED_TESTING_DATA), SESSION_SUBDIR)
+        source_session = Path(str(STUBBED_TESTING_DATA)) / SESSION_SUBDIR
         base_directory = tmp_path_factory.mktemp("integration_psth_significance_off")
-        session = base_directory / os.path.basename(source_session)
+        session = base_directory / Path(source_session).name
         shutil.copytree(source_session, session, ignore=shutil.ignore_patterns("*_output_*"))
 
         step1(
@@ -212,14 +212,14 @@ class TestSignificanceIsOptional:
         step3(base_dir=str(base_directory), selected_folders=[str(session)], selected_runs=selected_runs)
         step4(base_dir=str(base_directory), selected_folders=[str(session)], selected_runs=selected_runs)
 
-        assert not os.path.exists(results_path(output_directory))
+        assert not Path(results_path(output_directory)).exists()
 
 
 class TestGroupScopeSignificance:
     @pytest.fixture(scope="class")
     def group_folder(self, tmp_path_factory):
         """A three-member group built from repeats of the stubbed session."""
-        source_session = os.path.join(str(STUBBED_TESTING_DATA), SESSION_SUBDIR)
+        source_session = Path(str(STUBBED_TESTING_DATA)) / SESSION_SUBDIR
         base_directory = tmp_path_factory.mktemp("integration_psth_significance_group")
 
         member_run_folders = []
@@ -243,7 +243,7 @@ class TestGroupScopeSignificance:
             destination_directory=str(base_directory),
             group_name="saline",
         )
-        group_folder = os.path.join(str(base_directory), "saline_group")
+        group_folder = Path(str(base_directory)) / "saline_group"
         group_analysis(
             base_dir=str(base_directory),
             selected_group_folders=[group_folder],
@@ -255,8 +255,10 @@ class TestGroupScopeSignificance:
     def test_writes_results_into_the_group_directory(self, group_folder):
         folder, _ = group_folder
 
-        assert os.path.exists(results_path(folder))
-        assert "significance_port_entries_dms_z_score_dms.h5" in os.listdir(results_path(folder))
+        assert Path(results_path(folder)).exists()
+        assert "significance_port_entries_dms_z_score_dms.h5" in [
+            entry.name for entry in Path(results_path(folder)).iterdir()
+        ]
 
     def test_resamples_sessions_rather_than_trials(self, group_folder):
         folder, member_count = group_folder

--- a/tests/integration/test_tonic.py
+++ b/tests/integration/test_tonic.py
@@ -9,9 +9,8 @@ averages the traces over them; the resulting ``tonic_region.h5`` is checked for 
 per-epoch means and for the rise-then-recover ordering across the three epochs.
 """
 
-import glob
-import os
 import shutil
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -37,18 +36,18 @@ WASH_OUT_EPOCH = (145.0, 178.0)  # clearance settled onto its residual level
 
 
 def _stubbed_data_root():
-    return os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "stubbed_testing_data")
+    return Path((Path(__file__).parent).parent.parent) / "stubbed_testing_data"
 
 
 def _output_directory(session):
-    return sorted(glob.glob(os.path.join(session, f"{SESSION_NAME}_output_*")))[0]
+    return sorted(list(Path(session).glob(f"{SESSION_NAME}_output_*")))[0]
 
 
 @pytest.fixture
 def injection_session(tmp_path):
-    source = os.path.join(_stubbed_data_root(), SESSION_SUBDIR)
+    source = Path(_stubbed_data_root()) / SESSION_SUBDIR
     base_dir = str(tmp_path)
-    session = os.path.join(base_dir, SESSION_NAME)
+    session = Path(base_dir) / SESSION_NAME
     # Output dirs are gitignored, so running GuPPy against the stubbed data leaves them
     # behind; copying them would seed this session with another run's results.
     shutil.copytree(source, session, ignore=shutil.ignore_patterns("*_output_*"))
@@ -87,8 +86,8 @@ class TestTonicAnalysis:
         )
 
         output_directory = _output_directory(injection_session["session"])
-        tonic_path = os.path.join(output_directory, "tonic_region.h5")
-        assert os.path.exists(tonic_path)
+        tonic_path = Path(output_directory) / "tonic_region.h5"
+        assert Path(tonic_path).exists()
 
         tonic = pd.read_hdf(tonic_path, key="df")
         assert list(tonic.index) == ["baseline", "wash_in", "wash_out"]
@@ -124,4 +123,4 @@ class TestTonicAnalysis:
             selected_runs=injection_session["selected_runs"],
         )
         output_directory = _output_directory(injection_session["session"])
-        assert not os.path.exists(os.path.join(output_directory, "tonic_region.h5"))
+        assert not (Path(output_directory) / "tonic_region.h5").exists()

--- a/tests/unit/analysis/test_io_utils.py
+++ b/tests/unit/analysis/test_io_utils.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -81,8 +81,8 @@ def test_decide_naming_convention_pairs_recording_sites_with_underscores(tmp_pat
     (tmp_path / "signal_left_hemisphere.hdf5").touch()
     result = decide_naming_convention(str(tmp_path))
     assert result.shape == (2, 1)
-    assert os.path.basename(result[0, 0]) == "control_left_hemisphere.hdf5"
-    assert os.path.basename(result[1, 0]) == "signal_left_hemisphere.hdf5"
+    assert Path(result[0, 0]).name == "control_left_hemisphere.hdf5"
+    assert Path(result[1, 0]).name == "signal_left_hemisphere.hdf5"
 
 
 # ── read_hdf5 / write_hdf5 ────────────────────────────────────────────────────

--- a/tests/unit/extractors/test_csv_recording_extractor.py
+++ b/tests/unit/extractors/test_csv_recording_extractor.py
@@ -1,6 +1,5 @@
 """Contract tests for CsvRecordingExtractor."""
 
-import os
 from pathlib import Path
 
 import numpy as np
@@ -36,7 +35,7 @@ from guppy_test_data import STUBBED_TESTING_DATA
 
 class TestCsvRecordingExtractor(RecordingExtractorTestMixin):
     extractor_class = CsvRecordingExtractor
-    folder_path = os.path.join(STUBBED_TESTING_DATA, "csv", "sample_data_csv_1")
+    folder_path = Path(STUBBED_TESTING_DATA) / "csv" / "sample_data_csv_1"
     extractor_instance = CsvRecordingExtractor(folder_path)
     expected_events = ["Sample_Control_Channel", "Sample_Signal_Channel", "Sample_TTL"]
     discover_kwargs = {}
@@ -47,27 +46,27 @@ class TestCsvRecordingExtractor(RecordingExtractorTestMixin):
 
     @pytest.fixture
     def expected_control_timestamps(self):
-        csv_path = os.path.join(self.folder_path, "Sample_Control_Channel.csv")
+        csv_path = Path(self.folder_path) / "Sample_Control_Channel.csv"
         return pd.read_csv(csv_path)["timestamps"].to_numpy()
 
     @pytest.fixture
     def expected_control_data(self):
-        csv_path = os.path.join(self.folder_path, "Sample_Control_Channel.csv")
+        csv_path = Path(self.folder_path) / "Sample_Control_Channel.csv"
         return pd.read_csv(csv_path)["data"].to_numpy()
 
     @pytest.fixture
     def expected_signal_timestamps(self):
-        csv_path = os.path.join(self.folder_path, "Sample_Signal_Channel.csv")
+        csv_path = Path(self.folder_path) / "Sample_Signal_Channel.csv"
         return pd.read_csv(csv_path)["timestamps"].to_numpy()
 
     @pytest.fixture
     def expected_signal_data(self):
-        csv_path = os.path.join(self.folder_path, "Sample_Signal_Channel.csv")
+        csv_path = Path(self.folder_path) / "Sample_Signal_Channel.csv"
         return pd.read_csv(csv_path)["data"].to_numpy()
 
     @pytest.fixture
     def expected_ttl_timestamps(self):
-        csv_path = os.path.join(self.folder_path, "Sample_TTL.csv")
+        csv_path = Path(self.folder_path) / "Sample_TTL.csv"
         return pd.read_csv(csv_path)["timestamps"].to_numpy()
 
 

--- a/tests/unit/extractors/test_detect_acquisition_formats.py
+++ b/tests/unit/extractors/test_detect_acquisition_formats.py
@@ -1,7 +1,7 @@
 """Unit tests for pure helper functions in detect_acquisition_formats."""
 
-import os
 import shutil
+from pathlib import Path
 
 import pytest
 
@@ -132,7 +132,7 @@ def test_classify_csv_file_raises_for_headerless_single_numeric_column(tmp_path)
     ids=["tdt", "doric", "csv", "npm"],
 )
 def test_detect_acquisition_formats(session_subdir, expected_formats):
-    folder_path = os.path.join(STUBBED_TESTING_DATA, session_subdir)
+    folder_path = Path(STUBBED_TESTING_DATA) / session_subdir
     assert detect_acquisition_formats(folder_path) == expected_formats
 
 
@@ -149,8 +149,8 @@ def test_detect_acquisition_formats(session_subdir, expected_formats):
     ids=["tdt_csv", "doric_csv", "npm_csv", "csv_csv"],
 )
 def test_detect_acquisition_formats_with_external_csv_events(tmp_path, session_subdir, expected_formats):
-    src = os.path.join(STUBBED_TESTING_DATA, session_subdir)
-    session_copy = tmp_path / os.path.basename(session_subdir)
+    src = Path(STUBBED_TESTING_DATA) / session_subdir
+    session_copy = tmp_path / Path(session_subdir).name
     shutil.copytree(src, session_copy)
     (session_copy / "port_entries.csv").write_text("timestamps\n0.1\n0.2\n0.3\n")
     assert detect_acquisition_formats(str(session_copy)) == expected_formats
@@ -161,7 +161,7 @@ def test_detect_acquisition_formats_after_npm_split_events(tmp_path):
     # session with split-event TTLs is detected as "npm" only — even after running discover.
     # NPM owns its event streams end-to-end; only a genuine external single-column TTL file
     # would add "csv" (covered by test_detect_acquisition_formats_with_external_csv_events).
-    src = os.path.join(STUBBED_TESTING_DATA, "npm/sampleData_NPM_4")
+    src = Path(STUBBED_TESTING_DATA) / "npm/sampleData_NPM_4"
     session_copy = tmp_path / "sampleData_NPM_4"
     shutil.copytree(src, session_copy)
 
@@ -195,7 +195,7 @@ def test_detect_acquisition_formats_after_npm_split_events(tmp_path):
     ids=["tdt", "doric", "csv", "npm"],
 )
 def test_detect_trace_formats(session_subdir, expected_formats):
-    folder_path = os.path.join(STUBBED_TESTING_DATA, session_subdir)
+    folder_path = Path(STUBBED_TESTING_DATA) / session_subdir
     assert detect_trace_formats(folder_path) == expected_formats
 
 
@@ -212,8 +212,8 @@ def test_detect_trace_formats(session_subdir, expected_formats):
 def test_detect_trace_formats_ignores_external_csv_events(tmp_path, session_subdir, expected_formats):
     # A single-column timestamps CSV carries event onsets and no photometry channel, so it must not
     # make the folder a "csv" trace source the way detect_acquisition_formats reports it.
-    src = os.path.join(STUBBED_TESTING_DATA, session_subdir)
-    session_copy = tmp_path / os.path.basename(session_subdir)
+    src = Path(STUBBED_TESTING_DATA) / session_subdir
+    session_copy = tmp_path / Path(session_subdir).name
     shutil.copytree(src, session_copy)
     (session_copy / "port_entries.csv").write_text("timestamps\n0.1\n0.2\n0.3\n")
 

--- a/tests/unit/extractors/test_doric_recording_extractor.py
+++ b/tests/unit/extractors/test_doric_recording_extractor.py
@@ -1,6 +1,6 @@
 """Contract tests for DoricRecordingExtractor."""
 
-import os
+from pathlib import Path
 
 import h5py
 import numpy as np
@@ -141,7 +141,7 @@ _EVENT_NAME_TO_EVENT_TYPE = {
 
 class TestDoricRecordingExtractor(DoricRecordingExtractorTestMixin):
     extractor_class = DoricRecordingExtractor
-    folder_path = os.path.join(STUBBED_TESTING_DATA, "doric", "sample_doric_1")
+    folder_path = Path(STUBBED_TESTING_DATA) / "doric" / "sample_doric_1"
     extractor_instance = DoricRecordingExtractor(folder_path, _EVENT_NAME_TO_EVENT_TYPE)
     expected_events = ["AIn-1 - Raw", "AIn-2 - Raw", "DI--O-1"]
     discover_kwargs = {}
@@ -161,7 +161,7 @@ _EVENT_NAME_TO_EVENT_TYPE_SAMPLE2 = {
 
 class TestDoricRecordingExtractorSample2(DoricRecordingExtractorTestMixin):
     extractor_class = DoricRecordingExtractor
-    folder_path = os.path.join(STUBBED_TESTING_DATA, "doric", "sample_doric_2")
+    folder_path = Path(STUBBED_TESTING_DATA) / "doric" / "sample_doric_2"
     extractor_instance = DoricRecordingExtractor(folder_path, _EVENT_NAME_TO_EVENT_TYPE_SAMPLE2)
     expected_events = ["AIn-1 - Dem (ref)", "AIn-1 - Dem (da)", "DI/O-1"]
     discover_kwargs = {}
@@ -180,7 +180,7 @@ _EVENT_NAME_TO_EVENT_TYPE_SAMPLE4 = {
 
 class TestDoricRecordingExtractorSample4(DoricRecordingExtractorTestMixin):
     extractor_class = DoricRecordingExtractor
-    folder_path = os.path.join(STUBBED_TESTING_DATA, "doric", "sample_doric_4")
+    folder_path = Path(STUBBED_TESTING_DATA) / "doric" / "sample_doric_4"
     extractor_instance = DoricRecordingExtractor(folder_path, _EVENT_NAME_TO_EVENT_TYPE_SAMPLE4)
     expected_events = ["Series0001/AIN01xAOUT01-LockIn", "Series0001/AIN01xAOUT02-LockIn"]
     discover_kwargs = {}
@@ -198,7 +198,7 @@ _EVENT_NAME_TO_EVENT_TYPE_SAMPLE5 = {
 
 class TestDoricRecordingExtractorSample5(DoricRecordingExtractorTestMixin):
     extractor_class = DoricRecordingExtractor
-    folder_path = os.path.join(STUBBED_TESTING_DATA, "doric", "sample_doric_5")
+    folder_path = Path(STUBBED_TESTING_DATA) / "doric" / "sample_doric_5"
     extractor_instance = DoricRecordingExtractor(folder_path, _EVENT_NAME_TO_EVENT_TYPE_SAMPLE5)
     expected_events = ["Series0001/AIN01xAOUT01-LockIn", "Series0001/AIN01xAOUT02-LockIn"]
     discover_kwargs = {}
@@ -217,7 +217,7 @@ _EVENT_NAME_TO_EVENT_TYPE_V6 = {
 
 class TestDoricRecordingExtractorV6(DoricRecordingExtractorTestMixin):
     extractor_class = DoricRecordingExtractor
-    folder_path = os.path.join(STUBBED_TESTING_DATA, "doric", "sample_doric_3")
+    folder_path = Path(STUBBED_TESTING_DATA) / "doric" / "sample_doric_3"
     extractor_instance = DoricRecordingExtractor(folder_path, _EVENT_NAME_TO_EVENT_TYPE_V6)
     expected_events = ["CAM1_EXC1/ROI01", "CAM1_EXC2/ROI01", "DigitalIO/CAM1"]
     discover_kwargs = {}

--- a/tests/unit/extractors/test_npm_recording_extractor.py
+++ b/tests/unit/extractors/test_npm_recording_extractor.py
@@ -1,7 +1,7 @@
 """Contract tests for NpmRecordingExtractor."""
 
-import os
 import shutil
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -397,7 +397,7 @@ class NpmRecordingExtractorTestMixin(RecordingExtractorTestMixin):
 
 class TestNpmRecordingExtractor(NpmRecordingExtractorTestMixin):
     extractor_class = NpmRecordingExtractor
-    folder_path = os.path.join(STUBBED_TESTING_DATA, "npm", "sampleData_NPM_1")
+    folder_path = Path(STUBBED_TESTING_DATA) / "npm" / "sampleData_NPM_1"
     # This session offers two timestamp columns and its stimuli file rides ComputerTimestamp;
     # the defaults would put the events on a different clock than the photometry. See the
     # sampleData_NPM_1 entry in stubbed_testing_data/README.md.
@@ -414,7 +414,7 @@ class TestNpmRecordingExtractor(NpmRecordingExtractorTestMixin):
 
 class TestNpmRecordingExtractorSession2(NpmRecordingExtractorTestMixin):
     extractor_class = NpmRecordingExtractor
-    folder_path = os.path.join(STUBBED_TESTING_DATA, "npm", "sampleData_NPM_2")
+    folder_path = Path(STUBBED_TESTING_DATA) / "npm" / "sampleData_NPM_2"
     extractor_instance = NpmRecordingExtractor(folder_path, num_ch=2)
     expected_events = ["file0_chev6", "file1_chev6"]
     discover_kwargs = {"num_ch": 2, "inputParameters": {}}
@@ -426,7 +426,7 @@ class TestNpmRecordingExtractorSession2(NpmRecordingExtractorTestMixin):
 
 class TestNpmRecordingExtractorSession3(NpmRecordingExtractorTestMixin):
     extractor_class = NpmRecordingExtractor
-    folder_path = os.path.join(STUBBED_TESTING_DATA, "npm", "sampleData_NPM_3")
+    folder_path = Path(STUBBED_TESTING_DATA) / "npm" / "sampleData_NPM_3"
     # Same two-column shape as sampleData_NPM_1: ttls.csv rides ComputerTimestamp.
     clock_kwargs = {"npm_timestamp_column_name": "ComputerTimestamp", "npm_time_unit": "milliseconds"}
     extractor_instance = NpmRecordingExtractor(folder_path, num_ch=2, **clock_kwargs)
@@ -441,7 +441,7 @@ class TestNpmRecordingExtractorSession3(NpmRecordingExtractorTestMixin):
 
 class TestNpmRecordingExtractorSession4(NpmRecordingExtractorTestMixin):
     extractor_class = NpmRecordingExtractor
-    folder_path = os.path.join(STUBBED_TESTING_DATA, "npm", "sampleData_NPM_4")
+    folder_path = Path(STUBBED_TESTING_DATA) / "npm" / "sampleData_NPM_4"
     extractor_instance = NpmRecordingExtractor(folder_path, num_ch=2, npm_split_events=[True, True])
     expected_events = ["file0_chev1", "file0_chod1", "eventTrue"]
     # npm_split_events=[True, True] splits the boolean event stream into eventTrue/eventFalse.
@@ -455,7 +455,7 @@ class TestNpmRecordingExtractorSession4(NpmRecordingExtractorTestMixin):
 
 class TestNpmRecordingExtractorSession5(NpmRecordingExtractorTestMixin):
     extractor_class = NpmRecordingExtractor
-    folder_path = os.path.join(STUBBED_TESTING_DATA, "npm", "sampleData_NPM_5")
+    folder_path = Path(STUBBED_TESTING_DATA) / "npm" / "sampleData_NPM_5"
     extractor_instance = NpmRecordingExtractor(folder_path, num_ch=2, npm_time_unit="milliseconds")
     expected_events = ["file0_chev1", "file0_chod1", "event0"]
     # npm_split_events=None means no splitting: the event stream becomes event0.
@@ -596,7 +596,7 @@ class TestNpmEventClockValidation:
     (milliseconds); its stimuli file is on the latter.
     """
 
-    folder_path = os.path.join(STUBBED_TESTING_DATA, "npm", "sampleData_NPM_1")
+    folder_path = Path(STUBBED_TESTING_DATA) / "npm" / "sampleData_NPM_1"
 
     @pytest.fixture
     def wrong_clock_extractor(self):

--- a/tests/unit/extractors/test_tdt_recording_extractor.py
+++ b/tests/unit/extractors/test_tdt_recording_extractor.py
@@ -1,7 +1,7 @@
 """Contract tests for TdtRecordingExtractor."""
 
-import os
 import shutil
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -91,9 +91,9 @@ def test_readtsq_returns_zeros_when_no_tsq_present(tmp_path):
 
 def test_readtev_raises_for_multiple_tev_files(tmp_path):
     """A folder with one valid tank's tsq plus an extra .tev triggers the multi-tev guard."""
-    source = os.path.join(STUBBED_TESTING_DATA, "tdt", "Photo_63_207-181030-103332")
-    for filename in os.listdir(source):
-        shutil.copy(os.path.join(source, filename), tmp_path / filename)
+    source = Path(STUBBED_TESTING_DATA) / "tdt" / "Photo_63_207-181030-103332"
+    for filename in [entry.name for entry in Path(source).iterdir()]:
+        shutil.copy(Path(source) / filename, tmp_path / filename)
     # Add a second .tev so the read path detects duplicates.
     (tmp_path / "extra.tev").write_bytes(b"")
     extractor = TdtRecordingExtractor(str(tmp_path))
@@ -103,7 +103,7 @@ def test_readtev_raises_for_multiple_tev_files(tmp_path):
 
 def test_readtev_raises_when_store_name_not_present(tmp_path):
     """A bogus store name surfaces a ValueError listing the available stores."""
-    extractor = TdtRecordingExtractor(os.path.join(STUBBED_TESTING_DATA, "tdt", "Photo_63_207-181030-103332"))
+    extractor = TdtRecordingExtractor(Path(STUBBED_TESTING_DATA) / "tdt" / "Photo_63_207-181030-103332")
     with pytest.raises(ValueError, match=r"'BOGUS' not found.*Available stores"):
         extractor._readtev("BOGUS")
 
@@ -201,7 +201,7 @@ class TestTdtRecordingExtractorChunkedRead:
     @pytest.mark.parametrize("event", ["Dv1A", "Fi1r"])
     def test_stub_read_is_independent_of_chunk_size(self, event):
         """Fi1r's 2048-byte blocks sit 2048 bytes apart, so a 4096-byte chunk straddles constantly."""
-        extractor = TdtRecordingExtractor(os.path.join(STUBBED_TESTING_DATA, "tdt", "Photo_63_207-181030-103332"))
+        extractor = TdtRecordingExtractor(Path(STUBBED_TESTING_DATA) / "tdt" / "Photo_63_207-181030-103332")
         default_chunks = extractor._readtev(event)
         small_chunks = extractor._readtev(event, chunk_bytes=4096)
         np.testing.assert_array_equal(small_chunks["data"], default_chunks["data"])
@@ -255,7 +255,7 @@ class TdtRecordingExtractorTestMixin(RecordingExtractorTestMixin):
 
 class TestTdtRecordingExtractor(TdtRecordingExtractorTestMixin):
     extractor_class = TdtRecordingExtractor
-    folder_path = os.path.join(STUBBED_TESTING_DATA, "tdt", "Photo_63_207-181030-103332")
+    folder_path = Path(STUBBED_TESTING_DATA) / "tdt" / "Photo_63_207-181030-103332"
     extractor_instance = TdtRecordingExtractor(folder_path)
     expected_events = ["Dv1A", "Dv2A", "PrtN"]
     discover_kwargs = {}
@@ -267,7 +267,7 @@ class TestTdtRecordingExtractor(TdtRecordingExtractorTestMixin):
 
 class TestTdtRecordingExtractorSample2(TdtRecordingExtractorTestMixin):
     extractor_class = TdtRecordingExtractor
-    folder_path = os.path.join(STUBBED_TESTING_DATA, "tdt", "Photo_048_392-200728-121222")
+    folder_path = Path(STUBBED_TESTING_DATA) / "tdt" / "Photo_048_392-200728-121222"
     extractor_instance = TdtRecordingExtractor(folder_path)
     expected_events = ["Dv1A", "Dv2A", "PrtN"]
     discover_kwargs = {}
@@ -307,9 +307,9 @@ class TdtRecordingExtractorSplitTestMixin(TdtRecordingExtractorTestMixin):
             assert result[0]["store_id"] == split_name
 
     def test_read_split_subevents_writes_nothing(self, tmp_path):
-        before = set(os.listdir(tmp_path))
+        before = set([entry.name for entry in Path(tmp_path).iterdir()])
         self.extractor_instance.read(events=list(self.expected_split_events), outputPath=str(tmp_path))
-        assert set(os.listdir(tmp_path)) == before
+        assert set([entry.name for entry in Path(tmp_path).iterdir()]) == before
 
     def test_count_samples_split_subevent_matches_parent_rows(self):
         split_map = self.extractor_class._compute_split_map(self.extractor_instance._header_df)
@@ -325,7 +325,7 @@ class TdtRecordingExtractorSplitTestMixin(TdtRecordingExtractorTestMixin):
 
 class TestTdtRecordingExtractorSplitEvent(TdtRecordingExtractorSplitTestMixin):
     extractor_class = TdtRecordingExtractor
-    folder_path = os.path.join(STUBBED_TESTING_DATA, "tdt", "Photometry-161823")
+    folder_path = Path(STUBBED_TESTING_DATA) / "tdt" / "Photometry-161823"
     extractor_instance = TdtRecordingExtractor(folder_path)
     # PAB/ splits into one sub-event per marker value, enumerated at discover time.
     split_parent = "PAB/"
@@ -339,7 +339,7 @@ class TestTdtRecordingExtractorSplitEvent(TdtRecordingExtractorSplitTestMixin):
 
 class TestTdtRecordingExtractorSplitFloat(TdtRecordingExtractorSplitTestMixin):
     extractor_class = TdtRecordingExtractor
-    folder_path = os.path.join(STUBBED_TESTING_DATA, "tdt", "ME112-ME113-260420-114630")
+    folder_path = Path(STUBBED_TESTING_DATA) / "tdt" / "ME112-ME113-260420-114630"
     extractor_instance = TdtRecordingExtractor(folder_path)
     # Widt carries float-valued codes (0.1, 0.2, 0.4, 0.8, 10.0); splitting must produce one
     # sub-event per unique float (regression for the int()-collapse bug), not collapse them.

--- a/tests/unit/frontend/test_artifact_windows_page.py
+++ b/tests/unit/frontend/test_artifact_windows_page.py
@@ -1,5 +1,5 @@
 import json
-import os
+from pathlib import Path
 
 import holoviews as hv
 import numpy as np
@@ -36,7 +36,7 @@ def run_folder(tmp_path):
     for site in ("DMS", "DLS"):
         _write_site(tmp_path, site)
     # Step 3 always leaves a snapshot behind; the page updates its artifact keys on save.
-    with open(os.path.join(str(tmp_path), "GuPPyParamtersUsed.json"), "w") as parameters_file:
+    with (Path(str(tmp_path)) / "GuPPyParamtersUsed.json").open("w") as parameters_file:
         json.dump({"removeArtifacts": False, "artifactsRemovalMethod": "replace with NaN"}, parameters_file)
     return tmp_path
 
@@ -50,7 +50,7 @@ def session_folder(tmp_path):
         run_folder.mkdir(parents=True)
         for site in ("DMS", "DLS"):
             _write_site(run_folder, site)
-        with open(os.path.join(str(run_folder), "GuPPyParamtersUsed.json"), "w") as parameters_file:
+        with (Path(str(run_folder)) / "GuPPyParamtersUsed.json").open("w") as parameters_file:
             json.dump({"removeArtifacts": False, "artifactsRemovalMethod": "replace with NaN"}, parameters_file)
     return session
 
@@ -230,7 +230,7 @@ class TestClampingBoundsIntoTheRecording:
 
         selector.save()
 
-        with open(os.path.join(str(run_folder), "GuPPyParamtersUsed.json")) as parameters_file:
+        with (Path(str(run_folder)) / "GuPPyParamtersUsed.json").open() as parameters_file:
             saved = json.load(parameters_file)
         assert saved["artifactsRemovalMethod"] == "concatenate"
         # Selecting windows does not itself remove anything.

--- a/tests/unit/frontend/test_covariate_correlation_view.py
+++ b/tests/unit/frontend/test_covariate_correlation_view.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -22,7 +22,7 @@ def write_covariate_stores(filepath, covariates=("akinesia", "tremor")):
     """Write the Step-2 store list and raw covariate series a session carries."""
     store_ids = ["Cov" + str(index) for index in range(len(covariates))]
     store_array = np.array([store_ids, ["covariate_" + covariate for covariate in covariates]])
-    np.savetxt(os.path.join(filepath, "storesList.csv"), store_array, delimiter=",", fmt="%s")
+    np.savetxt(Path(filepath) / "storesList.csv", store_array, delimiter=",", fmt="%s")
 
     for index, store_id in enumerate(store_ids):
         write_hdf5(np.array([0.0, 5.0, 9.0]), store_id, filepath, "timestamps")

--- a/tests/unit/frontend/test_dandi_selector.py
+++ b/tests/unit/frontend/test_dandi_selector.py
@@ -1,6 +1,6 @@
 """Unit tests for the DandiSelector Panel component."""
 
-import os
+from pathlib import Path
 
 import pytest
 from dandi.exceptions import NotFoundError
@@ -71,15 +71,15 @@ class TestDandiSelector:
         selector.dandiset_input.value = "000971"
         mirror_root = selector._current_mirror_root
         assert mirror_root is not None
-        assert os.path.isdir(os.path.join(mirror_root, "sub-01"))
-        assert os.path.isdir(os.path.join(mirror_root, "sub-02"))
-        assert os.path.isfile(os.path.join(mirror_root, "sub-01", "ses-1_behavior.nwb"))
-        assert os.path.isfile(os.path.join(mirror_root, "sub-01", "ses-2_behavior.nwb"))
-        assert os.path.isfile(os.path.join(mirror_root, "sub-02", "ses-1_behavior.nwb"))
+        assert (Path(mirror_root) / "sub-01").is_dir()
+        assert (Path(mirror_root) / "sub-02").is_dir()
+        assert (Path(mirror_root) / "sub-01" / "ses-1_behavior.nwb").is_file()
+        assert (Path(mirror_root) / "sub-01" / "ses-2_behavior.nwb").is_file()
+        assert (Path(mirror_root) / "sub-02" / "ses-1_behavior.nwb").is_file()
         # Placeholders are zero bytes.
-        assert os.path.getsize(os.path.join(mirror_root, "sub-01", "ses-1_behavior.nwb")) == 0
+        assert (Path(mirror_root) / "sub-01" / "ses-1_behavior.nwb").stat().st_size == 0
         # README.md (non-NWB) is filtered out.
-        assert not os.path.exists(os.path.join(mirror_root, "README.md"))
+        assert not (Path(mirror_root) / "README.md").exists()
         assert "3 NWB asset" in selector.status.object
 
     def test_file_selector_is_scoped_to_dandiset(self, selector):
@@ -91,8 +91,8 @@ class TestDandiSelector:
         selector.dandiset_input.value = "000971"
         mirror_root = selector._current_mirror_root
         selector.asset_file_selector.value = [
-            os.path.join(mirror_root, "sub-01", "ses-1_behavior.nwb"),
-            os.path.join(mirror_root, "sub-02", "ses-1_behavior.nwb"),
+            str(Path(mirror_root) / "sub-01" / "ses-1_behavior.nwb"),
+            str(Path(mirror_root) / "sub-02" / "ses-1_behavior.nwb"),
         ]
         assert selector.selected_uris == [
             "dandi://000971/sub-01/ses-1_behavior.nwb",
@@ -104,8 +104,8 @@ class TestDandiSelector:
         mirror_root = selector._current_mirror_root
         # A folder path sneaking into .value should be ignored.
         selector.asset_file_selector.value = [
-            os.path.join(mirror_root, "sub-01"),
-            os.path.join(mirror_root, "sub-01", "ses-1_behavior.nwb"),
+            str(Path(mirror_root) / "sub-01"),
+            str(Path(mirror_root) / "sub-01" / "ses-1_behavior.nwb"),
         ]
         assert selector.selected_uris == ["dandi://000971/sub-01/ses-1_behavior.nwb"]
 
@@ -115,7 +115,7 @@ class TestDandiSelector:
         selector.dandiset_input.value = "000001"
         second_root = selector._current_mirror_root
         assert first_root != second_root
-        assert os.path.isfile(os.path.join(second_root, "sub-a", "data.nwb"))
+        assert (Path(second_root) / "sub-a" / "data.nwb").is_file()
         assert selector.asset_file_selector.root_directory == second_root
         # Prior selection cleared on dandiset change.
         assert selector.asset_file_selector.value == []
@@ -123,7 +123,7 @@ class TestDandiSelector:
     def test_clearing_dandiset_clears_selections(self, selector):
         selector.dandiset_input.value = "000971"
         mirror_root = selector._current_mirror_root
-        selector.asset_file_selector.value = [os.path.join(mirror_root, "sub-01", "ses-1_behavior.nwb")]
+        selector.asset_file_selector.value = [str(Path(mirror_root) / "sub-01" / "ses-1_behavior.nwb")]
         selector.dandiset_input.value = ""
         assert selector._current_mirror_root is None
         assert selector.selected_uris == []
@@ -157,7 +157,7 @@ class TestDandiSelector:
         assert calls == []
         assert selector._current_mirror_root is None
         # No <id>/ folder was created.
-        assert not os.path.isdir(os.path.join(selector._mirror_parent, malformed))
+        assert not (Path(selector._mirror_parent) / malformed).is_dir()
 
     def test_not_found_shows_warning_and_no_stale_folder(self, selector, patched_client, monkeypatch):
         def raising_get_dandiset(self_inner, dandiset_id, version=None):
@@ -170,7 +170,7 @@ class TestDandiSelector:
         assert "\u26a0\ufe0f" in selector.status.object
         assert "not found" in selector.status.object
         assert selector._current_mirror_root is None
-        assert not os.path.isdir(os.path.join(selector._mirror_parent, "999999"))
+        assert not (Path(selector._mirror_parent) / "999999").is_dir()
 
     def test_recovery_after_error(self, selector, patched_client):
         selector.dandiset_input.value = "abc"
@@ -182,7 +182,7 @@ class TestDandiSelector:
         assert selector.asset_file_selector.root_directory == selector._current_mirror_root
 
         mirror_root = selector._current_mirror_root
-        selector.asset_file_selector.value = [os.path.join(mirror_root, "sub-01", "ses-1_behavior.nwb")]
+        selector.asset_file_selector.value = [str(Path(mirror_root) / "sub-01" / "ses-1_behavior.nwb")]
         assert selector.selected_uris == ["dandi://000971/sub-01/ses-1_behavior.nwb"]
 
     def test_widget_swapped_on_load(self, selector):
@@ -206,7 +206,7 @@ class TestDandiSelector:
         selector.attach_asset_selection_watcher(callback=events.append)
         selector.dandiset_input.value = "000971"
         mirror_root = selector._current_mirror_root
-        asset_path = os.path.join(mirror_root, "sub-01", "ses-1_behavior.nwb")
+        asset_path = Path(mirror_root) / "sub-01" / "ses-1_behavior.nwb"
         events.clear()
 
         # The widget selected into here is the replacement built for this dandiset,

--- a/tests/unit/frontend/test_group_labeling.py
+++ b/tests/unit/frontend/test_group_labeling.py
@@ -42,7 +42,7 @@ class TestSaveGroupDefinition:
         save_group_definition(group_folder=str(group_folder), member_run_folders=[str(member_run_folder)])
 
         assert [entry.name for entry in group_folder.iterdir()] == [GROUP_MEMBERS_FILENAME]
-        with open(group_folder / GROUP_MEMBERS_FILENAME) as manifest:
+        with (group_folder / GROUP_MEMBERS_FILENAME).open() as manifest:
             assert json.load(manifest) == {"member_run_folders": [str(member_run_folder)]}
 
     def test_overwrites_the_membership_of_an_existing_group(self, tmp_path, member_run_folder):

--- a/tests/unit/frontend/test_input_parameters.py
+++ b/tests/unit/frontend/test_input_parameters.py
@@ -1,6 +1,6 @@
 import json
 import math
-import os
+from pathlib import Path
 from types import SimpleNamespace
 
 import numpy as np
@@ -404,16 +404,16 @@ def _dandi_form_with_existing_runs(*, form, patched_dandi_client, output_root, a
     patched_dandi_client.dandisets_by_id = {"000971": _FakeDandiset(asset_paths)}
     output_root.mkdir()
     for asset_path in asset_paths:
-        session = output_root / os.path.basename(asset_path).removesuffix(".nwb")
+        session = output_root / Path(asset_path).name.removesuffix(".nwb")
         session.mkdir()
         for run_name in run_names:
-            os.mkdir(run_folder_for_run(str(session), run_name))
+            Path(run_folder_for_run(str(session), run_name)).mkdir()
 
     form.source_mode.value = "dandi"
     form.dandi_selector.dandiset_input.value = "000971"
     mirror_root = form.dandi_selector._current_mirror_root
     form.dandi_selector.asset_file_selector.value = [
-        os.path.join(mirror_root, *asset_path.split("/")) for asset_path in asset_paths
+        str(Path(mirror_root).joinpath(*asset_path.split("/"))) for asset_path in asset_paths
     ]
     form.dandi_selector.output_root_selector.value = [str(output_root)]
     return form
@@ -431,8 +431,8 @@ class TestParameterFormDandiMode:
         form.dandi_selector.dandiset_input.value = "000971"
         mirror_root = form.dandi_selector._current_mirror_root
         form.dandi_selector.asset_file_selector.value = [
-            os.path.join(mirror_root, "sub-01", "session_a.nwb"),
-            os.path.join(mirror_root, "sub-02", "session_b.nwb"),
+            str(Path(mirror_root) / "sub-01" / "session_a.nwb"),
+            str(Path(mirror_root) / "sub-02" / "session_b.nwb"),
         ]
         form.dandi_selector.output_root_selector.value = [str(output_root)]
 
@@ -448,7 +448,7 @@ class TestParameterFormDandiMode:
             session_b: "dandi://000971/sub-02/session_b.nwb",
         }
         for session_dir in (session_a, session_b):
-            assert os.path.isdir(session_dir)
+            assert Path(session_dir).is_dir()
 
     def test_dandi_mode_no_asset_raises(self, bare_parameter_form, tmp_path):
         form = bare_parameter_form
@@ -463,7 +463,7 @@ class TestParameterFormDandiMode:
         form.source_mode.value = "dandi"
         form.dandi_selector.dandiset_input.value = "000971"
         mirror_root = form.dandi_selector._current_mirror_root
-        form.dandi_selector.asset_file_selector.value = [os.path.join(mirror_root, "sub-01", "data.nwb")]
+        form.dandi_selector.asset_file_selector.value = [str(Path(mirror_root) / "sub-01" / "data.nwb")]
         with pytest.raises(Exception, match="local output directory"):
             form.getInputParameters()
 
@@ -545,7 +545,7 @@ def sessions_with_runs(tmp_path):
         session = tmp_path / name
         session.mkdir()
         for run_name in run_names:
-            os.mkdir(run_folder_for_run(str(session), run_name))
+            Path(run_folder_for_run(str(session), run_name)).mkdir()
         return str(session)
 
     return SimpleNamespace(
@@ -601,7 +601,7 @@ class TestOutputsSelector:
         run_a2 = run_folder_for_run(str(session_a), "run2")
         run_b1 = run_folder_for_run(str(session_b), "run1")
         for path in (run_a1, run_a2, run_b1):
-            os.mkdir(path)
+            Path(path).mkdir()
 
         bare_parameter_form.outputs_selector.value = [run_a1, run_a2, run_b1]
         result = bare_parameter_form._collect_selected_runs()
@@ -619,7 +619,7 @@ class TestOutputsSelector:
     ):
         session = tmp_path / "sessionA"
         session.mkdir()
-        os.mkdir(run_folder_for_run(str(session), "baseline"))
+        Path(run_folder_for_run(str(session), "baseline")).mkdir()
 
         bare_parameter_form.files_1.value = [str(session)]
         bare_parameter_form.outputs_selector.value = []
@@ -644,7 +644,7 @@ class TestOutputsSelector:
         session = tmp_path / "sessionA"
         session.mkdir()
         run_dir = run_folder_for_run(str(session), "baseline")
-        os.mkdir(run_dir)
+        Path(run_dir).mkdir()
 
         bare_parameter_form.files_1.value = [str(session)]
         bare_parameter_form.outputs_selector.value = [run_dir]
@@ -737,7 +737,7 @@ class TestRunNamePicker:
     ):
         bare_parameter_form.files_1.value = [sessions_with_runs.session_a]
         bare_parameter_form.run_names_for_all_sessions.value = ["1"]
-        os.mkdir(run_folder_for_run(sessions_with_runs.session_a, "2"))
+        Path(run_folder_for_run(sessions_with_runs.session_a, "2")).mkdir()
 
         bare_parameter_form.refresh_individual_outputs()
 
@@ -825,8 +825,8 @@ SAVED_PARAMETERS = {
 def _write_run_with_parameters(session_dir, run_name, parameters):
     """Create an ``_output_<run>`` dir under session_dir holding a GuPPyParamtersUsed.json."""
     run_dir = run_folder_for_run(str(session_dir), run_name)
-    os.mkdir(run_dir)
-    with open(os.path.join(run_dir, "GuPPyParamtersUsed.json"), "w") as parameters_file:
+    Path(run_dir).mkdir()
+    with (Path(run_dir) / "GuPPyParamtersUsed.json").open("w") as parameters_file:
         json.dump(parameters, parameters_file)
     return run_dir
 
@@ -897,7 +897,7 @@ class TestParameterAutoPopulate:
         session = tmp_path / "sessionA"
         session.mkdir()
         run_dir = run_folder_for_run(str(session), "fresh")
-        os.mkdir(run_dir)
+        Path(run_dir).mkdir()
 
         default_time = bare_parameter_form.timeForLightsTurnOn.value
         bare_parameter_form.files_1.value = [str(session)]

--- a/tests/unit/frontend/test_psth_significance_view.py
+++ b/tests/unit/frontend/test_psth_significance_view.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -17,8 +17,8 @@ from guppy.frontend.psth_significance_view import (
 
 def write_significance(filepath, name, *, significant_from=None, significant_to=None, n=12, n_b=None, alpha=0.05):
     """Write one significance table into the results subdirectory."""
-    results_path = os.path.join(filepath, PSTH_SIGNIFICANCE_DIRNAME)
-    os.makedirs(results_path, exist_ok=True)
+    results_path = Path(filepath) / PSTH_SIGNIFICANCE_DIRNAME
+    Path(results_path).mkdir(parents=True, exist_ok=True)
 
     timestamps = np.linspace(-1.0, 1.0, 11)
     significant = np.zeros(11, dtype=int)
@@ -39,7 +39,7 @@ def write_significance(filepath, name, *, significant_from=None, significant_to=
     if n_b is not None:
         table["n_b"] = n_b
 
-    table.to_hdf(os.path.join(results_path, "significance_" + name + ".h5"), key="df", mode="w")
+    table.to_hdf(Path(results_path) / ("significance_" + name + ".h5"), key="df", mode="w")
 
 
 @pytest.fixture

--- a/tests/unit/orchestration/test_export_nwb.py
+++ b/tests/unit/orchestration/test_export_nwb.py
@@ -10,7 +10,7 @@ the converter, an NWB file through the standalone interface.
 """
 
 import json
-import os
+from pathlib import Path
 
 import pytest
 from pynwb import NWBFile
@@ -38,8 +38,8 @@ class TestValidateArtifactRemovalMethods:
         return session
 
     def _write_parameters(self, session_path, parameters):
-        output_dir = session_path / f"{os.path.basename(session_path)}_output_run1"
-        with open(output_dir / "GuPPyParamtersUsed.json", "w") as parameters_file:
+        output_dir = session_path / f"{Path(session_path).name}_output_run1"
+        with (output_dir / "GuPPyParamtersUsed.json").open("w") as parameters_file:
             json.dump(parameters, parameters_file)
 
     def test_concatenate_with_remove_artifacts_aborts(self, session_path):
@@ -270,7 +270,7 @@ class TestRunExportNwbStep:
         session = tmp_path / "Photo_session"
         output_dir = session / "Photo_session_output_run1"
         output_dir.mkdir(parents=True)
-        with open(output_dir / "GuPPyParamtersUsed.json", "w") as parameters_file:
+        with (output_dir / "GuPPyParamtersUsed.json").open("w") as parameters_file:
             json.dump({"removeArtifacts": True, "artifactsRemovalMethod": "concatenate"}, parameters_file)
 
         with pytest.raises(ValueError, match="does not support the 'concatenate'"):

--- a/tests/unit/orchestration/test_import_custom_events.py
+++ b/tests/unit/orchestration/test_import_custom_events.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import pandas as pd
 import pytest
@@ -28,7 +28,7 @@ class TestBuildCustomEventsTemplate:
         _set_row(config, 0, "movement_onset", "0.5\n1.5\n2.5")
         template._hooks["save_button"](None)
 
-        df = pd.read_csv(os.path.join(str(tmp_path), "movement_onset.csv"))
+        df = pd.read_csv(Path(str(tmp_path)) / "movement_onset.csv")
         assert df["timestamps"].tolist() == [0.5, 1.5, 2.5]
         assert "Saved" in config.alert.object
 
@@ -36,7 +36,7 @@ class TestBuildCustomEventsTemplate:
         config = template._widgets["config"]
         template._hooks["save_button"](None)
 
-        assert os.listdir(str(tmp_path)) == []
+        assert [entry.name for entry in Path(str(tmp_path)).iterdir()] == []
         assert "No events to save" in config.alert.object
 
     def test_unsorted_writes_csv_with_warning(self, template, tmp_path):
@@ -44,7 +44,7 @@ class TestBuildCustomEventsTemplate:
         _set_row(config, 0, "ev", "3.0\n1.0\n2.0")
         template._hooks["save_button"](None)
 
-        df = pd.read_csv(os.path.join(str(tmp_path), "ev.csv"))
+        df = pd.read_csv(Path(str(tmp_path)) / "ev.csv")
         assert df["timestamps"].tolist() == [3.0, 1.0, 2.0]
         assert "Warning" in config.alert.object
 
@@ -53,7 +53,7 @@ class TestBuildCustomEventsTemplate:
         _set_row(config, 0, "ev", "0.1\nabc")
         template._hooks["save_button"](None)
 
-        assert os.listdir(str(tmp_path)) == []
+        assert [entry.name for entry in Path(str(tmp_path)).iterdir()] == []
         assert "abc" in config.alert.object
 
     def test_named_event_without_timestamps_errors(self, template, tmp_path):
@@ -61,7 +61,7 @@ class TestBuildCustomEventsTemplate:
         _set_row(config, 0, "ev", "   ")
         template._hooks["save_button"](None)
 
-        assert os.listdir(str(tmp_path)) == []
+        assert [entry.name for entry in Path(str(tmp_path)).iterdir()] == []
         assert "no timestamps" in config.alert.object
 
     def test_collision_warns_then_overwrites(self, template, tmp_path):
@@ -73,9 +73,9 @@ class TestBuildCustomEventsTemplate:
         _set_row(config, 0, "ev", "9.0\n8.0")
         template._hooks["save_button"](None)
         assert "already exists" in config.alert.object
-        assert pd.read_csv(os.path.join(str(tmp_path), "ev.csv"))["timestamps"].tolist() == [1.0]
+        assert pd.read_csv(Path(str(tmp_path)) / "ev.csv")["timestamps"].tolist() == [1.0]
 
         # Enable overwrite and save again: file is replaced.
         config.overwrite.value = True
         template._hooks["save_button"](None)
-        assert pd.read_csv(os.path.join(str(tmp_path), "ev.csv"))["timestamps"].tolist() == [9.0, 8.0]
+        assert pd.read_csv(Path(str(tmp_path)) / "ev.csv")["timestamps"].tolist() == [9.0, 8.0]

--- a/tests/unit/orchestration/test_psth.py
+++ b/tests/unit/orchestration/test_psth.py
@@ -1,5 +1,5 @@
 import json
-import os
+from pathlib import Path
 
 import h5py
 import numpy as np
@@ -143,7 +143,7 @@ def test_execute_compute_cross_correlation_no_op_for_transient_events(
 
 def _record_artifact_provenance(run_folder, *, remove_artifacts, artifacts_removal_method):
     """Write the artifact provenance the Remove Artifacts step would have left behind."""
-    with open(os.path.join(str(run_folder), "GuPPyParamtersUsed.json"), "w") as parameters_file:
+    with (Path(str(run_folder)) / "GuPPyParamtersUsed.json").open("w") as parameters_file:
         json.dump(
             {"removeArtifacts": remove_artifacts, "artifactsRemovalMethod": artifacts_removal_method},
             parameters_file,

--- a/tests/unit/orchestration/test_psth_significance.py
+++ b/tests/unit/orchestration/test_psth_significance.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -19,7 +19,7 @@ from guppy.utils.progress import StepProgress, _current_step
 
 def write_stores_list(run_folder, store_ids, store_labels):
     np.savetxt(
-        os.path.join(run_folder, "storesList.csv"),
+        Path(run_folder) / "storesList.csv",
         np.asarray([store_ids, store_labels]),
         delimiter=",",
         fmt="%s",
@@ -39,7 +39,7 @@ def write_psth(run_folder, event, recording_site, basename, *, num_trials=5, num
     data += [np.linspace(-1, 1, num_timepoints), np.zeros(num_timepoints), np.zeros(num_timepoints)]
 
     frame = pd.DataFrame(np.asarray(data).T, columns=columns, dtype="float32")
-    frame.to_hdf(os.path.join(run_folder, f"{event}_{recording_site}_{basename}.h5"), key="df", mode="w")
+    frame.to_hdf(Path(run_folder) / (f"{event}_{recording_site}_{basename}.h5"), key="df", mode="w")
 
 
 @pytest.fixture
@@ -327,7 +327,7 @@ class TestSmallSampleReporting:
             "at least 3 trials or sessions to resample. Skipped: rewarded_dms_z_score_dms (found 2), "
             "unrewarded_dms_z_score_dms (found 2)."
         )
-        assert not os.path.exists(os.path.join(two_trial_run_folder, PSTH_SIGNIFICANCE_DIRNAME))
+        assert not (Path(two_trial_run_folder) / PSTH_SIGNIFICANCE_DIRNAME).exists()
 
     def test_a_usable_run_warns_about_nothing(self, run_folder, significance_parameters, bound_step):
         significance_parameters["psthBootstrapResamples"] = 50

--- a/tests/unit/orchestration/test_save_parameters.py
+++ b/tests/unit/orchestration/test_save_parameters.py
@@ -1,6 +1,6 @@
 import json
-import os
 from importlib.metadata import version
+from pathlib import Path
 
 import pytest
 
@@ -139,14 +139,14 @@ def test_save_parameters_writes_json_to_each_folder(tmp_path, base_input_paramet
     save_parameters(base_input_parameters)
 
     for folder in base_input_parameters["session_folders"]:
-        assert os.path.exists(os.path.join(folder, "GuPPyParamtersUsed.json"))
+        assert (Path(folder) / "GuPPyParamtersUsed.json").exists()
 
 
 def test_save_parameters_saves_exactly_expected_keys(base_input_parameters):
     save_parameters(base_input_parameters)
 
     folder = base_input_parameters["session_folders"][0]
-    with open(os.path.join(folder, "GuPPyParamtersUsed.json")) as file:
+    with (Path(folder) / "GuPPyParamtersUsed.json").open() as file:
         saved = json.load(file)
 
     assert set(saved.keys()) == EXPECTED_KEYS
@@ -156,7 +156,7 @@ def test_save_parameters_excludes_orchestration_keys(base_input_parameters):
     save_parameters(base_input_parameters)
 
     folder = base_input_parameters["session_folders"][0]
-    with open(os.path.join(folder, "GuPPyParamtersUsed.json")) as file:
+    with (Path(folder) / "GuPPyParamtersUsed.json").open() as file:
         saved = json.load(file)
 
     assert ORCHESTRATION_ONLY_KEYS.isdisjoint(saved.keys())
@@ -166,7 +166,7 @@ def test_save_parameters_preserves_values(base_input_parameters):
     save_parameters(base_input_parameters)
 
     folder = base_input_parameters["session_folders"][0]
-    with open(os.path.join(folder, "GuPPyParamtersUsed.json")) as file:
+    with (Path(folder) / "GuPPyParamtersUsed.json").open() as file:
         saved = json.load(file)
 
     for key in PARAMETER_KEYS:
@@ -177,7 +177,7 @@ def test_save_parameters_writes_guppy_version(base_input_parameters):
     save_parameters(base_input_parameters)
 
     folder = base_input_parameters["session_folders"][0]
-    with open(os.path.join(folder, "GuPPyParamtersUsed.json")) as file:
+    with (Path(folder) / "GuPPyParamtersUsed.json").open() as file:
         saved = json.load(file)
 
     assert saved["guppy_version"] == version("guppy-neuro")
@@ -230,19 +230,19 @@ def test_save_parameters_single_folder(tmp_path):
 
     save_parameters(input_parameters)
 
-    json_path = os.path.join(str(folder), "GuPPyParamtersUsed.json")
-    assert os.path.exists(json_path)
-    with open(json_path) as file:
+    json_path = Path(str(folder)) / "GuPPyParamtersUsed.json"
+    assert Path(json_path).exists()
+    with Path(json_path).open() as file:
         saved = json.load(file)
     assert saved["zscore_method"] == "baseline"
     assert saved["combine_data"] is True
 
 
 def _make_output_dir(session_path, run_name):
-    run_folder = os.path.join(session_path, f"{os.path.basename(session_path)}_output_{run_name}")
-    os.mkdir(run_folder)
+    run_folder = Path(session_path) / (f"{Path(session_path).name}_output_{run_name}")
+    Path(run_folder).mkdir()
     # storesList.csv must exist so select_run_folders accepts the run name.
-    open(os.path.join(run_folder, "storesList.csv"), "w").close()
+    (Path(run_folder) / "storesList.csv").open("w").close()
     return run_folder
 
 
@@ -262,8 +262,8 @@ def test_save_parameters_filters_to_selected_run_name(base_input_parameters):
 
     save_parameters(base_input_parameters)
 
-    assert os.path.exists(os.path.join(baseline_dir, "GuPPyParamtersUsed.json"))
-    assert not os.path.exists(os.path.join(strict_dir, "GuPPyParamtersUsed.json"))
+    assert (Path(baseline_dir) / "GuPPyParamtersUsed.json").exists()
+    assert not (Path(strict_dir) / "GuPPyParamtersUsed.json").exists()
 
 
 def test_save_parameters_falls_back_to_session_root_when_no_output_dirs(base_input_parameters):
@@ -272,7 +272,7 @@ def test_save_parameters_falls_back_to_session_root_when_no_output_dirs(base_inp
 
     save_parameters(base_input_parameters)
 
-    assert os.path.exists(os.path.join(session, "GuPPyParamtersUsed.json"))
+    assert (Path(session) / "GuPPyParamtersUsed.json").exists()
 
 
 def test_save_parameters_raises_for_unknown_selected_run(base_input_parameters):

--- a/tests/unit/orchestration/test_store_labeling.py
+++ b/tests/unit/orchestration/test_store_labeling.py
@@ -1,6 +1,6 @@
 import json
-import os
 import types
+from pathlib import Path
 
 import numpy as np
 import panel as pn
@@ -82,7 +82,7 @@ def test_show_dir_with_explicit_run_name_returns_named_path(tmp_path):
     result = show_dir(str(session), run_name="strict")
 
     assert result == str(session / "session1_output_strict")
-    assert not os.path.exists(result)
+    assert not Path(result).exists()
 
 
 def test_show_dir_invalid_run_name_raises(tmp_path):
@@ -110,7 +110,7 @@ def test_save_writes_storeslist_csv(isolated_cache):
     )
 
     assert result == "#### No alerts !!"
-    assert os.path.exists(os.path.join(select_location, "storesList.csv"))
+    assert (Path(select_location) / "storesList.csv").exists()
 
 
 def test_save_csv_content_matches_input(isolated_cache):
@@ -124,7 +124,7 @@ def test_save_csv_content_matches_input(isolated_cache):
         store_labeling_config=store_labeling_config, select_location=select_location, overwrite_mode="create_new_file"
     )
 
-    loaded = np.loadtxt(os.path.join(select_location, "storesList.csv"), delimiter=",", dtype=str)
+    loaded = np.loadtxt(Path(select_location) / "storesList.csv", delimiter=",", dtype=str)
     np.testing.assert_array_equal(loaded[0], ["Dv1A", "Dv2A", "PulA"])
     np.testing.assert_array_equal(loaded[1], ["control_DMS", "signal_DMS", "event1"])
 
@@ -194,7 +194,7 @@ def test_save_updates_cache_file(isolated_cache):
 
     cache_path = isolated_cache / ".storesList.json"
     assert cache_path.exists()
-    with open(cache_path) as file:
+    with Path(cache_path).open() as file:
         cache = json.load(file)
     assert "Dv1A" in cache
     assert "control_DMS" in cache["Dv1A"]
@@ -230,7 +230,7 @@ def test_save_overwrites_clears_all_files_in_existing_dir(isolated_cache):
 
     assert result == "#### No alerts !!"
     # Only the freshly written storesList.csv should remain.
-    remaining = set(os.listdir(str(select_location)))
+    remaining = set([entry.name for entry in Path(str(select_location)).iterdir()])
     assert remaining == {"storesList.csv"}, f"Expected only storesList.csv, found: {remaining}"
 
 
@@ -647,7 +647,7 @@ def test_overwrite_button_actions_create_new_file_sets_next_output_dir(store_lab
 
     overwrite_button_actions(types.SimpleNamespace(new="create_new_file"))
 
-    expected = os.path.join(folder_path, "my_session_output_1")
+    expected = str(Path(folder_path) / "my_session_output_1")
     assert selector.select_location_options == [expected]
 
 
@@ -655,12 +655,12 @@ def test_overwrite_button_actions_over_write_file_returns_existing_output_dirs(s
     selector, folder_path = store_labeling_closures
     overwrite_button_actions = selector.callbacks["overwrite_button"]
 
-    run_folder = os.path.join(folder_path, "my_session_output_1")
-    os.mkdir(run_folder)
+    run_folder = Path(folder_path) / "my_session_output_1"
+    run_folder.mkdir()
 
     overwrite_button_actions(types.SimpleNamespace(new="over_write_file"))
 
-    assert selector.select_location_options == [run_folder]
+    assert selector.select_location_options == [str(run_folder)]
 
 
 # ---------------------------------------------------------------------------
@@ -685,7 +685,7 @@ def test_run_name_input_changed_updates_select_location_options(store_labeling_c
 
     selector.run_name_callback(types.SimpleNamespace(new="myrun"))
 
-    expected = os.path.join(folder_path, "my_session_output_myrun")
+    expected = str(Path(folder_path) / "my_session_output_myrun")
     assert selector.select_location_options == [expected]
     assert selector.alert_message == "#### No alerts !!"
 
@@ -696,7 +696,7 @@ def test_run_name_input_changed_empty_string_falls_back_to_numeric(store_labelin
 
     selector.run_name_callback(types.SimpleNamespace(new=""))
 
-    expected = os.path.join(folder_path, "my_session_output_1")
+    expected = str(Path(folder_path) / "my_session_output_1")
     assert selector.select_location_options == [expected]
 
 
@@ -800,7 +800,7 @@ def test_update_values_loads_store_ids_cache_when_json_file_exists(store_labelin
 
     cache = {"Dv1A": ["control_DMS"]}
     cache_file = tmp_path / ".storesList.json"
-    with open(cache_file, "w") as f:
+    with Path(cache_file).open("w") as f:
         json.dump(cache, f)
 
     selector.callbacks["update_options"](types.SimpleNamespace())
@@ -839,8 +839,8 @@ def test_save_button_writes_storeslist_and_updates_path(store_labeling_closures,
     selector.callbacks["save"](None)
 
     assert selector.alert_message == "#### No alerts !!"
-    assert selector.path_value == os.path.join(run_folder, "storesList.csv")
-    assert os.path.exists(os.path.join(run_folder, "storesList.csv"))
+    assert selector.path_value == str(Path(run_folder) / "storesList.csv")
+    assert (Path(run_folder) / "storesList.csv").exists()
 
 
 def test_save_button_sets_alert_on_mismatched_lengths(store_labeling_closures, tmp_path):
@@ -867,7 +867,7 @@ def test_compute_npm_channel_previews_aligns_ragged_channel_lengths():
     # sampleData_NPM_4 interleaves unevenly: chod has one more sample than chev, so chod
     # borrows chev's (shorter) timestamps. The preview must align x/y to equal length,
     # otherwise hv.Curve raises a DataError in the Step-1 GUI.
-    folder_path = os.path.join(STUBBED_TESTING_DATA, "npm", "sampleData_NPM_4")
+    folder_path = Path(STUBBED_TESTING_DATA) / "npm" / "sampleData_NPM_4"
     input_parameters = {"noChannels": 2}
 
     # Confirm the ragged scenario is real: at least one channel stream has unequal
@@ -891,7 +891,7 @@ def test_compute_npm_channel_previews_aligns_ragged_channel_lengths():
 # read_header: NPM defers discovery to the configuration form
 # ---------------------------------------------------------------------------
 
-NPM_3_FOLDER = os.path.join(STUBBED_TESTING_DATA, "npm", "sampleData_NPM_3")
+NPM_3_FOLDER = Path(STUBBED_TESTING_DATA) / "npm" / "sampleData_NPM_3"
 
 
 def test_read_header_npm_defers_discovery():
@@ -1031,7 +1031,7 @@ def test_orchestrate_store_labeling_page_serves_one_page_per_session(panel_exten
     monkeypatch.setattr(pn.template.BootstrapTemplate, "show", lambda self, port: served_ports.append(port))
     input_parameters = {
         "session_folders": ["sample_data_csv_1"],
-        "abspath": os.path.join(str(STUBBED_TESTING_DATA), "csv"),
+        "abspath": Path(str(STUBBED_TESTING_DATA)) / "csv",
         "isosbestic_control": True,
         "noChannels": 2,
     }

--- a/tests/unit/orchestration/test_transients.py
+++ b/tests/unit/orchestration/test_transients.py
@@ -1,5 +1,5 @@
 import json
-import os
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -75,7 +75,7 @@ class TestFindBinnedMetrics:
         np.testing.assert_allclose(binned["mean_zscore"].to_numpy(), [2.0, 7.5])
         np.testing.assert_allclose(binned["mean_dff"].to_numpy(), [0.2, 0.75])
         np.testing.assert_array_equal(binned["transient_count_z_score"].to_numpy(), [1, 2])
-        assert os.path.exists(os.path.join(run_folder, "binned_metrics_dms.csv"))
+        assert (Path(run_folder) / "binned_metrics_dms.csv").exists()
 
     def test_bins_span_the_uncompressed_time_axis(self, run_folder, base_input_parameters):
         # Regression guard: binning must use timestampNew, not the NaN-stripped
@@ -105,7 +105,7 @@ class TestFindCovariateCorrelations:
     def run_folder(self, tmp_path):
         """A run folder with one binned-metrics table and one covariate store."""
         np.savetxt(
-            os.path.join(str(tmp_path), "storesList.csv"),
+            Path(str(tmp_path)) / "storesList.csv",
             np.array([["akinesia", "Dv2A"], ["covariate_akinesia", "signal_dms"]]),
             delimiter=",",
             fmt="%s",
@@ -155,12 +155,12 @@ class TestFindCovariateCorrelations:
     def test_writes_csv_twins(self, run_folder, base_input_parameters):
         findCovariateCorrelations(run_folder, base_input_parameters, ["dms"])
 
-        assert os.path.exists(os.path.join(run_folder, "binned_covariates_dms.csv"))
-        assert os.path.exists(os.path.join(run_folder, "covariate_correlations_dms.csv"))
+        assert (Path(run_folder) / "binned_covariates_dms.csv").exists()
+        assert (Path(run_folder) / "covariate_correlations_dms.csv").exists()
 
     def test_no_covariate_store_writes_nothing(self, tmp_path, base_input_parameters):
         np.savetxt(
-            os.path.join(str(tmp_path), "storesList.csv"),
+            Path(str(tmp_path)) / "storesList.csv",
             np.array([["Dv2A", "PrtN"], ["signal_dms", "port_entries"]]),
             delimiter=",",
             fmt="%s",
@@ -168,10 +168,10 @@ class TestFindCovariateCorrelations:
 
         findCovariateCorrelations(str(tmp_path), base_input_parameters, ["dms"])
 
-        assert not os.path.exists(os.path.join(str(tmp_path), "covariate_correlations_dms.h5"))
+        assert not (Path(str(tmp_path)) / "covariate_correlations_dms.h5").exists()
 
     def test_concatenated_outputs_raise(self, run_folder, base_input_parameters):
-        with open(os.path.join(run_folder, "GuPPyParamtersUsed.json"), "w") as parameters_file:
+        with (Path(run_folder) / "GuPPyParamtersUsed.json").open("w") as parameters_file:
             json.dump({"removeArtifacts": True, "artifactsRemovalMethod": "concatenate"}, parameters_file)
 
         with pytest.raises(ValueError, match="concatenate"):

--- a/tests/unit/testing/test_api.py
+++ b/tests/unit/testing/test_api.py
@@ -1,6 +1,6 @@
-import os
 import shutil
 import types
+from pathlib import Path
 
 import pytest
 
@@ -303,7 +303,7 @@ def staged_csv_session(tmp_path):
     base_directory.mkdir()
     session_copy = base_directory / "sample_data_csv_1"
     shutil.copytree(
-        os.path.join(str(STUBBED_TESTING_DATA), "csv", "sample_data_csv_1"),
+        Path(str(STUBBED_TESTING_DATA)) / "csv" / "sample_data_csv_1",
         session_copy,
         ignore=shutil.ignore_patterns("sample_data_csv_1_output_*", "GuPPyParamtersUsed.json"),
     )
@@ -355,14 +355,14 @@ class TestStep1Driver:
             isosbestic_control=False,
         )
 
-        stores_list_path = os.path.join(staged_csv_session["session"], "sample_data_csv_1_output_1", "storesList.csv")
-        assert os.path.exists(stores_list_path)
+        stores_list_path = Path(staged_csv_session["session"]) / "sample_data_csv_1_output_1" / "storesList.csv"
+        assert Path(stores_list_path).exists()
 
 
 @pytest.fixture
 def npm_template_two_timestamp_columns(panel_extension):
     """Label Stores template for the NPM_3 stub: two timestamp columns, split checkbox on file 1."""
-    folder_path = os.path.join(str(STUBBED_TESTING_DATA), "npm", "sampleData_NPM_3")
+    folder_path = Path(str(STUBBED_TESTING_DATA)) / "npm" / "sampleData_NPM_3"
     input_parameters = {"noChannels": 2}
     _, _, npm_interactive = read_header(input_parameters, 2, folder_path)
     return build_store_labeling_template(
@@ -373,7 +373,7 @@ def npm_template_two_timestamp_columns(panel_extension):
 @pytest.fixture
 def npm_template_single_timestamp_column(panel_extension):
     """Label Stores template for the NPM_4 stub: one timestamp column, split checkbox on file 1."""
-    folder_path = os.path.join(str(STUBBED_TESTING_DATA), "npm", "sampleData_NPM_4")
+    folder_path = Path(str(STUBBED_TESTING_DATA)) / "npm" / "sampleData_NPM_4"
     input_parameters = {"noChannels": 2}
     _, _, npm_interactive = read_header(input_parameters, 2, folder_path)
     return build_store_labeling_template(

--- a/tests/unit/utils/test_custom_events.py
+++ b/tests/unit/utils/test_custom_events.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import pandas as pd
 import pytest
@@ -60,7 +60,7 @@ class TestWriteCustomEventCsv:
     def test_overwrites_when_requested(self, tmp_path):
         write_custom_event_csv(name="ev", timestamps=[1.0], folder_path=str(tmp_path))
         write_custom_event_csv(name="ev", timestamps=[9.0, 8.0], folder_path=str(tmp_path), overwrite=True)
-        df = pd.read_csv(os.path.join(str(tmp_path), "ev.csv"))
+        df = pd.read_csv(Path(str(tmp_path)) / "ev.csv")
         assert df["timestamps"].tolist() == [9.0, 8.0]
 
     def test_empty_name_raises(self, tmp_path):

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -1,5 +1,6 @@
 import json
 import pathlib
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -198,9 +199,8 @@ def test_output_dir_for_run_does_not_create_directory(tmp_path):
     session = tmp_path / "mySession"
     session.mkdir()
     result = run_folder_for_run(str(session), "x")
-    import os as _os
 
-    assert not _os.path.exists(result)
+    assert not Path(result).exists()
 
 
 # ── discover_run_folders ──────────────────────────────────────────────────────
@@ -578,7 +578,7 @@ class TestGroupMembersManifest:
 
     def test_manifest_holds_only_the_members_key(self, tmp_path):
         write_group_members(group_folder=str(tmp_path), member_run_folders=["/data/A/A_output_1"])
-        with open(tmp_path / GROUP_MEMBERS_FILENAME) as file:
+        with (tmp_path / GROUP_MEMBERS_FILENAME).open() as file:
             assert json.load(file) == {"member_run_folders": ["/data/A/A_output_1"]}
 
     def test_read_raises_when_manifest_absent(self, tmp_path):


### PR DESCRIPTION
<!-- summary line goes here -->

<details>
<summary>Details (AI-generated)</summary>

Last of the #478 stack. Stacked on #488 → #487 → #486 → #485 → #484 → #483 → #482 → #481 → #480 — review the last commit.

Converts the remaining 718 findings across `tests/` and deletes the `"tests/*"` entry, which was the last one in the `PTH` ignore list. **#478 is done.** What is left in the tree is `os.path.relpath` (two sites), `os.path.commonpath` and `os.path.normpath` — `pathlib` has no equivalent for any of them and `PTH` flags none of them.

The interesting part is where assertions had to *keep* comparing strings, because the production helper still returns one:

- `select_location_options` in `test_store_labeling`, which holds what `run_folder_for_run` returns.
- `member_run_folders` in the group manifest, which is JSON.
- `step7(base_dir=...)`, which `guppy.testing.api` validates as `isinstance(base_dir, str)`.
- `FileSelector.value` in the DANDI selector tests — Panel holds those as `str`, and `selected_uris` calls `.endswith(".nwb")` on them.

Each of those is a real `str` boundary rather than an oversight, and the suites caught all four.

Unit suite (2248) and integration suite (189) both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>
